### PR TITLE
feat(F2 PWA): wire up Verde Manual fonts via Bunny CDN + SW cache

### DIFF
--- a/deliverables/F2/PWA/app/DESIGN.md
+++ b/deliverables/F2/PWA/app/DESIGN.md
@@ -44,31 +44,31 @@ the trust HCWs need to install government software on their personal phones.
 
 ### Light mode (default)
 
-| Token | Hex | Role |
-|---|---|---|
-| `--paper` | `#F2F5EE` | Background. Pale verde-tinted off-white. References DOH `#e7efe7`, slightly warmer for screen comfort. |
-| `--ink` | `#1A1F1A` | Primary text. Warm near-black with subtle green undertone. ~14:1 contrast on paper, exceeds WCAG AAA. |
-| `--hairline` | `#B5C0A9` | Rule color. Section dividers, input borders. Verde-tinted to harmonize. |
-| `--muted` | `#5A655A` | Secondary text, helpers, eyebrows. Warm gray-green. |
-| `--signal` | `#006B3F` | DOH emerald. Primary CTAs, current-question marker, active progress, selected radio rings. The recognizable institutional handshake. |
-| `--signal-bg` | `#006B3F1A` | 10% alpha tint. Used only as the current-question background fade. |
-| `--highlight` | `#E5B23B` | DOH yellow inner-rim color. Used **very sparingly** — only for "saved" toasts and similar punctuation moments. Never as fill or surface. |
-| `--success` | `#006B3F` | Same as signal — green is intrinsically "OK" in DOH context, no separate success color. |
-| `--warning` | `#C68A2E` | Ochre. Storage-quota warnings, near-stale draft notices. |
-| `--error` | `#B72020` | Cherry red. References the cross at the center of the DOH seal. Used only on validation errors and submission rejections. |
+| Token         | Hex         | Role                                                                                                                                     |
+| ------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--paper`     | `#F2F5EE`   | Background. Pale verde-tinted off-white. References DOH `#e7efe7`, slightly warmer for screen comfort.                                   |
+| `--ink`       | `#1A1F1A`   | Primary text. Warm near-black with subtle green undertone. ~14:1 contrast on paper, exceeds WCAG AAA.                                    |
+| `--hairline`  | `#B5C0A9`   | Rule color. Section dividers, input borders. Verde-tinted to harmonize.                                                                  |
+| `--muted`     | `#5A655A`   | Secondary text, helpers, eyebrows. Warm gray-green.                                                                                      |
+| `--signal`    | `#006B3F`   | DOH emerald. Primary CTAs, current-question marker, active progress, selected radio rings. The recognizable institutional handshake.     |
+| `--signal-bg` | `#006B3F1A` | 10% alpha tint. Used only as the current-question background fade.                                                                       |
+| `--highlight` | `#E5B23B`   | DOH yellow inner-rim color. Used **very sparingly** — only for "saved" toasts and similar punctuation moments. Never as fill or surface. |
+| `--success`   | `#006B3F`   | Same as signal — green is intrinsically "OK" in DOH context, no separate success color.                                                  |
+| `--warning`   | `#C68A2E`   | Ochre. Storage-quota warnings, near-stale draft notices.                                                                                 |
+| `--error`     | `#B72020`   | Cherry red. References the cross at the center of the DOH seal. Used only on validation errors and submission rejections.                |
 
 ### Dark mode
 
-| Token | Hex | Role |
-|---|---|---|
-| `--paper` | `#0F1410` | Background. Warm graphite, never pure black. |
-| `--ink` | `#DCE3D5` | Primary text. Warm off-white with subtle green undertone. |
-| `--hairline` | `#2A3328` | Rule color. |
-| `--muted` | `#828C82` | Secondary text. |
-| `--signal` | `#2A9166` | Emerald shifted brighter for retina balance on dark ground. |
-| `--signal-bg` | `#2A91661F` | 12% alpha tint. |
-| `--highlight` | `#F1C95C` | DOH yellow shifted brighter. |
-| `--error` | `#D6504C` | Cherry shifted brighter. |
+| Token         | Hex         | Role                                                        |
+| ------------- | ----------- | ----------------------------------------------------------- |
+| `--paper`     | `#0F1410`   | Background. Warm graphite, never pure black.                |
+| `--ink`       | `#DCE3D5`   | Primary text. Warm off-white with subtle green undertone.   |
+| `--hairline`  | `#2A3328`   | Rule color.                                                 |
+| `--muted`     | `#828C82`   | Secondary text.                                             |
+| `--signal`    | `#2A9166`   | Emerald shifted brighter for retina balance on dark ground. |
+| `--signal-bg` | `#2A91661F` | 12% alpha tint.                                             |
+| `--highlight` | `#F1C95C`   | DOH yellow shifted brighter.                                |
+| `--error`     | `#D6504C`   | Cherry shifted brighter.                                    |
 
 ### Color usage rules
 
@@ -81,30 +81,34 @@ the trust HCWs need to install government software on their personal phones.
 
 ## Typography
 
-**All three fonts are free + open source. Loaded via local `/public/fonts/*.woff2` and precached by the service worker.** First-install bundle adds ~120 kB; zero runtime cost after install.
+**All three fonts are free + open source.**
+
+**Long-term target:** Loaded via local `/public/fonts/*.woff2` and precached by the service worker. First-install bundle adds ~120 kB; zero runtime cost after install.
+
+**Currently (as of PR 2):** Loaded from [Bunny Fonts CDN](https://fonts.bunny.net) (privacy-friendly, GDPR-clean, no Google tracking). The service worker runtime-caches `fonts.bunny.net` responses so the app works offline after first visit. The self-host transition is gated on `pyftsubset` tooling for proper Latin Extended subsetting and will land as a follow-up PR.
 
 ### Faces
 
-| Role | Font | License | Why |
-|---|---|---|---|
-| **Display** | **Newsreader** by Production Type | OFL | Contemporary serif with clean terminals. Reads as edited document, not browser default. Carries Filipino diacritics (`ñ`, `ng`) cleanly. Variable axes for fine weight control. |
-| **Body** | **Public Sans Variable** by US Web Design System | OFL | Designed specifically for government-form accessibility. Excellent x-height. Full Latin Extended for Filipino. Tabular-nums built in. Variable. |
-| **Mono / Data** | **JetBrains Mono** | Apache 2.0 | Question numbers in margin, IDs, timestamps, sync counters, version tags. Genuine monospaced figures. |
-| **Fallback (system)** | `Georgia, "Times New Roman", serif` for display; `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif` for body; `"SF Mono", Menlo, Consolas, monospace` for mono | — | Only seen during initial load before woff2 hydrates. |
+| Role                  | Font                                                                                                                                                                            | License    | Why                                                                                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Display**           | **Newsreader** by Production Type                                                                                                                                               | OFL        | Contemporary serif with clean terminals. Reads as edited document, not browser default. Carries Filipino diacritics (`ñ`, `ng`) cleanly. Variable axes for fine weight control. |
+| **Body**              | **Public Sans Variable** by US Web Design System                                                                                                                                | OFL        | Designed specifically for government-form accessibility. Excellent x-height. Full Latin Extended for Filipino. Tabular-nums built in. Variable.                                 |
+| **Mono / Data**       | **JetBrains Mono**                                                                                                                                                              | Apache 2.0 | Question numbers in margin, IDs, timestamps, sync counters, version tags. Genuine monospaced figures.                                                                           |
+| **Fallback (system)** | `Georgia, "Times New Roman", serif` for display; `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif` for body; `"SF Mono", Menlo, Consolas, monospace` for mono | —          | Only seen during initial load before woff2 hydrates.                                                                                                                            |
 
 ### Type scale (modular 1.250 ratio, 16px base)
 
-| Token | Size / Line | Use |
-|---|---|---|
-| `text-xs` | 12 / 18 | Helper text, mono labels, badges |
-| `text-sm` | 14 / 21 | Form labels, secondary copy |
-| `text-base` | 16 / 25 | Body, question prompts (default) |
-| `text-lg` | 18 / 27 | Question prompts at desktop, emphasized body |
-| `text-xl` | 20 / 28 | Subsection headers |
-| `text-2xl` | 24 / 32 | h2, dialog titles |
-| `text-3xl` | 28 / 36 | Mobile section titles |
-| `text-4xl` | 36 / 42 | Desktop section titles (Newsreader 500) |
-| `text-5xl` | 48 / 54 | Splash / first-launch hero (Newsreader 500) |
+| Token       | Size / Line | Use                                          |
+| ----------- | ----------- | -------------------------------------------- |
+| `text-xs`   | 12 / 18     | Helper text, mono labels, badges             |
+| `text-sm`   | 14 / 21     | Form labels, secondary copy                  |
+| `text-base` | 16 / 25     | Body, question prompts (default)             |
+| `text-lg`   | 18 / 27     | Question prompts at desktop, emphasized body |
+| `text-xl`   | 20 / 28     | Subsection headers                           |
+| `text-2xl`  | 24 / 32     | h2, dialog titles                            |
+| `text-3xl`  | 28 / 36     | Mobile section titles                        |
+| `text-4xl`  | 36 / 42     | Desktop section titles (Newsreader 500)      |
+| `text-5xl`  | 48 / 54     | Splash / first-launch hero (Newsreader 500)  |
 
 ### Type rules
 
@@ -125,16 +129,16 @@ the trust HCWs need to install government software on their personal phones.
 
 ### Spacing rules
 
-| Where | Value |
-|---|---|
-| Form field vertical rhythm | 12px between label and input, 8px between input and helper, 24px between fields |
-| Question vertical breathing | 32px between questions |
-| Section breaks | 48px above section opener, 24px between section title and first question |
-| Header padding | 16px vertical, 32px horizontal (desktop) / 12px vertical, 20px horizontal (mobile) |
-| Section opener top margin | 56px (desktop) / 32px (mobile) |
+| Where                              | Value                                                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Form field vertical rhythm         | 12px between label and input, 8px between input and helper, 24px between fields                             |
+| Question vertical breathing        | 32px between questions                                                                                      |
+| Section breaks                     | 48px above section opener, 24px between section title and first question                                    |
+| Header padding                     | 16px vertical, 32px horizontal (desktop) / 12px vertical, 20px horizontal (mobile)                          |
+| Section opener top margin          | 56px (desktop) / 32px (mobile)                                                                              |
 | Margin gutter for question numbers | 88px (desktop/tablet, holds the JetBrains Mono `047` left of question text), 0 mobile (number stacks above) |
-| Page max content width | 720px (the question column) |
-| Frame max width | 1280px (centered with hairline borders left/right) |
+| Page max content width             | 720px (the question column)                                                                                 |
+| Frame max width                    | 1280px (centered with hairline borders left/right)                                                          |
 
 ---
 
@@ -182,12 +186,14 @@ the trust HCWs need to install government software on their personal phones.
 ## Components
 
 This section grows as components are built. For every domain component:
+
 - Document the component's role
 - Specify the spacing rhythm in/around it
 - List the color tokens used
 - Note any deviation from the rules above (and why)
 
 ### `<Question>` (current)
+
 - Role: renders one F2 item, dispatches by type (text, number, radio, multi-select, matrix, date)
 - Layout: 88px gutter (desktop) holds the JetBrains Mono `047` number; 720px max-width content column with prompt + helper + response affordance
 - Vertical breathing: 32px before, 32px after, hairline between
@@ -195,27 +201,32 @@ This section grows as components are built. For every domain component:
 - Required indicator: `*` in `--signal`, immediately after the prompt text
 
 ### `<Likert>`
+
 - 5 options in a horizontal `border` `rounded-2px` `divide-x` row (desktop), stacks vertical on mobile
 - Each option: 1.5px ring radio dot in `--muted`, switching to filled `--signal` (with paper-color inner ring) when selected
 - Selected option's row gets `--signal-bg` background tint
 - Hover: same `--signal-bg` tint, dot color stays muted
 
 ### `<YesNo>`
+
 - 2 options, inline-flex, hairline border, `rounded-2px`
 - Selected: `--signal` solid background, `--paper` text
 - Unselected: transparent, `--ink` text, hairline-bordered
 
 ### `<Navigator>`
+
 - Bottom-fixed bar at the survey level; hairline border-top
 - Left: ghost `← Previous` button
 - Center: typographic ledger progress in JetBrains Mono
 - Right: solid `--signal` `Next →` button (default state) or ghost `Submit responses` (last question)
 
 ### `<SyncBadge>` / `<PendingCount>`
+
 - Header pill, JetBrains Mono `text-xs`
 - Format: `{count} pending` where `{count}` is `--signal` and "pending" is `--muted`
 
 ### `<LanguageSwitcher>`
+
 - Inline-flex pill, hairline-bordered, `rounded-2px`
 - Active language: `--ink` background, `--paper` text
 - Inactive language: transparent, `--muted` text
@@ -241,7 +252,7 @@ These are forward-looking notes for the PRs that will land this design system in
 ### PR plan (suggested)
 
 1. **PR 1 — Tokens.** Replace `:root` HSL variables in `src/index.css` with the Verde Manual hex tokens. Update `tailwind.config.ts` if needed (current config maps Tailwind classes to CSS vars, so most changes ride through automatically). Update `public/manifest.webmanifest` `theme_color` from `#0f766e` (teal) to `#006B3F` (DOH emerald).
-2. **PR 2 — Typography.** Add `public/fonts/{newsreader, public-sans, jetbrains-mono}.woff2` (subset to Latin Extended). Reference in `index.css` `@font-face` rules. Precache via vite-plugin-pwa workbox config. Add `font-family` declarations to body + Tailwind theme extend.
+2. **PR 2 — Typography.** _(Shipping as #38)_ Add Bunny Fonts CDN `<link>` to `index.html`. Update `tailwind.config.ts` `theme.fontFamily` extend to map `font-serif` → Newsreader, `font-sans` → Public Sans, `font-mono` → JetBrains Mono. Add workbox `runtimeCaching` for `fonts.bunny.net` (CSS = StaleWhileRevalidate, woff2 = CacheFirst). Self-host transition deferred to a follow-up PR (gated on `pyftsubset` tooling).
 3. **PR 3 — Layout & components.** Refactor `<Question>` to add the 88px gutter + marginal mono number. Replace any `border rounded-lg shadow` patterns with hairline rules. Update `<MultiSectionForm>` section dividers to hairlines + whitespace. Update `<Navigator>` to typographic-ledger progress.
 
 Each PR is small enough to review in 10 minutes and ship under `/ship` (which does NOT bump version per `project_gstack_adoption`).
@@ -265,7 +276,7 @@ If you're about to commit a UI change, verify:
 - [ ] No `bg-white shadow-md rounded-lg` "card" patterns
 - [ ] No gradient buttons (signal is flat, full stop)
 - [ ] No emoji in UI chrome (emoji is fine in user-generated content)
-- [ ] No system-ui or `-apple-system` as the *primary* display or body font (only as fallback while woff2 loads)
+- [ ] No system-ui or `-apple-system` as the _primary_ display or body font (only as fallback while woff2 loads)
 - [ ] No "Get Started" / "Built for X" / "Designed for Y" copy patterns
 - [ ] No Lottie or decorative SVG blobs
 - [ ] No glassmorphism, no backdrop-blur on chrome surfaces
@@ -275,8 +286,8 @@ If you're about to commit a UI change, verify:
 
 ## Decisions Log
 
-| Date | Decision | Rationale |
-|---|---|---|
+| Date       | Decision                      | Rationale                                                                                                                                                                                                                                                                                                                                    |
+| ---------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 2026-04-26 | Initial design system created | Created by `/gstack-design-consultation`. Memorable thing: "real software, not a government form." Verde Manual chosen over Field Manual to ladder up to DOH institutional brand without losing craft. Hex values approximated from visible DOH seal + Verde Vision documented background; refine when official brand-book PDF is available. |
 
 ---

--- a/deliverables/F2/PWA/app/index.html
+++ b/deliverables/F2/PWA/app/index.html
@@ -5,6 +5,14 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>UHC Survey Y2 — Healthcare Worker Survey Questionnaire</title>
+
+    <!-- Verde Manual fonts. See DESIGN.md. CDN now, self-host follow-up.
+         Service worker runtime-caches fonts.bunny.net for offline use. -->
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.bunny.net/css?family=newsreader:400,500,600,700|public-sans:400,500,600,700|jetbrains-mono:400,500,600&display=swap"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/deliverables/F2/PWA/app/tailwind.config.ts
+++ b/deliverables/F2/PWA/app/tailwind.config.ts
@@ -43,6 +43,20 @@ export default {
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
       },
+      fontFamily: {
+        // Verde Manual. See DESIGN.md.
+        // `serif` overrides the Tailwind default so `font-serif` resolves to Newsreader.
+        serif: ['Newsreader', 'Georgia', '"Times New Roman"', 'serif'],
+        sans: [
+          'Public Sans',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          '"Segoe UI"',
+          'Roboto',
+          'sans-serif',
+        ],
+        mono: ['"JetBrains Mono"', '"SF Mono"', 'Menlo', 'Consolas', 'monospace'],
+      },
     },
   },
   plugins: [tailwindcssAnimate],

--- a/deliverables/F2/PWA/app/vite.config.ts
+++ b/deliverables/F2/PWA/app/vite.config.ts
@@ -41,6 +41,27 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,svg,png,ico,webmanifest}'],
         navigateFallback: '/index.html',
         cleanupOutdatedCaches: true,
+        // Verde Manual fonts. See DESIGN.md. CDN now, self-host follow-up.
+        // CSS = StaleWhileRevalidate (refresh when online); woff2 = CacheFirst.
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/fonts\.bunny\.net\/css/,
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'bunny-fonts-css',
+              expiration: { maxEntries: 5, maxAgeSeconds: 60 * 60 * 24 * 365 },
+            },
+          },
+          {
+            urlPattern: /^https:\/\/fonts\.bunny\.net\/.*\.(woff2?|ttf|otf)$/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'bunny-fonts-files',
+              expiration: { maxEntries: 30, maxAgeSeconds: 60 * 60 * 24 * 365 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+        ],
       },
       devOptions: {
         enabled: false,


### PR DESCRIPTION
## Summary

PR **2 of 3** from the DESIGN.md migration plan. Wires up the Verde Manual typography stack: **Newsreader** (display) + **Public Sans Variable** (body) + **JetBrains Mono** (data/margin). All three are free + open source (OFL / Apache 2.0). Loaded via [Bunny Fonts CDN](https://fonts.bunny.net), runtime-cached by the service worker for offline use.

See [`deliverables/F2/PWA/app/DESIGN.md`](./deliverables/F2/PWA/app/DESIGN.md) Typography section for the full font roles, scale, and rules.

## Changes

- `index.html` — `<link>` preconnect + stylesheet for `fonts.bunny.net` serving Newsreader (400/500/600/700), Public Sans (400/500/600/700), JetBrains Mono (400/500/600)
- `tailwind.config.ts` — `theme.fontFamily` extend:
  - `font-serif` → Newsreader (Georgia / Times New Roman fallback)
  - `font-sans` → Public Sans (-apple-system / BlinkMacSystemFont / Segoe UI / Roboto fallback)
  - `font-mono` → JetBrains Mono (SF Mono / Menlo / Consolas fallback)
- `vite.config.ts` — workbox `runtimeCaching` for `fonts.bunny.net` (CSS = StaleWhileRevalidate, woff2 = CacheFirst, 1-year max age, status 0/200 cacheable)
- `DESIGN.md` — Typography section updated to acknowledge the staged approach (CDN now, self-host follow-up gated on `pyftsubset` tooling)

## Validation

- ✅ `npm run typecheck` clean
- ✅ `npm run lint` 0 errors (6 pre-existing warnings unchanged)
- ✅ `npm run format:check` clean on edited files
- ✅ `npm run test` 307/307 passing
- ✅ Visual smoke on dev server: Public Sans 400/500/600 loaded from Bunny CDN (`document.fonts` API confirmed `loaded` status); body font-family resolved to `"Public Sans", -apple-system, ...`. Newsreader and JetBrains Mono registered in `@font-face` but in `unloaded` state — they'll load on demand when PR 3 applies `font-serif` and `font-mono` utility classes to components.

## Why CDN now (and not self-host)

DESIGN.md's long-term target is `/public/fonts/*.woff2` precached at build time. Self-hosting requires `pyftsubset` (fontTools) for proper Latin Extended subsetting — which isn't installed on the dev machine.

**The CDN path here is not a compromise on offline.** Bunny Fonts pre-subsets woff2 by Latin / Latin-Ext unicode ranges, so the user only fetches the bytes they need. The service worker `CacheFirst` strategy on woff2 means after first visit, fonts come from the cache forever (1-year max age). StaleWhileRevalidate on the CSS catches Bunny additions without breaking the offline guarantee.

**Bunny vs Google Fonts:** Bunny is GDPR-compliant by default (no IP logging, no tracking cookies), API-compatible with Google Fonts CSS, and the woff2 quality is identical (Bunny mirrors Google's source).

**Self-host follow-up** lands once `pyftsubset` is available on the build machine. At that point the migration is: download the same woff2 files Bunny serves, place under `public/fonts/`, swap the `<link>` for inline `@font-face` with `unicode-range`, and let workbox `globPatterns` precache them. The Tailwind config doesn't change.

## Test plan

- [ ] Pull the branch, `npm run dev`, open at `localhost:5173`. Verify body text is in Public Sans (not system Helvetica/Arial). The "x" character should have a higher x-height than system-ui.
- [ ] Open DevTools → Network → filter to "font" — confirm 1-3 woff2 requests to `fonts.bunny.net` (only the ranges/weights the page uses). Total transferred should be < 50 kB on first load.
- [ ] Toggle offline in DevTools, hard-reload. Service worker should serve fonts from cache without a network request.
- [ ] DevTools → Console: `Array.from(document.fonts).filter(f => f.status === 'loaded').map(f => f.family + ' ' + f.weight)` — should list Public Sans (and Newsreader / JetBrains Mono once PR 3 lands).

## Caveats

- **Visible diff vs origin/staging:** This PR adds fonts; the Verde Manual color palette lands in PR #37 (tokens). When this branch is dev-served in isolation, you'll see fonts swapped on top of the OLD teal palette — that's expected. Both PRs together produce the full Verde Manual experience.
- **Newsreader and JetBrains Mono:** Won't appear in the live UI yet because nothing applies `font-serif` / `font-mono` until PR 3.

## What's next

**PR 3 — layout & components.** 88px gutter on `<Question>` for marginal mono numbers, kill any `border rounded shadow` card patterns, replace `<ProgressBar>` graphical bar with typographic ledger.