### PR TITLE
chore(F2): lint + format hygiene (prettier scope + worker tsconfig)

### DIFF
--- a/deliverables/F2/PWA/app/.prettierignore
+++ b/deliverables/F2/PWA/app/.prettierignore
@@ -5,3 +5,7 @@ node_modules/
 public/icons/
 test-results/
 playwright-report/
+src/generated/
+spec/
+scripts/_one-shot-*.mjs
+CHANGELOG.md

--- a/deliverables/F2/PWA/app/NEXT.md
+++ b/deliverables/F2/PWA/app/NEXT.md
@@ -3,6 +3,7 @@
 **Current phase:** Round 1 + Round 2 fully closed 2026-04-25. v1.1.0 + v1.1.1 milestones complete. Round 3 (v1.2.0) is queued with 3 UX features: "I don't know" exclusivity (#16), "All of the above" auto-select (#17), scale-question matrix view (#18).
 
 **Closed batches:**
+
 - v1.1.0 — UAT Round 1: 7 issues (skip-logic gates, Section G hide, max constraints, age letter input, etc.)
 - v1.1.1 — UAT Round 2: 7 issues (specialty filter, real-time tooltips, conditional-required generator, submit error UX, Q9 Month optional, gate navigation regression fix)
 
@@ -12,26 +13,26 @@
 
 ### ✅ Addressed in fix batch `3003c253` (shipped 2026-04-25, awaits verification)
 
-| Issue | Title | Verification |
-|---|---|---|
-| #4 | Q4 age — max 99 | Try Q4=120 → blocked |
-| #5 / #7 (dup) | Q9_2 months — max 11 | Try Q9_2=15 → blocked |
-| #6 / #9 (dup) | Q12 UHC skip logic | Q12=No → Q13–Q30 skipped |
-| #11 | Section G hidden for Nurse | Q5=Nurse → Section G not in tree |
-| (also) | Section C Q31-gate | Q31=No → Q32–Q40 skipped |
-| (also) | Section H Q91-gate | Q91='never happened' → Q92–Q95 skipped |
+| Issue         | Title                      | Verification                           |
+| ------------- | -------------------------- | -------------------------------------- |
+| #4            | Q4 age — max 99            | Try Q4=120 → blocked                   |
+| #5 / #7 (dup) | Q9_2 months — max 11       | Try Q9_2=15 → blocked                  |
+| #6 / #9 (dup) | Q12 UHC skip logic         | Q12=No → Q13–Q30 skipped               |
+| #11           | Section G hidden for Nurse | Q5=Nurse → Section G not in tree       |
+| (also)        | Section C Q31-gate         | Q31=No → Q32–Q40 skipped               |
+| (also)        | Section H Q91-gate         | Q91='never happened' → Q92–Q95 skipped |
 
 **Verify these on staging:** https://c9765fdf.f2-pwa-staging.pages.dev — then close issues #4/#5/#6/#7/#9/#11 with reference to commit + verification screenshot.
 
 ### ⏳ NOT yet addressed — Round 2 fix batch needed
 
-| Issue | Title | Type | Notes |
-|---|---|---|---|
-| #2 | Specialty filter by role (Q5 → specialty list) | UX/data | e.g., Q5=Dentist → hide Dermatology. Pure filter, no schema change. |
-| #8 | Q25 sub-question gating | Skip-logic | Salary only → Q27–Q30 unanswerable; #patients only → Q26 + Q28–Q30 unanswerable; both → Q28–Q30 unanswerable |
-| #10 | Auto-advance on required questions | **Bug — needs investigation** | Form jumps to next section after one required answer (Q25, Q96/Q97, Q123–Q125) when sibling required fields still pending. Likely `MultiSectionForm.tsx` `handleSectionValid` or section-completion predicate. |
-| #12 TC-005 | Language switch failure | Bug | Read `LanguageSwitcher.tsx` + i18n setup |
-| #12 TC-010 | Submission flow ("No Submission yet" / "Nothing to Sync") | Bug | Read `App.tsx` `handleFinalSubmit` → `onSubmit` → IndexedDB write path |
+| Issue      | Title                                                     | Type                          | Notes                                                                                                                                                                                                          |
+| ---------- | --------------------------------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #2         | Specialty filter by role (Q5 → specialty list)            | UX/data                       | e.g., Q5=Dentist → hide Dermatology. Pure filter, no schema change.                                                                                                                                            |
+| #8         | Q25 sub-question gating                                   | Skip-logic                    | Salary only → Q27–Q30 unanswerable; #patients only → Q26 + Q28–Q30 unanswerable; both → Q28–Q30 unanswerable                                                                                                   |
+| #10        | Auto-advance on required questions                        | **Bug — needs investigation** | Form jumps to next section after one required answer (Q25, Q96/Q97, Q123–Q125) when sibling required fields still pending. Likely `MultiSectionForm.tsx` `handleSectionValid` or section-completion predicate. |
+| #12 TC-005 | Language switch failure                                   | Bug                           | Read `LanguageSwitcher.tsx` + i18n setup                                                                                                                                                                       |
+| #12 TC-010 | Submission flow ("No Submission yet" / "Nothing to Sync") | Bug                           | Read `App.tsx` `handleFinalSubmit` → `onSubmit` → IndexedDB write path                                                                                                                                         |
 
 ### Suggested Round 2 batch sequence
 
@@ -52,6 +53,7 @@
 ## Deploy commands
 
 **Redeploy staging:**
+
 ```bash
 cd deliverables/F2/PWA/app
 npm run build
@@ -59,6 +61,7 @@ npx wrangler pages deploy dist --project-name f2-pwa-staging --commit-dirty=true
 ```
 
 **Redeploy production (only after final UAT sign-off):**
+
 ```bash
 cd deliverables/F2/PWA/app
 npm run build
@@ -66,6 +69,7 @@ npx wrangler pages deploy dist --project-name f2-pwa --branch main --commit-dirt
 ```
 
 **Redeploy backend (Apps Script):**
+
 ```bash
 cd deliverables/F2/PWA/backend
 npm run build

--- a/deliverables/F2/PWA/app/e2e/golden-path.spec.ts
+++ b/deliverables/F2/PWA/app/e2e/golden-path.spec.ts
@@ -6,13 +6,16 @@ import { installMockBackend, defaultState } from './fixtures/mock-backend';
 // without triggering optional conditional branches unnecessarily.
 const COMPLETE_ANSWERS: Record<string, unknown> = {
   // Section A — Healthcare Worker Profile
-  Q1_1: 'Dela Cruz', Q1_2: 'Juan', Q1_3: 'P',
+  Q1_1: 'Dela Cruz',
+  Q1_2: 'Juan',
+  Q1_3: 'P',
   Q2: 'Regular',
   Q3: 'Female',
   Q4: 32,
   Q5: 'Nurse',
   Q7: 'No',
-  Q9_1: 2, Q9_2: 6,
+  Q9_1: 2,
+  Q9_2: 6,
   Q10: 5,
   Q11: 8,
 
@@ -58,9 +61,15 @@ const COMPLETE_ANSWERS: Record<string, unknown> = {
   Q66: 'Yes',
   Q72: 'Yes',
   Q74: 'UAT test answer',
-  Q77: '1', Q78: '1', Q79: '1', Q80: '1', Q81: '1',
+  Q77: '1',
+  Q78: '1',
+  Q79: '1',
+  Q80: '1',
+  Q81: '1',
   Q82: 'UAT test answer',
-  Q83: 'Never', Q84: 'Never', Q85: 'Never',
+  Q83: 'Never',
+  Q84: 'Never',
+  Q85: 'Never',
   Q86: 'UAT test answer',
   Q90: 'UAT test answer',
 
@@ -75,24 +84,33 @@ const COMPLETE_ANSWERS: Record<string, unknown> = {
   Q96: 'Yes',
 
   // Section J — Job Satisfaction
-  Q98: 'Strongly Agree', Q99: 'Strongly Agree', Q100: 'Strongly Agree',
-  Q101: 'Strongly Agree', Q102: 'Strongly Agree', Q103: 'Strongly Agree',
-  Q104: 'Strongly Agree', Q105: 'Strongly Agree', Q106: 'Strongly Agree',
+  Q98: 'Strongly Agree',
+  Q99: 'Strongly Agree',
+  Q100: 'Strongly Agree',
+  Q101: 'Strongly Agree',
+  Q102: 'Strongly Agree',
+  Q103: 'Strongly Agree',
+  Q104: 'Strongly Agree',
+  Q105: 'Strongly Agree',
+  Q106: 'Strongly Agree',
   Q107: 'Strongly Agree',
   Q109: 'UAT test answer',
   Q110: ['Professional development opportunities'],
   Q111: ['Seminars, conferences, workshops'],
   Q112: ['Clinical audits'],
   Q113: ['Clinical audits'],
-  Q114: 'Always', Q115: 'Always', Q116: 'Always', Q117: 'Always',
-  Q118: 'Always', Q119: 'Always', Q120: 'Always', Q121: 'Always',
+  Q114: 'Always',
+  Q115: 'Always',
+  Q116: 'Always',
+  Q117: 'Always',
+  Q118: 'Always',
+  Q119: 'Always',
+  Q120: 'Always',
+  Q121: 'Always',
   Q123: "Yes, I've thought about it and have definite plans to leave",
 };
 
-async function seedDraft(
-  page: import('@playwright/test').Page,
-  values: Record<string, unknown>,
-) {
+async function seedDraft(page: import('@playwright/test').Page, values: Record<string, unknown>) {
   await page.evaluate(async (vals) => {
     const draftId = localStorage.getItem('f2_current_draft_id');
     if (!draftId) throw new Error('No draft ID in localStorage');
@@ -148,7 +166,9 @@ test('golden path: enrollment → all sections complete → review → submit', 
   // Wait for each section heading before clicking Next to avoid race conditions.
   const sectionIds = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
   for (const id of sectionIds) {
-    await expect(page.getByRole('heading', { name: new RegExp(`Section ${id}`) })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('heading', { name: new RegExp(`Section ${id}`) })).toBeVisible({
+      timeout: 5000,
+    });
     await page.getByRole('button', { name: 'Next section' }).click();
   }
 
@@ -156,7 +176,9 @@ test('golden path: enrollment → all sections complete → review → submit', 
 
   // Review shows all 10 sections
   for (const id of ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J']) {
-    await expect(page.getByRole('heading', { name: new RegExp(`Section ${id}`, 'i') })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: new RegExp(`Section ${id}`, 'i') }),
+    ).toBeVisible();
   }
 
   // 4. Submit
@@ -178,7 +200,11 @@ test('section lock: cannot navigate to an unvisited section via tree', async ({ 
   await expect(page.getByRole('heading', { name: /Section A/i })).toBeVisible({ timeout: 5000 });
 
   // Try to jump to Section J via the desktop sidebar (Section A is index 0, J is index 9)
-  await page.locator('aside').first().getByRole('button', { name: /Job Satisfaction/i }).click();
+  await page
+    .locator('aside')
+    .first()
+    .getByRole('button', { name: /Job Satisfaction/i })
+    .click();
 
   // Lock message should appear
   await expect(page.getByText(/complete sections in order/i)).toBeVisible({ timeout: 3000 });

--- a/deliverables/F2/PWA/app/scripts/lib/parse-spec.ts
+++ b/deliverables/F2/PWA/app/scripts/lib/parse-spec.ts
@@ -451,9 +451,7 @@ const EXCLUSIVE_VALUES = new Set([
 
 // Multi-select option values that should auto-select all other non-exclusive
 // non-otherSpecify options when checked.
-const SELECT_ALL_VALUES = new Set([
-  'All of the above',
-]);
+const SELECT_ALL_VALUES = new Set(['All of the above']);
 
 function parseChoiceList(text: string, hasOtherSpecify: boolean): Choice[] | undefined {
   if (!text) return undefined;

--- a/deliverables/F2/PWA/app/src/App.test.tsx
+++ b/deliverables/F2/PWA/app/src/App.test.tsx
@@ -10,8 +10,7 @@ import { db, type SubmissionRow } from '@/lib/db';
  * client-side, so a hand-rolled string is sufficient for tests.
  */
 function makeFakeDeviceToken(overrides: Record<string, unknown> = {}): string {
-  const b64url = (s: string) =>
-    btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const b64url = (s: string) => btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
   const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
   const claims = {
     jti: 'test-jti',

--- a/deliverables/F2/PWA/app/src/App.tsx
+++ b/deliverables/F2/PWA/app/src/App.tsx
@@ -298,9 +298,7 @@ function AppShell() {
         </section>
       ) : status === 'submit_failed' ? (
         <section className="mx-auto flex max-w-xl flex-col gap-4 p-6">
-          <h2 className="text-2xl font-semibold text-red-700">
-            {t('chrome.submitFailedHeading')}
-          </h2>
+          <h2 className="text-2xl font-semibold text-red-700">{t('chrome.submitFailedHeading')}</h2>
           <p className="text-sm text-muted-foreground">
             {submitError ?? t('chrome.submitFailedBody')}
           </p>

--- a/deliverables/F2/PWA/app/src/components/enrollment/ChangeEnrollmentButton.test.tsx
+++ b/deliverables/F2/PWA/app/src/components/enrollment/ChangeEnrollmentButton.test.tsx
@@ -9,8 +9,7 @@ import { DRAFT_ID_KEY } from '@/lib/draft';
 import { db } from '@/lib/db';
 
 function fakeDeviceToken(): string {
-  const b64url = (s: string) =>
-    btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const b64url = (s: string) => btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
   const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
   const payload = b64url(
     JSON.stringify({

--- a/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.test.tsx
+++ b/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.test.tsx
@@ -92,7 +92,9 @@ describe('<EnrollmentScreen>', () => {
     setup();
     await user.type(screen.getByTestId('enrollment-token-input'), FAKE_TOKEN);
     await user.click(screen.getByRole('button', { name: /verify token/i }));
-    await waitFor(() => expect(screen.getByTestId('enrollment-token-accepted')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId('enrollment-token-accepted')).toBeInTheDocument(),
+    );
     expect(screen.getByLabelText(/HCW ID/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^enroll$/i })).toBeInTheDocument();
     // The accepted message names the facility from the token's claim.

--- a/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.tsx
+++ b/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.tsx
@@ -162,12 +162,7 @@ export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
             <Button type="submit" disabled={!canSubmit}>
               {t('enrollment.enrollButton')}
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleRefresh}
-              disabled={refreshing}
-            >
+            <Button type="button" variant="outline" onClick={handleRefresh} disabled={refreshing}>
               {refreshing ? t('enrollment.refreshingButton') : t('enrollment.refreshButton')}
             </Button>
           </div>

--- a/deliverables/F2/PWA/app/src/components/i18n/LanguageSwitcher.tsx
+++ b/deliverables/F2/PWA/app/src/components/i18n/LanguageSwitcher.tsx
@@ -41,12 +41,7 @@ export function LanguageSwitcher() {
       >
         FIL
       </Button>
-      <span
-        role="status"
-        aria-live="polite"
-        className="sr-only"
-        data-testid="active-locale"
-      >
+      <span role="status" aria-live="polite" className="sr-only" data-testid="active-locale">
         {locale === 'en' ? t('language.en') : t('language.fil')}
       </span>
     </div>

--- a/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.test.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.test.tsx
@@ -43,7 +43,12 @@ const scale15: Choice[] = [
 
 describe('<MatrixQuestion>', () => {
   it('renders one column header per choice plus a Statement header', () => {
-    render(<Harness items={[row('Q75', 'fairness ZBB', scale15), row('Q76', 'fairness NBB', scale15)]} choices={scale15} />);
+    render(
+      <Harness
+        items={[row('Q75', 'fairness ZBB', scale15), row('Q76', 'fairness NBB', scale15)]}
+        choices={scale15}
+      />,
+    );
     // Column headers
     expect(screen.getByText(/Statement/i)).toBeInTheDocument();
     for (const c of scale15) {
@@ -52,13 +57,18 @@ describe('<MatrixQuestion>', () => {
   });
 
   it('renders one row per item with the localised statement text', () => {
-    render(<Harness items={[row('Q75', 'fairness ZBB', scale15), row('Q76', 'fairness NBB', scale15)]} choices={scale15} />);
+    render(
+      <Harness
+        items={[row('Q75', 'fairness ZBB', scale15), row('Q76', 'fairness NBB', scale15)]}
+        choices={scale15}
+      />,
+    );
     // Both desktop table and mobile card render in the DOM; use getAllByText
     expect(screen.getAllByText(/fairness ZBB/).length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText(/fairness NBB/).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('clicking a radio in row Q75 sets only that row\'s value', async () => {
+  it("clicking a radio in row Q75 sets only that row's value", async () => {
     const user = userEvent.setup();
     let captured: Record<string, unknown> = {};
     function CaptureHarness({ items, choices }: { items: Item[]; choices: Choice[] }) {
@@ -70,15 +80,24 @@ describe('<MatrixQuestion>', () => {
           <FormProvider {...methods}>
             <form>
               <MatrixQuestion items={items} choices={choices} />
-              <button type="button" onClick={() => (captured = methods.getValues())}>snapshot</button>
+              <button type="button" onClick={() => (captured = methods.getValues())}>
+                snapshot
+              </button>
             </form>
           </FormProvider>
         </LocaleProvider>
       );
     }
-    render(<CaptureHarness items={[row('Q75', 'fairness ZBB', scale15), row('Q76', 'fairness NBB', scale15)]} choices={scale15} />);
+    render(
+      <CaptureHarness
+        items={[row('Q75', 'fairness ZBB', scale15), row('Q76', 'fairness NBB', scale15)]}
+        choices={scale15}
+      />,
+    );
     // Each row's radios share name = item.id; desktop + mobile = 10 total for Q75
-    const q75Radios = screen.getAllByRole('radio').filter((el) => (el as HTMLInputElement).name === 'Q75');
+    const q75Radios = screen
+      .getAllByRole('radio')
+      .filter((el) => (el as HTMLInputElement).name === 'Q75');
     expect(q75Radios).toHaveLength(10);
     // Click the last "5" radio in the desktop table (index 4)
     await user.click(q75Radios[4]);
@@ -89,7 +108,7 @@ describe('<MatrixQuestion>', () => {
     expect(q76 == null).toBe(true);
   });
 
-  it('renders a row\'s required error inline when triggered', async () => {
+  it("renders a row's required error inline when triggered", async () => {
     function ErrHarness({ items, choices }: { items: Item[]; choices: Choice[] }) {
       const methods = useForm<Record<string, unknown>>({
         defaultValues: {},
@@ -98,7 +117,7 @@ describe('<MatrixQuestion>', () => {
       // mount and doesn't trigger an infinite re-render loop.
       useEffect(() => {
         methods.setError('Q76', { type: 'required', message: 'This field is required.' });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
       return (
         <LocaleProvider>
@@ -110,7 +129,9 @@ describe('<MatrixQuestion>', () => {
         </LocaleProvider>
       );
     }
-    render(<ErrHarness items={[row('Q75', 'A', scale15), row('Q76', 'B', scale15)]} choices={scale15} />);
+    render(
+      <ErrHarness items={[row('Q75', 'A', scale15), row('Q76', 'B', scale15)]} choices={scale15} />,
+    );
     // Both desktop table and mobile card show alerts; check at least one has the message
     const alerts = await screen.findAllByRole('alert');
     expect(alerts.length).toBeGreaterThanOrEqual(1);

--- a/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.tsx
@@ -60,7 +60,11 @@ export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
             if (errorMessage || error) {
               out.push(
                 <tr key={`${item.id}-err`}>
-                  <td colSpan={choices.length + 1} className="py-1 text-xs text-red-600" role="alert">
+                  <td
+                    colSpan={choices.length + 1}
+                    className="py-1 text-xs text-red-600"
+                    role="alert"
+                  >
                     {errorMessage ?? t('question.requiredFallback')}
                   </td>
                 </tr>,

--- a/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
@@ -78,9 +78,7 @@ function getSectionStatus(section: SectionConfig, values: FormValues): SectionSt
     if (it.type === 'multi-field' && it.subFields) {
       // A subfield is required only if the parent is required AND its own required
       // flag isn't explicitly false. Optional subfields don't block completion.
-      return it.subFields.every(
-        (sf) => sf.required === false || hasValue(values[sf.id]),
-      );
+      return it.subFields.every((sf) => sf.required === false || hasValue(values[sf.id]));
     }
     return hasValue(values[it.id]);
   });
@@ -135,13 +133,11 @@ export function MultiSectionForm({
   );
 
   const visibleSectionEntries = useMemo(
-    () => SECTIONS.reduce<Array<{ config: SectionConfig; originalIndex: number }>>(
-      (acc, s, i) => {
+    () =>
+      SECTIONS.reduce<Array<{ config: SectionConfig; originalIndex: number }>>((acc, s, i) => {
         if (shouldShowSection(s.id, merged)) acc.push({ config: s, originalIndex: i });
         return acc;
-      },
-      [],
-    ),
+      }, []),
     [merged],
   );
 
@@ -176,7 +172,7 @@ export function MultiSectionForm({
   // Reset entry status when navigating to a new section (must be before the auto-advance effect)
   useEffect(() => {
     entryStatusRef.current = sectionStatuses[index] ?? 'empty';
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [index]);
 
   // Auto-advance when current section transitions from non-complete to complete
@@ -190,7 +186,7 @@ export function MultiSectionForm({
       handleNext();
     }, 400);
     return () => clearTimeout(timer);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sectionStatuses]);
 
   const showLockMsg = () => {
@@ -290,7 +286,9 @@ export function MultiSectionForm({
           sections={visibleSectionEntries.map((e) => e.config)}
           currentIndex={visibleIndex}
           statuses={visibleSectionEntries.map((e) => sectionStatuses[e.originalIndex]!)}
-          maxVisitedIndex={visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1}
+          maxVisitedIndex={
+            visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1
+          }
           onNavigate={(i) => handleNavigate(visibleSectionEntries[i]!.originalIndex)}
         />
       </aside>
@@ -313,8 +311,13 @@ export function MultiSectionForm({
               sections={visibleSectionEntries.map((e) => e.config)}
               currentIndex={visibleIndex}
               statuses={visibleSectionEntries.map((e) => sectionStatuses[e.originalIndex]!)}
-              maxVisitedIndex={visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1}
-              onNavigate={(i) => { handleNavigate(visibleSectionEntries[i]!.originalIndex); setDrawerOpen(false); }}
+              maxVisitedIndex={
+                visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1
+              }
+              onNavigate={(i) => {
+                handleNavigate(visibleSectionEntries[i]!.originalIndex);
+                setDrawerOpen(false);
+              }}
               onClose={() => setDrawerOpen(false)}
             />
           </aside>
@@ -331,7 +334,15 @@ export function MultiSectionForm({
           isFirst && 'invisible',
         )}
       >
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
           <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
         </svg>
       </button>
@@ -348,7 +359,15 @@ export function MultiSectionForm({
             : 'bg-background/90 hover:bg-muted',
         )}
       >
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
           <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
         </svg>
       </button>
@@ -368,11 +387,27 @@ export function MultiSectionForm({
               className="shrink-0 rounded p-1 hover:bg-muted lg:hidden"
               onClick={() => setDrawerOpen(true)}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
               </svg>
             </button>
-            <ProgressBar current={visibleIndex + 1} total={visibleSectionEntries.length} className="flex-1 px-0 pt-0" />
+            <ProgressBar
+              current={visibleIndex + 1}
+              total={visibleSectionEntries.length}
+              className="flex-1 px-0 pt-0"
+            />
             {/* Save Draft — upper right */}
             <button
               type="button"

--- a/deliverables/F2/PWA/app/src/components/survey/Navigator.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Navigator.tsx
@@ -15,7 +15,9 @@ export function Navigator({ onSaveDraft, showSaved }: NavigatorProps) {
         {t('navigator.saveDraft')}
       </Button>
       {showSaved ? (
-        <span className="whitespace-nowrap text-sm text-green-600">{t('navigator.draftSaved')}</span>
+        <span className="whitespace-nowrap text-sm text-green-600">
+          {t('navigator.draftSaved')}
+        </span>
       ) : null}
     </div>
   );

--- a/deliverables/F2/PWA/app/src/components/survey/Question.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Question.tsx
@@ -91,18 +91,26 @@ function blockNonNumericKeys(event: React.KeyboardEvent<HTMLInputElement>) {
 //   is no longer accurate).
 export function nextMultiValue(
   current: string[],
-  clicked: { value: string; isExclusive?: boolean; isSelectAll?: boolean; isOtherSpecify?: boolean },
+  clicked: {
+    value: string;
+    isExclusive?: boolean;
+    isSelectAll?: boolean;
+    isOtherSpecify?: boolean;
+  },
   willBeChecked: boolean,
-  allChoices: ReadonlyArray<{ value: string; isExclusive?: boolean; isSelectAll?: boolean; isOtherSpecify?: boolean }>,
+  allChoices: ReadonlyArray<{
+    value: string;
+    isExclusive?: boolean;
+    isSelectAll?: boolean;
+    isOtherSpecify?: boolean;
+  }>,
 ): string[] {
   const findChoice = (v: string) => allChoices.find((c) => c.value === v);
 
   if (willBeChecked) {
     if (clicked.isExclusive) return [clicked.value];
     if (clicked.isSelectAll) {
-      return allChoices
-        .filter((c) => !c.isExclusive && !c.isOtherSpecify)
-        .map((c) => c.value);
+      return allChoices.filter((c) => !c.isExclusive && !c.isOtherSpecify).map((c) => c.value);
     }
     const filtered = current.filter((v) => {
       const c = findChoice(v);
@@ -222,16 +230,13 @@ function renderControl(
                     checked={isChecked}
                     onChange={(e) => {
                       if (!onChange) return;
-                      const next = nextMultiValue(
-                        selected,
-                        choice,
-                        e.target.checked,
-                        allChoices,
-                      );
+                      const next = nextMultiValue(selected, choice, e.target.checked, allChoices);
                       onChange(next);
                     }}
                     onBlur={reg.onBlur}
-                    {...(idx === 0 ? { id: item.id, ref: reg.ref, name: reg.name } : { name: reg.name })}
+                    {...(idx === 0
+                      ? { id: item.id, ref: reg.ref, name: reg.name }
+                      : { name: reg.name })}
                   />
                   {localized(choice.label, locale)}
                 </label>

--- a/deliverables/F2/PWA/app/src/components/survey/ReviewSection.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/ReviewSection.tsx
@@ -106,7 +106,9 @@ export function ReviewSection({ values, onEdit, onSubmit }: ReviewSectionProps) 
 
       {SECTIONS.map((section) => {
         const grouped = groupVisibleItems(section.items);
-        type Block = { kind: 'rows'; rows: ReturnType<typeof rowsForItem> } | { kind: 'matrix'; group: MatrixGroup };
+        type Block =
+          | { kind: 'rows'; rows: ReturnType<typeof rowsForItem> }
+          | { kind: 'matrix'; group: MatrixGroup };
         const blocks: Block[] = [];
         for (const entry of grouped) {
           if (isMatrixGroup(entry)) {
@@ -135,10 +137,7 @@ export function ReviewSection({ values, onEdit, onSubmit }: ReviewSectionProps) 
             <div className="divide-y divide-slate-200 rounded border border-slate-200">
               {blocks.map((block, blockIdx) =>
                 block.kind === 'matrix' ? (
-                  <div
-                    key={`matrix-${block.group.items[0].id}`}
-                    className="px-3 py-2"
-                  >
+                  <div key={`matrix-${block.group.items[0].id}`} className="px-3 py-2">
                     <table className="w-full text-sm">
                       <tbody>
                         {block.group.items.map((it) => (
@@ -146,9 +145,7 @@ export function ReviewSection({ values, onEdit, onSubmit }: ReviewSectionProps) 
                             <td className="py-1 pr-2 text-slate-700">
                               {it.id} {localized(it.label, locale)}
                             </td>
-                            <td className="py-1 text-slate-900">
-                              {formatValue(values[it.id])}
-                            </td>
+                            <td className="py-1 text-slate-900">{formatValue(values[it.id])}</td>
                           </tr>
                         ))}
                       </tbody>

--- a/deliverables/F2/PWA/app/src/components/survey/SectionTree.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/SectionTree.tsx
@@ -40,8 +40,20 @@ export function SectionTree({
             className="rounded p-1 hover:bg-muted"
             onClick={onClose}
           >
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
             </svg>
           </button>
         ) : null}
@@ -79,15 +91,43 @@ export function SectionTree({
                 {isCurrent ? (
                   s.id
                 ) : isLocked ? (
-                  <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="9"
+                    height="9"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z"
+                    />
                   </svg>
                 ) : status === 'complete' ? (
-                  <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="10"
+                    height="10"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={3}
+                  >
                     <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                   </svg>
                 ) : status === 'incomplete' ? (
-                  <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="10"
+                    height="10"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={3}
+                  >
                     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 ) : (
@@ -99,7 +139,11 @@ export function SectionTree({
               <span
                 className={cn(
                   'leading-snug',
-                  isCurrent ? 'text-primary' : isLocked ? 'text-muted-foreground' : 'text-foreground',
+                  isCurrent
+                    ? 'text-primary'
+                    : isLocked
+                      ? 'text-muted-foreground'
+                      : 'text-foreground',
                 )}
               >
                 {localized(s.section.title, locale)}

--- a/deliverables/F2/PWA/app/src/components/survey/group-matrix.test.ts
+++ b/deliverables/F2/PWA/app/src/components/survey/group-matrix.test.ts
@@ -15,8 +15,7 @@ const single = (id: string, choices: Choice[], extra: Partial<Item> = {}): Item 
   ...extra,
 });
 
-const isMatrix = (e: Item | MatrixGroup): e is MatrixGroup =>
-  (e as MatrixGroup).kind === 'matrix';
+const isMatrix = (e: Item | MatrixGroup): e is MatrixGroup => (e as MatrixGroup).kind === 'matrix';
 
 describe('groupVisibleItems', () => {
   it('returns an empty array for empty input', () => {
@@ -73,18 +72,12 @@ describe('groupVisibleItems', () => {
   });
 
   it('does not group items if choices differ in order', () => {
-    const items = [
-      single('Q1', ch(['Yes', 'No'])),
-      single('Q2', ch(['No', 'Yes'])),
-    ];
+    const items = [single('Q1', ch(['Yes', 'No'])), single('Q2', ch(['No', 'Yes']))];
     expect(groupVisibleItems(items)).toEqual(items);
   });
 
   it('does not group items if choices differ in length', () => {
-    const items = [
-      single('Q1', ch(['1', '2', '3', '4', '5'])),
-      single('Q2', ch(['1', '2', '3'])),
-    ];
+    const items = [single('Q1', ch(['1', '2', '3', '4', '5'])), single('Q2', ch(['1', '2', '3']))];
     expect(groupVisibleItems(items)).toEqual(items);
   });
 
@@ -105,9 +98,7 @@ describe('groupVisibleItems', () => {
 
   it('groups a long realistic Likert cluster (Q75-Q81)', () => {
     const ch15 = ch(['1', '2', '3', '4', '5']);
-    const items = ['Q75', 'Q76', 'Q77', 'Q78', 'Q79', 'Q80', 'Q81'].map((id) =>
-      single(id, ch15),
-    );
+    const items = ['Q75', 'Q76', 'Q77', 'Q78', 'Q79', 'Q80', 'Q81'].map((id) => single(id, ch15));
     const out = groupVisibleItems(items);
     expect(out).toHaveLength(1);
     if (isMatrix(out[0])) {
@@ -131,9 +122,7 @@ describe('groupVisibleItems', () => {
       'Disagree',
       'Strongly Disagree',
     ]);
-    const items = ['Q108', 'Q109', 'Q110', 'Q111', 'Q112'].map((id) =>
-      single(id, agreement),
-    );
+    const items = ['Q108', 'Q109', 'Q110', 'Q111', 'Q112'].map((id) => single(id, agreement));
     const out = groupVisibleItems(items);
     expect(out).toHaveLength(1);
   });

--- a/deliverables/F2/PWA/app/src/lib/auth-context.test.tsx
+++ b/deliverables/F2/PWA/app/src/lib/auth-context.test.tsx
@@ -7,8 +7,7 @@ import * as enrollmentModule from './enrollment';
 
 /** Hand-rolled JWT for tests; auth-context only reads `exp` via parseClaimsUnsafe. */
 function fakeDeviceToken(expEpochS = Math.floor(Date.now() / 1000) + 86400): string {
-  const b64url = (s: string) =>
-    btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const b64url = (s: string) => btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
   const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
   const payload = b64url(
     JSON.stringify({

--- a/deliverables/F2/PWA/app/src/lib/skip-logic.test.ts
+++ b/deliverables/F2/PWA/app/src/lib/skip-logic.test.ts
@@ -26,11 +26,15 @@ describe('shouldShow', () => {
 
   describe('Section B', () => {
     it('hides Q14 when Q13 is a No variant', () => {
-      expect(shouldShow('B', 'Q14', { Q12: 'Yes', Q13: 'No, and no plans in next 1–2 years' })).toBe(false);
+      expect(
+        shouldShow('B', 'Q14', { Q12: 'Yes', Q13: 'No, and no plans in next 1–2 years' }),
+      ).toBe(false);
     });
 
     it('shows Q14 when Q12 is Yes and Q13 starts with Yes', () => {
-      expect(shouldShow('B', 'Q14', { Q12: 'Yes', Q13: 'Yes, direct result of UHC Act' })).toBe(true);
+      expect(shouldShow('B', 'Q14', { Q12: 'Yes', Q13: 'Yes, direct result of UHC Act' })).toBe(
+        true,
+      );
     });
 
     it('hides Q14 when Q13 is unanswered', () => {
@@ -38,7 +42,9 @@ describe('shouldShow', () => {
     });
 
     it('hides Q14 when Q12 is No (entire Q13–Q30 block hidden)', () => {
-      expect(shouldShow('B', 'Q14', { Q12: 'No', Q13: 'Yes, direct result of UHC Act' })).toBe(false);
+      expect(shouldShow('B', 'Q14', { Q12: 'No', Q13: 'Yes, direct result of UHC Act' })).toBe(
+        false,
+      );
     });
   });
 
@@ -153,8 +159,8 @@ describe('shouldShow', () => {
 
     it('shows Q71 when either Q69 or Q70 is Yes', () => {
       expect(shouldShow('G', 'Q71', { Q69: 'Yes' })).toBe(true);
-      expect(shouldShow('G', 'Q71', { 'Q70': 'Yes' })).toBe(true);
-      expect(shouldShow('G', 'Q71', { Q69: 'No', 'Q70': 'No' })).toBe(false);
+      expect(shouldShow('G', 'Q71', { Q70: 'Yes' })).toBe(true);
+      expect(shouldShow('G', 'Q71', { Q69: 'No', Q70: 'No' })).toBe(false);
     });
 
     it('shows Q73 only when Q72 is No', () => {
@@ -164,8 +170,8 @@ describe('shouldShow', () => {
 
     it('shows Q89 when either Q87 or Q88 is Yes', () => {
       expect(shouldShow('G', 'Q89', { Q87: 'Yes' })).toBe(true);
-      expect(shouldShow('G', 'Q89', { 'Q88': 'Yes' })).toBe(true);
-      expect(shouldShow('G', 'Q89', { Q87: 'No', 'Q88': 'No' })).toBe(false);
+      expect(shouldShow('G', 'Q89', { Q88: 'Yes' })).toBe(true);
+      expect(shouldShow('G', 'Q89', { Q87: 'No', Q88: 'No' })).toBe(false);
     });
   });
 

--- a/deliverables/F2/PWA/worker/package-lock.json
+++ b/deliverables/F2/PWA/worker/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250101.0",
+        "@types/node": "^25.6.0",
         "typescript": "^5.5.0",
         "vitest": "^2.1.0",
         "wrangler": "^3.90.0"
@@ -1349,6 +1350,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -2291,6 +2302,13 @@
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.14",

--- a/deliverables/F2/PWA/worker/package.json
+++ b/deliverables/F2/PWA/worker/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "secret:put:jwt": "wrangler secret put JWT_SIGNING_KEY",
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250101.0",
+    "@types/node": "^25.6.0",
     "typescript": "^5.5.0",
     "vitest": "^2.1.0",
     "wrangler": "^3.90.0"

--- a/deliverables/F2/PWA/worker/tsconfig.json
+++ b/deliverables/F2/PWA/worker/tsconfig.json
@@ -16,5 +16,5 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/deliverables/F2/PWA/worker/tsconfig.test.json
+++ b/deliverables/F2/PWA/worker/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types", "node", "vitest/globals"]
+  },
+  "include": ["test/**/*"]
+}

--- a/scrum/epics/epic-04-backend-sync-infrastructure.md
+++ b/scrum/epics/epic-04-backend-sync-infrastructure.md
@@ -3,12 +3,12 @@ epic: 4
 title: Backend & Sync Infrastructure
 phase: per-track
 status: in-progress
-last_updated: 2026-04-25
+last_updated: 2026-04-26
 ---
 
 # Epic 4 — Backend & Sync Infrastructure
 
-Server-side and synchronization layer for both survey tracks: **Apps Script + Cloudflare Pages** for the F2 self-admin PWA, and **CSWeb** for the F1/F3/F4 CSPro CAPI track. Covers authentication, data ingestion, storage, and integration ETL between the two tracks.
+Server-side and synchronization layer for both survey tracks: **Apps Script + Cloudflare Pages + Cloudflare Worker (JWT proxy)** for the F2 self-admin PWA, and **CSWeb** for the F1/F3/F4 CSPro CAPI track. Covers authentication, data ingestion, storage, and integration ETL between the two tracks.
 
 **Ties to Product Backlog:** [[../product-backlog#Epic 4 — Backend & Sync Infrastructure|PB Epic 4]]
 **Methodology:** [[../../../../2_Areas/IT-Standards/templates/CAPI-Development-Workflow|CAPI Development Workflow]]
@@ -31,7 +31,19 @@ Server-side and synchronization layer for both survey tracks: **Apps Script + Cl
 - [x] **E4-PWA-005** FacilityMasterList provisioning sheet + `?action=facilities` endpoint `status::done` `priority::high`
 - [x] **E4-PWA-006** Submission audit log + de-duplication via `client_submission_id` `status::done` `priority::medium`
 - [x] **E4-PWA-007** Runtime config endpoint with kill-switch + spec-drift signal `status::done` `priority::medium`
-- [ ] **E4-PWA-010** Backend secrets rotation policy documented (HMAC, Apps Script deploy ID) `status::todo` `priority::medium` `estimate::2h`
+- [x] **E4-PWA-008** Auth re-arch — Cloudflare Worker JWT proxy replaces HMAC-in-bundle (PR #31) `status::done` `priority::critical`
+  - Done 2026-04-26. Mitigates CRITICAL finding from 2026-04-25 `/gstack-cso` audit. Worker at `deliverables/F2/PWA/worker/`, deployed to `https://f2-pwa-worker.hcw.workers.dev`. Spec at `docs/superpowers/specs/2026-04-26-f2-pwa-auth-rearch-design.md`. Runbook at `docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md`.
+- [x] **E4-PWA-009** Staging cutover executed (Phase A–E of auth re-arch runbook) `status::done` `priority::critical`
+  - Done 2026-04-26 ~17:50 PHT. Worker provisioned (KV + 4 secrets + deploy), HMAC rotated in Apps Script, PR #31 merged to staging, manual `wrangler pages deploy` to staging (auto-deploy didn't fire — see #34), end-to-end smoke test passed (worker → Apps Script `batch-submit` returned 200, spreadsheet row written). Disruption window ~18 min.
+- [x] **E4-PWA-012** EnrollmentScreen pre-refresh hot-fix (PR #32) `status::done` `priority::high`
+  - Done 2026-04-26. PR #32 deployed manually to staging during cutover smoke test. Auto-seeds facility cache on token verify so users don't hit the catch-22 between Refresh-needs-deviceToken and Enroll-needs-facility-cache.
+- [ ] **E4-PWA-013** Phase F — production cutover to Worker JWT proxy `status::blocked` `priority::critical` `estimate::1h`
+  - Blocked on: ≥24 hr clean staging soak (earliest start 2026-04-27 ~17:35 PHT) + GitHub #33 (Section F/G multi-select bug) + GitHub #34 (CF Pages auto-deploy regression) resolution.
+- [ ] **E4-PWA-014** Investigate Cloudflare Pages auto-deploy regression on `staging` push (GitHub #34) `status::todo` `priority::high` `estimate::2h`
+  - Phase F blocker if not fixed; otherwise Phase F runbook needs rewrite to make manual `wrangler pages deploy` the documented step.
+- [ ] **E4-PWA-015** Lower Worker PBKDF2 default to 100k (Workers runtime cap) — GitHub #35 `status::todo` `priority::medium` `estimate::1h`
+  - Two-line code change in `worker/scripts/hash-admin-password.mjs` + `worker/src/admin.ts`; add a vitest that documents the cap as test-enforced contract.
+- [ ] **E4-PWA-010** Backend secrets rotation policy documented (HMAC, JWT_SIGNING_KEY, Apps Script deploy ID) `status::todo` `priority::medium` `estimate::2h`
 - [ ] **E4-PWA-011** Backup + restore runbook for FacilityMasterList + submissions sheets `status::todo` `priority::medium` `estimate::3h`
 
 ### CSWeb Track *(not started)*

--- a/scrum/epics/epic-09-data-management-and-security.md
+++ b/scrum/epics/epic-09-data-management-and-security.md
@@ -3,7 +3,7 @@ epic: 9
 title: Data Management and Security
 phase: continuous
 status: governance-active
-last_updated: 2026-04-10
+last_updated: 2026-04-26
 ---
 
 # Epic 9 — Data Management and Security
@@ -37,6 +37,8 @@ Continuous governance workstream covering data privacy compliance, security arch
 
 ### Infrastructure Security
 
+- [x] **E9-019** F2 PWA HMAC-in-bundle finding closed via auth re-arch (PR #31, staging cutover 2026-04-26) `status::done` `priority::critical`
+  - Surfaced 2026-04-25 by `/gstack-cso` audit: `VITE_F2_HMAC_SECRET` was inlined into `dist/assets/*.js`, exposing the HMAC to anyone who downloaded the bundle. Closed by replacing with Cloudflare Worker JWT proxy (E4-PWA-008). Bundle scan now reports `check-bundle-secrets: OK`. Production closure pending Phase F (E4-PWA-013).
 - [ ] **E9-020** Encryption at rest specification (tablet storage, server storage) `status::todo` `priority::high` `estimate::2h`
 - [ ] **E9-021** Encryption in transit specification (sync channel tablet → CSWeb) `status::todo` `priority::high` `estimate::2h`
 - [ ] **E9-022** CSWeb server access control policy (who can read, who can export, who can admin) `status::todo` `priority::high` `estimate::3h`

--- a/scrum/product-backlog.md
+++ b/scrum/product-backlog.md
@@ -6,7 +6,7 @@ data_programmer: Carl Patrick L. Reyes
 qa_tester: Shan (ASPSI, RA)
 contract: CSA signed 2025-12-15, effective 2025-11-14
 engagement_window: November 2025 – August 2026
-last_updated: 2026-04-25
+last_updated: 2026-04-26
 ---
 
 # Product Backlog — UHC Survey Year 2 CAPI Development
@@ -23,7 +23,9 @@ last_updated: 2026-04-25
 
 ### Headline (this week)
 
-**Inter-sprint, Sat 2026-04-25 — F2 PWA Rounds 1 + 2 closed; Sprint 003 starts Mon 2026-04-28.** Tranche 2 (40%) was due 2026-04-24; ASPSI confirmed extension in effect, official revised deadline pending from DOH. Sprint 002 closed 2026-04-24 with F3 + F4 specs Build-ready and F1 DCF Designer-ready. Today's heavy lift was the F2 PWA UAT closure (see F2 PWA section below).
+**Inter-sprint, Sun 2026-04-26 — F2 PWA auth re-arch cut over to staging.** PR #31 (Cloudflare Worker JWT proxy replacing HMAC-in-bundle) merged to `staging` and live on `f2-pwa-staging.pages.dev`. Mitigates the **CRITICAL** finding from the 2026-04-25 `/gstack-cso` audit (HMAC was inlined into the Vite bundle, exposing it to anyone who downloaded the staging build). Worker URL: `https://f2-pwa-worker.hcw.workers.dev`. Disruption window ~18 min (longer than runbook's 4–6 min — see Issue #34). Three Round 3 issues filed during the cutover smoke test: **#33** Section F/G multi-select state pollution (Phase F blocker), **#34** CF Pages auto-deploy not firing on staging push (Phase F blocker or runbook rewrite), **#35** Worker PBKDF2 600k iters exceeds Workers' 100k cap (operational gotcha, fixed at runtime). PR #32 hot-fix opened for the EnrollmentScreen pre-refresh regression (deployed manually). **Phase F (production cutover) gated on ≥24 hours of clean staging soak + #33/#34 resolution; earliest window ~17:35 PHT 2026-04-27.**
+
+**Inter-sprint, Sat 2026-04-25 — F2 PWA Rounds 1 + 2 closed; Sprint 003 starts Mon 2026-04-28.** Tranche 2 (40%) was due 2026-04-24; ASPSI confirmed extension in effect, official revised deadline pending from DOH. Sprint 002 closed 2026-04-24 with F3 + F4 specs Build-ready and F1 DCF Designer-ready. Heavy lift on the 25th was the F2 PWA UAT closure (see F2 PWA section below).
 
 **F3 and F4 skip-logic + validation specs both landed 2026-04-21 (Sprint 002 Day 2 overdelivery).** F3 spec reviewed at 1133 lines — all 12 sections A–L, 14 sanity findings, 15 CSPro PROC templates, 6 open questions dispositioned (1 routed to Juvy: Q31 IP_GROUP; 5 spec-decisions with override clause). F4 spec drafted at 904 lines — all 17 sections A–Q, 13 sanity findings (findings #1/#2 CLOSED-BY-VERIFICATION 2026-04-21: `C_HOUSEHOLD_ROSTER` already repeating at `max_occurs=20`, `J_HEALTH_SEEKING` intentionally respondent-level per Apr 20 source), 11 CSPro PROC templates, 8 open questions dispositioned (3 routed to ASPSI, 5 spec-decisions). Both F3 and F4 are **Build-ready**. Deliverables at `deliverables/CSPro/F3/` and `deliverables/CSPro/F4/`.
 
@@ -52,7 +54,7 @@ Comms infrastructure fully provisioned (project mailbox + Viber group both live,
 | **1** | Inception & Engagement Setup | **Done** | — (historical, closed Dec 2025) |
 | **2** | Survey Questionnaire Design & Dictionary | **In Progress** (F1 Design — Designer round 2 / sign-off next; **F3 Build-ready, F4 Build-ready** — specs complete 2026-04-21; F2 data model lives inside the PWA spec; PLF Source Captured) | F1 sign-off (E2-F1-010); F3/F4 Designer validation (E2-F3-010, E2-F4-010) |
 | **3** | CAPI Application Development | **In Progress** (F2 **PWA in production at v1.1.1**, Rounds 1+2 closed, Round 3 v1.2.0 queued; F1 CSPro build pending Designer sign-off; F3/F4 Build-ready) | F1 `FacilityHeadSurvey.fmf` Section A layout (Sprint 003); F3/F4 build slots TBD; F2 Round 3 features when slot opens |
-| **4** | Backend & Sync Infrastructure (CSWeb for CAPI; Apps Script + Cloudflare Pages for PWA) | **In Progress** (PWA backend live and serving production v1.1.1; CSWeb track Not Started) | CSWeb provisioning + integration ETL spec drafted |
+| **4** | Backend & Sync Infrastructure (CSWeb for CAPI; Apps Script + Cloudflare Pages + Worker for PWA) | **In Progress** (PWA staging on auth re-arch v1.2.0 via Worker JWT proxy; production still on v1.1.1 awaiting Phase F cutover; CSWeb track Not Started) | Phase F production cutover (≥24 hr staging soak + #33/#34 resolved); CSWeb provisioning + integration ETL spec drafted |
 | **5** | Field Distribution & Device Management (tablets for CAPI; URL distribution + PWA install + reminder ops for F2) | **In Progress** (PWA distribution model proven via UAT; CAPI tablet provisioning Not Started) | Tablet provisioning SOP drafted; F2 distribution-list SOP drafted |
 | **6** | Testing and Pilot | **Mode-aware:** PWA test stack live (vitest + Playwright + cross-platform QA; UAT Rounds 1+2 closed). CAPI track Not Started. | F1 desk test (follows Epic 3); QA Tester (Shan) handoff workflow extended to CAPI |
 | **7** | Training and Documentation | Not Started | Survey manual outline (tied to D2); F2 self-admin one-pager + in-app help review |


### PR DESCRIPTION
## Summary

Two related cleanups discovered during the 2026-04-26 staging cutover lint pass.

### Commit 1 — prettier hygiene (`c1edb4e`)

`npm run format:check` was flagging 24 files. Three of them inflated any `prettier --write` to ~5,300 line diffs because they're auto-generated or canonical source-of-truth.

- Extended `.prettierignore` to skip `src/generated/` (regenerated per spec), `spec/` (canonical F2-Spec.md), `scripts/_one-shot-*.mjs` (historical migration scripts), and `CHANGELOG.md` (auto-maintained by `gen-changelog.mjs` postversion hook).
- Ran `npm run format` on the remaining 19 files — small whitespace / quote / line-break drift accumulated during PR #31's merge activity. No semantic changes.

### Commit 2 — worker tsconfig split (`892c947`)

`npm run typecheck` in `worker/` was failing on `test/hmac.test.ts` with `Cannot find module 'node:crypto'`. The worker tsconfig only loaded `@cloudflare/workers-types`, but the HMAC tests use Node's `node:crypto` via webcrypto for byte-compat with the Worker's runtime crypto. Tests ran fine via vitest at runtime; only tsc was broken.

- `tsconfig.json` — dropped `test/` from `include`; keeps workers-types only. Prevents accidental Node-API use in `src/` passing typecheck.
- `tsconfig.test.json` (new) — extends main; adds `node` + `vitest/globals` to types; includes `test/` only.
- `package.json` `typecheck` — chains both: `tsc --noEmit && tsc --noEmit -p tsconfig.test.json`.
- `package-lock.json` — adds `@types/node` devDep.

## Test plan

- [x] `npm test` in app — 307/307 passing
- [x] `npm test` in worker — 15/15 passing (jwt + hmac + sentinel)
- [x] `npm run typecheck` in app — clean
- [x] `npm run typecheck` in worker — clean (both main + test configs)
- [x] `npm run lint` in app — 0 errors, 6 advisory warnings (pre-existing `react-refresh/only-export-components` on context/hook files; not in scope)
- [x] `npm run format:check` in app — clean

## Out of scope

- The 6 `react-refresh/only-export-components` warnings — left as-is. They're advisory HMR-perf notices on context/hook files, deliberate pattern, not bugs.
- Worker has no ESLint or Prettier configured — only typecheck. Could add in a follow-up.