### PR TITLE
feat(F2 PWA): migrate design tokens to Verde Manual (DOH-anchored)

### DIFF
--- a/deliverables/F2/PWA/app/CLAUDE.md
+++ b/deliverables/F2/PWA/app/CLAUDE.md
@@ -11,6 +11,17 @@ work — those live in `deliverables/{F1,F3,F4}/` and follow the CSPro generator
 workflow, not the PWA git/PR flow. `/ship` for this app must NOT bump version
 or write CHANGELOG (the release-notes workflow owns those).
 
+## Design System
+
+Always read [`DESIGN.md`](./DESIGN.md) before making any visual, UI, color, type,
+spacing, or motion decision in this app. Memorable thing anchor:
+**"This is real software, not a government form."** Palette: Verde Manual
+(DOH-anchored emerald + pale verde paper). Type: Newsreader display + Public Sans
+Variable body + JetBrains Mono data. Layout: hairline-divided, no cards,
+marginal mono question numbers. Do not deviate without explicit user approval and
+without adding a row to the Decisions Log in `DESIGN.md`. In QA mode, flag any code
+that doesn't match.
+
 ## Skill routing
 
 When the user's request matches an available skill, invoke it via the Skill tool. The

--- a/deliverables/F2/PWA/app/CLAUDE.md
+++ b/deliverables/F2/PWA/app/CLAUDE.md
@@ -1,0 +1,53 @@
+# F2 PWA — App-level Claude instructions
+
+This CLAUDE.md is scoped to the F2 PWA app workstream only. The vault-level
+(`analytiflow/CLAUDE.md`) and LLM Wiki schema (`ASPSI-DOH-CAPI-CSPro-Development/CLAUDE.md`)
+still apply higher up the tree. Anything below this directory follows these rules
+in addition to the parents.
+
+**gstack scope:** gstack is adopted for the F2 PWA workstream only. Never use
+gstack skills (especially `/ship`, `/qa`, `/review`) on F1, F3, or F4 CSPro
+work — those live in `deliverables/{F1,F3,F4}/` and follow the CSPro generator
+workflow, not the PWA git/PR flow. `/ship` for this app must NOT bump version
+or write CHANGELOG (the release-notes workflow owns those).
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. The
+skill has multi-step workflows, checklists, and quality gates that produce better
+results than an ad-hoc answer. When in doubt, invoke the skill. A false positive is
+cheaper than a false negative.
+
+Key routing rules:
+- Product ideas, "is this worth building", brainstorming → invoke /office-hours
+- Strategy, scope, "think bigger", "what should we build" → invoke /plan-ceo-review
+- Architecture, "does this design make sense" → invoke /plan-eng-review
+- Design system, brand, "how should this look" → invoke /design-consultation
+- Design review of a plan → invoke /plan-design-review
+- Developer experience of a plan → invoke /plan-devex-review
+- "Review everything", full review pipeline → invoke /autoplan
+- Bugs, errors, "why is this broken", "wtf", "this doesn't work" → invoke /investigate
+- Test the site, find bugs, "does this work" → invoke /qa (or /qa-only for report only)
+- Code review, check the diff, "look at my changes" → invoke /review
+- Visual polish, design audit, "this looks off" → invoke /design-review
+- Developer experience audit, try onboarding → invoke /devex-review
+- Ship, deploy, create a PR, "send it" → invoke /ship
+- Merge + deploy + verify → invoke /land-and-deploy
+- Configure deployment → invoke /setup-deploy
+- Post-deploy monitoring → invoke /canary
+- Update docs after shipping → invoke /document-release
+- Weekly retro, "how'd we do" → invoke /retro
+- Second opinion, codex review → invoke /codex
+- Safety mode, careful mode, lock it down → invoke /careful or /guard
+- Restrict edits to a directory → invoke /freeze or /unfreeze
+- Upgrade gstack → invoke /gstack-upgrade
+- Save progress, "save my work" → invoke /context-save
+- Resume, restore, "where was I" → invoke /context-restore
+- Security audit, OWASP, "is this secure" → invoke /cso
+- Make a PDF, document, publication → invoke /make-pdf
+- Launch real browser for QA → invoke /open-gstack-browser
+- Import cookies for authenticated testing → invoke /setup-browser-cookies
+- Performance regression, page speed, benchmarks → invoke /benchmark
+- Review what gstack has learned → invoke /learn
+- Tune question sensitivity → invoke /plan-tune
+- Code quality dashboard → invoke /health

--- a/deliverables/F2/PWA/app/DESIGN.md
+++ b/deliverables/F2/PWA/app/DESIGN.md
@@ -1,0 +1,291 @@
+# Design System — F2 PWA
+
+> **This file is the visual source of truth for the F2 PWA.**
+> Read it before making any UI, color, type, spacing, or motion decision.
+> Do not deviate without explicit approval. In QA, flag any code that doesn't match.
+
+---
+
+## Memorable Thing
+
+> **"This is real software, not a government form."**
+
+Every type, color, spacing, and motion decision in this system serves that anchor.
+Restraint compounds. Hairlines, pale verde paper, and one DOH emerald signal carry
+the trust HCWs need to install government software on their personal phones.
+
+---
+
+## Product Context
+
+- **What this is:** Offline-capable Progressive Web App for the F2 (Healthcare Worker Survey) instrument under the ASPSI → DOH UHC Act monitoring contract. Self-administered. 124 items, 35+ sections, 30 minutes to several hours to fill.
+- **Who it's for:** Filipino healthcare workers (HCWs) using their own phones, tablets, or laptops. Bilingual: English + Filipino (Tagalog).
+- **Space/industry:** Government health monitoring. Plan B to CSPro/CSEntry (Plan A) within the F2 track; PWA is the long-term F2 capture target per the 2026-04-21 track positioning.
+- **Project type:** Single-purpose web app (form-heavy). Not a dashboard, not a marketing site, not a general survey platform.
+
+---
+
+## Aesthetic Direction
+
+- **Direction:** **Verde Manual** — clinical stationery and utility, anchored on the Philippine DOH "Verde Vision / Berde para sa bayan" institutional palette.
+- **Decoration level:** Minimal. Typography does the work. No drop shadows. No decorative SVGs. No glassmorphism.
+- **Mood:** Quiet confidence. Print-influenced composition (hairlines, baseline grid, marginal numbering) translated to PWA. Tactile but not twee. Field manual, not SaaS dashboard.
+- **Reference sites:** [gov.uk](https://www.gov.uk) (single-blue institutional restraint), [Linear](https://linear.app) (modern indie polish via restraint), DOH Philippines visual identity (Verde Vision palette).
+
+---
+
+## Color — Verde Manual
+
+**Approach:** Restrained. One signal color. Warm-cool neutrals (verde-tinted) that read distinct from generic gov-tech white.
+
+> **Caveat:** Hex values below are best-fit approximations of the visible DOH seal +
+> the documented Verde Vision background tint `#e7efe7`. Refine when the official
+> DOH brand-book PDF is available (Department Order 2020-0011, Verde Vision 2023+).
+
+### Light mode (default)
+
+| Token | Hex | Role |
+|---|---|---|
+| `--paper` | `#F2F5EE` | Background. Pale verde-tinted off-white. References DOH `#e7efe7`, slightly warmer for screen comfort. |
+| `--ink` | `#1A1F1A` | Primary text. Warm near-black with subtle green undertone. ~14:1 contrast on paper, exceeds WCAG AAA. |
+| `--hairline` | `#B5C0A9` | Rule color. Section dividers, input borders. Verde-tinted to harmonize. |
+| `--muted` | `#5A655A` | Secondary text, helpers, eyebrows. Warm gray-green. |
+| `--signal` | `#006B3F` | DOH emerald. Primary CTAs, current-question marker, active progress, selected radio rings. The recognizable institutional handshake. |
+| `--signal-bg` | `#006B3F1A` | 10% alpha tint. Used only as the current-question background fade. |
+| `--highlight` | `#E5B23B` | DOH yellow inner-rim color. Used **very sparingly** — only for "saved" toasts and similar punctuation moments. Never as fill or surface. |
+| `--success` | `#006B3F` | Same as signal — green is intrinsically "OK" in DOH context, no separate success color. |
+| `--warning` | `#C68A2E` | Ochre. Storage-quota warnings, near-stale draft notices. |
+| `--error` | `#B72020` | Cherry red. References the cross at the center of the DOH seal. Used only on validation errors and submission rejections. |
+
+### Dark mode
+
+| Token | Hex | Role |
+|---|---|---|
+| `--paper` | `#0F1410` | Background. Warm graphite, never pure black. |
+| `--ink` | `#DCE3D5` | Primary text. Warm off-white with subtle green undertone. |
+| `--hairline` | `#2A3328` | Rule color. |
+| `--muted` | `#828C82` | Secondary text. |
+| `--signal` | `#2A9166` | Emerald shifted brighter for retina balance on dark ground. |
+| `--signal-bg` | `#2A91661F` | 12% alpha tint. |
+| `--highlight` | `#F1C95C` | DOH yellow shifted brighter. |
+| `--error` | `#D6504C` | Cherry shifted brighter. |
+
+### Color usage rules
+
+1. The signal color (`--signal`) is the only place emerald appears. Never as background fill, never as text in body copy, only as: CTA buttons, current-question marker (gutter number + 10%-alpha row tint), active progress fill, selected radio/checkbox dot ring, focus ring on inputs.
+2. The highlight color (`--highlight`) is reserved for save-confirmation toasts and the section-saved badge. Never use it for CTAs, links, or primary text.
+3. Error color (`--error`) is reserved for validation errors and submission rejections. Never for warnings, never for emphasis.
+4. No raw Tailwind color classes in app code (`text-red-500`, `bg-blue-100`, etc.). Always go through the CSS variable tokens.
+
+---
+
+## Typography
+
+**All three fonts are free + open source. Loaded via local `/public/fonts/*.woff2` and precached by the service worker.** First-install bundle adds ~120 kB; zero runtime cost after install.
+
+### Faces
+
+| Role | Font | License | Why |
+|---|---|---|---|
+| **Display** | **Newsreader** by Production Type | OFL | Contemporary serif with clean terminals. Reads as edited document, not browser default. Carries Filipino diacritics (`ñ`, `ng`) cleanly. Variable axes for fine weight control. |
+| **Body** | **Public Sans Variable** by US Web Design System | OFL | Designed specifically for government-form accessibility. Excellent x-height. Full Latin Extended for Filipino. Tabular-nums built in. Variable. |
+| **Mono / Data** | **JetBrains Mono** | Apache 2.0 | Question numbers in margin, IDs, timestamps, sync counters, version tags. Genuine monospaced figures. |
+| **Fallback (system)** | `Georgia, "Times New Roman", serif` for display; `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif` for body; `"SF Mono", Menlo, Consolas, monospace` for mono | — | Only seen during initial load before woff2 hydrates. |
+
+### Type scale (modular 1.250 ratio, 16px base)
+
+| Token | Size / Line | Use |
+|---|---|---|
+| `text-xs` | 12 / 18 | Helper text, mono labels, badges |
+| `text-sm` | 14 / 21 | Form labels, secondary copy |
+| `text-base` | 16 / 25 | Body, question prompts (default) |
+| `text-lg` | 18 / 27 | Question prompts at desktop, emphasized body |
+| `text-xl` | 20 / 28 | Subsection headers |
+| `text-2xl` | 24 / 32 | h2, dialog titles |
+| `text-3xl` | 28 / 36 | Mobile section titles |
+| `text-4xl` | 36 / 42 | Desktop section titles (Newsreader 500) |
+| `text-5xl` | 48 / 54 | Splash / first-launch hero (Newsreader 500) |
+
+### Type rules
+
+1. Display sizes (`text-3xl` and above) always use Newsreader, weight 500 (medium) by default, 600 only for splash heroes.
+2. Body sizes use Public Sans, weight 400 default, 500 for question prompts, 600 for active section indicators.
+3. Mono is used in: (a) the marginal question number gutter at `text-2xl`, (b) all timestamps and IDs at `text-xs`, (c) the typographic ledger progress at `text-sm`. Never for body copy, never for prompts.
+4. Letter-spacing: `tracking-tight` (-0.015em) on display sizes, default on body, `tracking-wide` (0.04em) on uppercase mono labels.
+5. Line height: 1.55 for body, 1.45 for question prompts, 1.15 for display.
+6. **Verbatim labels.** Per project convention (`feedback_verbatim_questionnaire_labels`): never paraphrase question text. Use the exact wording from the spec, including original question numbers — even when the rendered design diverges (e.g., the marginal `047` is rendered, but the prompt text is verbatim from `F2-Spec.md`).
+
+---
+
+## Spacing
+
+- **Base unit:** 4px
+- **Density:** Comfortable. Form-heavy app means HCWs read for hours; compact density causes fatigue.
+- **Scale:** `2 / 4 / 8 / 12 / 16 / 24 / 32 / 48 / 64 / 96`
+
+### Spacing rules
+
+| Where | Value |
+|---|---|
+| Form field vertical rhythm | 12px between label and input, 8px between input and helper, 24px between fields |
+| Question vertical breathing | 32px between questions |
+| Section breaks | 48px above section opener, 24px between section title and first question |
+| Header padding | 16px vertical, 32px horizontal (desktop) / 12px vertical, 20px horizontal (mobile) |
+| Section opener top margin | 56px (desktop) / 32px (mobile) |
+| Margin gutter for question numbers | 88px (desktop/tablet, holds the JetBrains Mono `047` left of question text), 0 mobile (number stacks above) |
+| Page max content width | 720px (the question column) |
+| Frame max width | 1280px (centered with hairline borders left/right) |
+
+---
+
+## Layout
+
+- **Approach:** Grid-disciplined, hairline-divided, asymmetric.
+- **First viewport:** Reads as a poster (oversized Newsreader headline, signal-color question-count badge, single CTA, ample paper). Not a document.
+- **Inside survey:** Strict 4pt baseline grid. Question text left-weighted in a 720px column. Question number hangs in an 88px left gutter on tablet/desktop, stacks above on phone.
+- **Grid columns:** 1 column on mobile (≤640px), 2 columns on tablet (gutter + content), 3 columns on desktop (gutter + content + free space).
+- **Max content width:** 720px (question column). 1280px (frame).
+- **Border radius scale:** `0` (cards — but we don't use cards), `2px` (default — buttons, inputs, pills), `4px` (max — used only for the Likert outer container and yes/no toggles). No `rounded-lg`, no `rounded-2xl`, no `rounded-full` except for radio dots.
+
+### Layout rules
+
+1. **No cards.** Sections separated by 1px `--hairline` rules and whitespace only. No `bg-white rounded-lg shadow` patterns anywhere in the app. This is the single biggest move that drops the gov-SaaS smell.
+2. **Hairlines are 1px solid `--hairline`.** Never thicker. Never dashed except in preview meta-bars.
+3. **Question numbers** in JetBrains Mono live in the left margin gutter (`text-2xl` weight 500, color `--muted` for non-current questions, `--signal` for current). On mobile they stack above the prompt at `text-base`.
+4. **Progress** is rendered as a typographic ledger (`047 ━━━━━━━━━━━━━╴╴╴╴╴ 124`) in JetBrains Mono, not a graphical progress bar. The filled portion uses `--signal`, the unfilled portion uses 45% opacity `--muted`.
+5. Asymmetric: question text left-aligned, response affordances inline-block right-flowing on tablet/desktop, stacked on phone.
+
+---
+
+## Motion
+
+- **Approach:** Minimal-functional. No entrance animations on form fields — distracting during 3-hour fills. Motion only at state transitions.
+- **Easing:**
+  - `enter`: `cubic-bezier(0.16, 1, 0.3, 1)` (gentle ease-out)
+  - `exit`: `cubic-bezier(0.4, 0, 1, 1)` (ease-in)
+  - `move`: `ease-in-out`
+- **Duration:**
+  - `micro` 80ms — save-confirm pulse on the question-number gutter (single flash, then back to neutral)
+  - `short` 150ms — input focus rings, button press, hover transitions
+  - `medium` 250ms — view transitions (form ↔ review ↔ sync), palette/theme switches
+  - `long` — not used
+
+### Motion rules
+
+1. Form fields never animate on entrance. Once they're rendered, they're rendered.
+2. The save-confirmation pulse is the only place `--signal` animates. 80ms flash on the question-number text, no other surface lights up.
+3. View transitions use `opacity` + 8px `translateY`, never scale or rotate.
+4. Respect `prefers-reduced-motion: reduce` — disable all transitions when the user has it set. Auto-fade still allowed but no `translate`.
+
+---
+
+## Components
+
+This section grows as components are built. For every domain component:
+- Document the component's role
+- Specify the spacing rhythm in/around it
+- List the color tokens used
+- Note any deviation from the rules above (and why)
+
+### `<Question>` (current)
+- Role: renders one F2 item, dispatches by type (text, number, radio, multi-select, matrix, date)
+- Layout: 88px gutter (desktop) holds the JetBrains Mono `047` number; 720px max-width content column with prompt + helper + response affordance
+- Vertical breathing: 32px before, 32px after, hairline between
+- Current-question style: background `--signal-bg` (10% alpha emerald), gutter number switches to `--signal`
+- Required indicator: `*` in `--signal`, immediately after the prompt text
+
+### `<Likert>`
+- 5 options in a horizontal `border` `rounded-2px` `divide-x` row (desktop), stacks vertical on mobile
+- Each option: 1.5px ring radio dot in `--muted`, switching to filled `--signal` (with paper-color inner ring) when selected
+- Selected option's row gets `--signal-bg` background tint
+- Hover: same `--signal-bg` tint, dot color stays muted
+
+### `<YesNo>`
+- 2 options, inline-flex, hairline border, `rounded-2px`
+- Selected: `--signal` solid background, `--paper` text
+- Unselected: transparent, `--ink` text, hairline-bordered
+
+### `<Navigator>`
+- Bottom-fixed bar at the survey level; hairline border-top
+- Left: ghost `← Previous` button
+- Center: typographic ledger progress in JetBrains Mono
+- Right: solid `--signal` `Next →` button (default state) or ghost `Submit responses` (last question)
+
+### `<SyncBadge>` / `<PendingCount>`
+- Header pill, JetBrains Mono `text-xs`
+- Format: `{count} pending` where `{count}` is `--signal` and "pending" is `--muted`
+
+### `<LanguageSwitcher>`
+- Inline-flex pill, hairline-bordered, `rounded-2px`
+- Active language: `--ink` background, `--paper` text
+- Inactive language: transparent, `--muted` text
+
+---
+
+## Accessibility
+
+1. **Contrast:** All text-on-paper combos exceed WCAG AAA (`--ink` on `--paper` ≈ 14:1; `--muted` on `--paper` ≈ 4.6:1, AA at minimum).
+2. **Focus:** Every interactive element gets a 2px `--signal` outline at 2px offset on `:focus-visible`. Never remove focus rings.
+3. **Touch targets:** Minimum 44×44px hit area on all interactive elements. The Likert dots are 16px visually but the click target spans the full option cell (typically 80×60px at desktop).
+4. **`prefers-reduced-motion`:** Disable all transitions and animations.
+5. **`prefers-color-scheme`:** Respected on first paint. User can override via the in-app dark-mode toggle (M11 hardening).
+6. **Screen readers:** All form fields have associated `<label>`. Required fields announce "required" via `aria-required`. The marginal `047` number is `aria-hidden="true"` so screen readers don't read "Question zero four seven" twice — use a `<span class="sr-only">Question 47</span>` inline with the prompt.
+7. **Filipino + English diacritics:** Public Sans Variable carries full Latin Extended. Test on real devices for `ñ`, `ng`, and the stylized `ng̃` combining-tilde before each release.
+
+---
+
+## Implementation Notes
+
+These are forward-looking notes for the PRs that will land this design system in code. Currently the app uses shadcn defaults + a teal primary; the migration to Verde Manual will land in 2-3 PRs.
+
+### PR plan (suggested)
+
+1. **PR 1 — Tokens.** Replace `:root` HSL variables in `src/index.css` with the Verde Manual hex tokens. Update `tailwind.config.ts` if needed (current config maps Tailwind classes to CSS vars, so most changes ride through automatically). Update `public/manifest.webmanifest` `theme_color` from `#0f766e` (teal) to `#006B3F` (DOH emerald).
+2. **PR 2 — Typography.** Add `public/fonts/{newsreader, public-sans, jetbrains-mono}.woff2` (subset to Latin Extended). Reference in `index.css` `@font-face` rules. Precache via vite-plugin-pwa workbox config. Add `font-family` declarations to body + Tailwind theme extend.
+3. **PR 3 — Layout & components.** Refactor `<Question>` to add the 88px gutter + marginal mono number. Replace any `border rounded-lg shadow` patterns with hairline rules. Update `<MultiSectionForm>` section dividers to hairlines + whitespace. Update `<Navigator>` to typographic-ledger progress.
+
+Each PR is small enough to review in 10 minutes and ship under `/ship` (which does NOT bump version per `project_gstack_adoption`).
+
+### Don't deviate without
+
+1. Updating this file with the new decision and adding a row to the Decisions Log below.
+2. Confirming the change doesn't break the Memorable Thing anchor: "real software, not a government form."
+3. Running through the Anti-Slop checklist (next section).
+
+---
+
+## Anti-Slop Checklist
+
+If you're about to commit a UI change, verify:
+
+- [ ] No purple, violet, or generic SaaS-blue gradients
+- [ ] No 3-column SaaS feature grid with circle-bg icons
+- [ ] No centered-everything layout (use the asymmetric grid)
+- [ ] No `rounded-2xl` or `rounded-full` (except radio dots)
+- [ ] No `bg-white shadow-md rounded-lg` "card" patterns
+- [ ] No gradient buttons (signal is flat, full stop)
+- [ ] No emoji in UI chrome (emoji is fine in user-generated content)
+- [ ] No system-ui or `-apple-system` as the *primary* display or body font (only as fallback while woff2 loads)
+- [ ] No "Get Started" / "Built for X" / "Designed for Y" copy patterns
+- [ ] No Lottie or decorative SVG blobs
+- [ ] No glassmorphism, no backdrop-blur on chrome surfaces
+- [ ] CTA reads "Begin Section 1" / "Next →" / "Submit responses" — concrete, not generic
+
+---
+
+## Decisions Log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-04-26 | Initial design system created | Created by `/gstack-design-consultation`. Memorable thing: "real software, not a government form." Verde Manual chosen over Field Manual to ladder up to DOH institutional brand without losing craft. Hex values approximated from visible DOH seal + Verde Vision documented background; refine when official brand-book PDF is available. |
+
+---
+
+## References
+
+- `../2026-04-17-design-spec.md` — F2 PWA architecture (this file is the visual layer)
+- `../2026-04-21-implementation-plan.md` — milestone roadmap M0–M11
+- DOH Philippines visual identity: Department Order 2020-0011, Verde Vision 2023+ (PDFs paywalled on Scribd; refine when available)
+- gov.uk design system — institutional restraint reference: <https://design-system.service.gov.uk/>
+- US Web Design System (Public Sans origin): <https://designsystem.digital.gov/>
+- Bunny Fonts (CDN for development): <https://fonts.bunny.net/>

--- a/deliverables/F2/PWA/app/src/index.css
+++ b/deliverables/F2/PWA/app/src/index.css
@@ -2,24 +2,66 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Design tokens — Verde Manual.
+ * See ../DESIGN.md for the full system, palette rationale, and DOH brand caveats.
+ * Hex values are best-fit approximations of the DOH "Verde Vision" palette;
+ * refine when the official brand-book PDF is available.
+ */
+
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --primary: 173 80% 26%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --ring: 173 80% 26%;
-    --radius: 0.5rem;
+    /* Surfaces */
+    --background: 85.7 25.9% 94.7%; /* #F2F5EE paper */
+    --foreground: 120 8.8% 11.2%; /* #1A1F1A ink */
+    --muted: 86 24% 92%; /* slightly darker paper tint */
+    --muted-foreground: 120 5.8% 37.5%; /* #5A655A */
+    --secondary: 86 24% 92%;
+    --secondary-foreground: 120 8.8% 11.2%;
+    --accent: 86 24% 92%;
+    --accent-foreground: 120 8.8% 11.2%;
+
+    /* Lines */
+    --border: 88.7 15.4% 70.8%; /* #B5C0A9 hairline */
+    --input: 88.7 15.4% 70.8%;
+    --ring: 155.3 100% 21%; /* signal — focus ring */
+
+    /* Signal — DOH emerald */
+    --primary: 155.3 100% 21%; /* #006B3F */
+    --primary-foreground: 85.7 25.9% 94.7%;
+
+    /* Destructive — cherry red, references the cross at the seal's center */
+    --destructive: 0 70.2% 42.2%; /* #B72020 */
+    --destructive-foreground: 85.7 25.9% 94.7%;
+
+    /* Highlight — DOH yellow inner rim. Used very sparingly (save toasts only).
+     * Not yet bound to a Tailwind utility; consume via hsl(var(--highlight)). */
+    --highlight: 42 76.6% 56.5%; /* #E5B23B */
+
+    /* Radius — Verde Manual caps at 4px; default is 2px */
+    --radius: 0.25rem;
+  }
+
+  .dark {
+    --background: 132 14.3% 6.9%; /* #0F1410 graphite */
+    --foreground: 90 20% 86.3%; /* #DCE3D5 */
+    --muted: 120 6% 12%;
+    --muted-foreground: 120 4.2% 52.9%; /* #828C82 */
+    --secondary: 120 6% 12%;
+    --secondary-foreground: 90 20% 86.3%;
+    --accent: 120 6% 12%;
+    --accent-foreground: 90 20% 86.3%;
+
+    --border: 109.1 12.1% 17.8%; /* #2A3328 */
+    --input: 109.1 12.1% 17.8%;
+    --ring: 155 55.1% 36.7%;
+
+    --primary: 155 55.1% 36.7%; /* #2A9166 — emerald shifted brighter for dark */
+    --primary-foreground: 90 20% 86.3%;
+
+    --destructive: 1.7 62.7% 56.9%; /* #D6504C */
+    --destructive-foreground: 90 20% 86.3%;
+
+    --highlight: 43.9 84.2% 65.3%; /* #F1C95C */
   }
 }
 

--- a/deliverables/F2/PWA/app/vite.config.ts
+++ b/deliverables/F2/PWA/app/vite.config.ts
@@ -23,8 +23,8 @@ export default defineConfig({
         scope: '/',
         display: 'standalone',
         orientation: 'portrait',
-        theme_color: '#0f766e',
-        background_color: '#ffffff',
+        theme_color: '#006B3F',
+        background_color: '#F2F5EE',
         lang: 'en',
         icons: [
           { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png' },


### PR DESCRIPTION
## Summary

PR **1 of 3** from the DESIGN.md migration plan. **Token-only swap.** No markup or component changes. Visible result: the app shifts from teal `#0f766e` to **DOH emerald `#006B3F`** across every component that consumes Tailwind theme tokens.

See [`deliverables/F2/PWA/app/DESIGN.md`](./deliverables/F2/PWA/app/DESIGN.md) for the full system rationale (memorable thing, palette, typography, layout, motion). Memorable-thing anchor: *"This is real software, not a government form."*

## Changes

- `src/index.css` `:root` rewritten to Verde Manual HSL triples
  - paper `#F2F5EE`, ink `#1A1F1A`, hairline `#B5C0A9`, muted-fg `#5A655A`
  - signal/primary `#006B3F` (DOH emerald)
  - destructive `#B72020` (cherry red, references the cross at the seal's center)
  - new `--highlight: #E5B23B` token (DOH yellow inner rim, used very sparingly for save toasts; not yet bound to a Tailwind utility)
- Adds `.dark` block (the file was light-only before) with the Verde dark palette: `#0F1410` graphite ground, `#DCE3D5` ink, `#2A9166` emerald shifted brighter for retina balance
- `--radius` dropped from `0.5rem` to `0.25rem` to honor DESIGN.md max-4px rule (default 2px, max 4px on Likert outer / yes-no toggles)
- `vite.config.ts` `manifest.theme_color` `#0f766e` → `#006B3F`, `background_color` `#ffffff` → `#F2F5EE`

## Validation

- ✅ `npm run typecheck` clean
- ✅ `npm run lint` 0 errors (6 pre-existing warnings unchanged)
- ✅ `npm run format:check` clean on edited files
- ✅ `npm run test` 307/307 passing
- ✅ Visual smoke on dev server: confirmed Verde paper + ink + hairline render on the Enroll screen; CSS vars resolved to expected RGB values (`rgb(242, 245, 238)` body bg, `rgb(26, 31, 26)` text, `--primary: 155.3 100% 21%`)

## Caveat

DOH hex values are best-fit approximations of the visible seal + the documented Verde Vision background tint `#e7efe7`. Refine when the official DOH brand-book PDF (DO 2020-0011, Verde Vision 2023+) is available — those PDFs are paywalled on Scribd, so the gate is access, not effort.

## What's next (separate PRs)

- **PR 2 — typography:** add Newsreader + Public Sans Variable + JetBrains Mono woff2 (Latin Extended subset) under `public/fonts/`, `@font-face`, Tailwind theme extend, vite-plugin-pwa precache
- **PR 3 — layout & components:** 88px gutter on `<Question>` for marginal mono numbers, kill any `border rounded shadow` card patterns, replace `<ProgressBar>` graphical bar with typographic ledger

## Test plan

- [ ] Pull the branch locally and run `npm run dev` — verify Verde palette on Enroll screen
- [ ] Toggle dark mode (add `.dark` to `<html>` via DevTools) — verify the `.dark` block resolves
- [ ] Confirm install prompt and PWA icon `theme_color` reflects DOH emerald
- [ ] Sanity-check that no Tailwind class breaks (e.g., `bg-primary`, `text-destructive`, `border-input`)