### PR TITLE
feat(F2 PWA): apply Verde Manual layout & components (PR 3 of 3)

### DIFF
--- a/deliverables/F2/PWA/app/src/App.tsx
+++ b/deliverables/F2/PWA/app/src/App.tsx
@@ -248,8 +248,8 @@ function AppShell() {
       <BroadcastBanner message={runtimeConfig.broadcast_message} />
       <header className="flex items-center justify-between border-b px-6 py-3">
         <div className="flex flex-col">
-          <h1 className="text-2xl font-bold tracking-tight">{t('chrome.appTitle')}</h1>
-          <span className="text-xs leading-none text-muted-foreground">
+          <h1 className="font-serif text-2xl font-medium tracking-tight">{t('chrome.appTitle')}</h1>
+          <span className="font-mono text-xs leading-none text-muted-foreground">
             v{APP_VERSION} · spec {LOCAL_SPEC_VERSION}
           </span>
         </div>
@@ -287,7 +287,9 @@ function AppShell() {
         <p className="p-6 text-sm text-muted-foreground">{t('chrome.loading')}</p>
       ) : status === 'submitted' ? (
         <section className="mx-auto flex max-w-xl flex-col gap-4 p-6">
-          <h2 className="text-2xl font-semibold">{t('chrome.thankYouHeading')}</h2>
+          <h2 className="font-serif text-2xl font-medium tracking-tight">
+            {t('chrome.thankYouHeading')}
+          </h2>
           <p className="text-sm text-muted-foreground">{t('chrome.thankYouBody')}</p>
           <div className="flex items-center gap-3">
             <Button variant="outline" size="sm" onClick={() => setView('sync')}>
@@ -298,7 +300,7 @@ function AppShell() {
         </section>
       ) : status === 'submit_failed' ? (
         <section className="mx-auto flex max-w-xl flex-col gap-4 p-6">
-          <h2 className="text-2xl font-semibold text-red-700">
+          <h2 className="font-serif text-2xl font-medium tracking-tight text-destructive">
             {t('chrome.submitFailedHeading')}
           </h2>
           <p className="text-sm text-muted-foreground">

--- a/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.tsx
+++ b/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.tsx
@@ -103,11 +103,13 @@ export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
 
   return (
     <form onSubmit={handleEnroll} className="mx-auto flex max-w-md flex-col gap-4 p-6">
-      <h2 className="text-2xl font-semibold tracking-tight">{t('enrollment.heading')}</h2>
+      <h2 className="font-serif text-2xl font-medium tracking-tight">{t('enrollment.heading')}</h2>
 
       {/* Step 1 — Tablet token */}
-      <section className="flex flex-col gap-2 rounded-md border border-border p-4">
-        <h3 className="text-sm font-semibold">{t('enrollment.tokenStep')}</h3>
+      <section className="flex flex-col gap-2 border-t border-border pt-4">
+        <h3 className="font-mono text-xs uppercase tracking-wide text-muted-foreground">
+          {t('enrollment.tokenStep')}
+        </h3>
         <p className="text-sm text-muted-foreground">{t('enrollment.tokenHelper')}</p>
 
         <label className="flex flex-col gap-1 text-sm">
@@ -118,7 +120,7 @@ export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
             placeholder={t('enrollment.tokenPlaceholder')}
             rows={3}
             disabled={!!verifiedToken}
-            className="rounded-md border border-input px-3 py-2 font-mono text-xs"
+            className="border border-input bg-background px-3 py-2 font-mono text-xs"
             data-testid="enrollment-token-input"
           />
         </label>
@@ -128,7 +130,7 @@ export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
             {verifying ? t('enrollment.verifyingTokenButton') : t('enrollment.verifyTokenButton')}
           </Button>
         ) : (
-          <p className="text-sm text-green-700" data-testid="enrollment-token-accepted">
+          <p className="text-sm text-primary" data-testid="enrollment-token-accepted">
             {t('enrollment.tokenAccepted', {
               facility: facilityFromToken?.facility_name ?? tokenFacilityId,
             })}
@@ -138,8 +140,10 @@ export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
 
       {/* Step 2 — Identity (only after token verified) */}
       {verifiedToken ? (
-        <section className="flex flex-col gap-2 rounded-md border border-border p-4">
-          <h3 className="text-sm font-semibold">{t('enrollment.identityStep')}</h3>
+        <section className="flex flex-col gap-2 border-t border-border pt-4">
+          <h3 className="font-mono text-xs uppercase tracking-wide text-muted-foreground">
+            {t('enrollment.identityStep')}
+          </h3>
 
           <label className="flex flex-col gap-1 text-sm">
             {t('enrollment.hcwIdLabel')}
@@ -147,7 +151,7 @@ export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
               type="text"
               value={hcwId}
               onChange={(e) => setHcwId(e.target.value)}
-              className="rounded-md border border-input px-3 py-2 text-sm"
+              className="border border-input bg-background px-3 py-2 text-sm"
               autoComplete="off"
             />
           </label>
@@ -162,19 +166,14 @@ export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
             <Button type="submit" disabled={!canSubmit}>
               {t('enrollment.enrollButton')}
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleRefresh}
-              disabled={refreshing}
-            >
+            <Button type="button" variant="outline" onClick={handleRefresh} disabled={refreshing}>
               {refreshing ? t('enrollment.refreshingButton') : t('enrollment.refreshButton')}
             </Button>
           </div>
         </section>
       ) : null}
 
-      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
     </form>
   );
 }

--- a/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.tsx
@@ -43,7 +43,7 @@ export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
                 <th scope="row" className="py-2 pr-2 text-left text-sm font-normal">
                   <span className="mr-1 text-muted-foreground">{item.id}.</span>
                   {localized(item.label, locale)}
-                  {item.required ? <span className="ml-1 text-red-600">*</span> : null}
+                  {item.required ? <span className="ml-1 text-destructive">*</span> : null}
                 </th>
                 {choices.map((c) => (
                   <td key={c.value} className="py-2 px-1 text-center">
@@ -60,7 +60,11 @@ export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
             if (errorMessage || error) {
               out.push(
                 <tr key={`${item.id}-err`}>
-                  <td colSpan={choices.length + 1} className="py-1 text-xs text-red-600" role="alert">
+                  <td
+                    colSpan={choices.length + 1}
+                    className="py-1 text-xs text-destructive"
+                    role="alert"
+                  >
                     {errorMessage ?? t('question.requiredFallback')}
                   </td>
                 </tr>,
@@ -82,7 +86,7 @@ export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
               <p id={groupId} className="text-sm font-medium">
                 <span className="mr-1 text-muted-foreground">{item.id}.</span>
                 {localized(item.label, locale)}
-                {item.required ? <span className="ml-1 text-red-600">*</span> : null}
+                {item.required ? <span className="ml-1 text-destructive">*</span> : null}
               </p>
               <div role="radiogroup" aria-labelledby={groupId} className="flex flex-wrap gap-3">
                 {choices.map((c) => (
@@ -98,7 +102,7 @@ export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
                 ))}
               </div>
               {errorMessage || error ? (
-                <p role="alert" className="text-xs text-red-600">
+                <p role="alert" className="text-xs text-destructive">
                   {errorMessage ?? t('question.requiredFallback')}
                 </p>
               ) : null}

--- a/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
@@ -78,9 +78,7 @@ function getSectionStatus(section: SectionConfig, values: FormValues): SectionSt
     if (it.type === 'multi-field' && it.subFields) {
       // A subfield is required only if the parent is required AND its own required
       // flag isn't explicitly false. Optional subfields don't block completion.
-      return it.subFields.every(
-        (sf) => sf.required === false || hasValue(values[sf.id]),
-      );
+      return it.subFields.every((sf) => sf.required === false || hasValue(values[sf.id]));
     }
     return hasValue(values[it.id]);
   });
@@ -135,13 +133,11 @@ export function MultiSectionForm({
   );
 
   const visibleSectionEntries = useMemo(
-    () => SECTIONS.reduce<Array<{ config: SectionConfig; originalIndex: number }>>(
-      (acc, s, i) => {
+    () =>
+      SECTIONS.reduce<Array<{ config: SectionConfig; originalIndex: number }>>((acc, s, i) => {
         if (shouldShowSection(s.id, merged)) acc.push({ config: s, originalIndex: i });
         return acc;
-      },
-      [],
-    ),
+      }, []),
     [merged],
   );
 
@@ -176,7 +172,7 @@ export function MultiSectionForm({
   // Reset entry status when navigating to a new section (must be before the auto-advance effect)
   useEffect(() => {
     entryStatusRef.current = sectionStatuses[index] ?? 'empty';
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [index]);
 
   // Auto-advance when current section transitions from non-complete to complete
@@ -190,7 +186,7 @@ export function MultiSectionForm({
       handleNext();
     }, 400);
     return () => clearTimeout(timer);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sectionStatuses]);
 
   const showLockMsg = () => {
@@ -290,7 +286,9 @@ export function MultiSectionForm({
           sections={visibleSectionEntries.map((e) => e.config)}
           currentIndex={visibleIndex}
           statuses={visibleSectionEntries.map((e) => sectionStatuses[e.originalIndex]!)}
-          maxVisitedIndex={visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1}
+          maxVisitedIndex={
+            visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1
+          }
           onNavigate={(i) => handleNavigate(visibleSectionEntries[i]!.originalIndex)}
         />
       </aside>
@@ -313,8 +311,13 @@ export function MultiSectionForm({
               sections={visibleSectionEntries.map((e) => e.config)}
               currentIndex={visibleIndex}
               statuses={visibleSectionEntries.map((e) => sectionStatuses[e.originalIndex]!)}
-              maxVisitedIndex={visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1}
-              onNavigate={(i) => { handleNavigate(visibleSectionEntries[i]!.originalIndex); setDrawerOpen(false); }}
+              maxVisitedIndex={
+                visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1
+              }
+              onNavigate={(i) => {
+                handleNavigate(visibleSectionEntries[i]!.originalIndex);
+                setDrawerOpen(false);
+              }}
               onClose={() => setDrawerOpen(false)}
             />
           </aside>
@@ -331,7 +334,15 @@ export function MultiSectionForm({
           isFirst && 'invisible',
         )}
       >
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
           <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
         </svg>
       </button>
@@ -348,7 +359,15 @@ export function MultiSectionForm({
             : 'bg-background/90 hover:bg-muted',
         )}
       >
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
           <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
         </svg>
       </button>
@@ -368,11 +387,27 @@ export function MultiSectionForm({
               className="shrink-0 rounded p-1 hover:bg-muted lg:hidden"
               onClick={() => setDrawerOpen(true)}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
               </svg>
             </button>
-            <ProgressBar current={visibleIndex + 1} total={visibleSectionEntries.length} className="flex-1 px-0 pt-0" />
+            <ProgressBar
+              current={visibleIndex + 1}
+              total={visibleSectionEntries.length}
+              className="flex-1 px-0 pt-0"
+            />
             {/* Save Draft — upper right */}
             <button
               type="button"
@@ -380,7 +415,7 @@ export function MultiSectionForm({
               className="shrink-0 rounded border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted"
             >
               {showSaved ? (
-                <span className="text-green-600">{t('navigator.draftSaved')}</span>
+                <span className="text-primary">{t('navigator.draftSaved')}</span>
               ) : (
                 t('navigator.saveDraft')
               )}
@@ -395,7 +430,7 @@ export function MultiSectionForm({
           ) : null}
 
           <div className="mx-auto max-w-xl px-6 pb-2">
-            <h2 className="text-xl font-semibold tracking-tight">
+            <h2 className="font-serif text-xl font-medium tracking-tight">
               {t('review.sectionHeading', {
                 id: current!.id,
                 title: localized(current!.section.title, locale),

--- a/deliverables/F2/PWA/app/src/components/survey/Navigator.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Navigator.tsx
@@ -15,7 +15,7 @@ export function Navigator({ onSaveDraft, showSaved }: NavigatorProps) {
         {t('navigator.saveDraft')}
       </Button>
       {showSaved ? (
-        <span className="whitespace-nowrap text-sm text-green-600">{t('navigator.draftSaved')}</span>
+        <span className="whitespace-nowrap text-sm text-primary">{t('navigator.draftSaved')}</span>
       ) : null}
     </div>
   );

--- a/deliverables/F2/PWA/app/src/components/survey/ProgressBar.test.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/ProgressBar.test.tsx
@@ -20,4 +20,12 @@ describe('<ProgressBar>', () => {
     render(<ProgressBar current={3} total={3} />);
     expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
   });
+
+  it('renders the typographic ledger with zero-padded counters', () => {
+    render(<ProgressBar current={4} total={35} />);
+    const bar = screen.getByRole('progressbar');
+    // Zero-padded to total's width: 35 → 2 chars, so 4 → '04'
+    expect(bar.textContent).toContain('04');
+    expect(bar.textContent).toContain('35');
+  });
 });

--- a/deliverables/F2/PWA/app/src/components/survey/ProgressBar.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/ProgressBar.tsx
@@ -7,12 +7,17 @@ interface ProgressBarProps {
   className?: string;
 }
 
+const TRACK_WIDTH = 18;
+
 export function ProgressBar({ current, total, className }: ProgressBarProps) {
   const { t } = useTranslation();
-  const percent = Math.min(100, Math.round((current / total) * 100));
+  const ratio = Math.min(1, Math.max(0, current / total));
+  const percent = Math.round(ratio * 100);
+  const filled = Math.round(ratio * TRACK_WIDTH);
+  const padded = (n: number) => String(n).padStart(String(total).length, '0');
   return (
     <div className={cn('flex flex-col gap-1 px-6 pt-3', className)}>
-      <p className="text-xs text-muted-foreground">
+      <p className="font-mono text-xs uppercase tracking-wide text-muted-foreground">
         {t('progressBar.sectionLabel', { current, total })}
       </p>
       <div
@@ -20,9 +25,18 @@ export function ProgressBar({ current, total, className }: ProgressBarProps) {
         aria-valuenow={percent}
         aria-valuemin={0}
         aria-valuemax={100}
-        className="h-2 w-full overflow-hidden rounded bg-muted"
+        className="font-mono text-sm leading-none"
       >
-        <div className="h-full bg-primary transition-all" style={{ width: `${percent}%` }} />
+        <span className="text-foreground">{padded(current)}</span>
+        <span aria-hidden="true">{'  '}</span>
+        <span aria-hidden="true" className="text-primary">
+          {'━'.repeat(filled)}
+        </span>
+        <span aria-hidden="true" className="text-muted-foreground opacity-45">
+          {'━'.repeat(TRACK_WIDTH - filled)}
+        </span>
+        <span aria-hidden="true">{'  '}</span>
+        <span className="text-muted-foreground">{padded(total)}</span>
       </div>
     </div>
   );

--- a/deliverables/F2/PWA/app/src/components/survey/Question.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Question.tsx
@@ -36,35 +36,46 @@ export function Question({ item }: QuestionProps) {
   const errorMessage = typeof error?.message === 'string' ? error.message : undefined;
 
   return (
-    <div className="flex flex-col gap-2 py-3">
-      <label htmlFor={item.id} className="text-sm font-medium">
-        <span className="mr-1 text-muted-foreground">{item.id}.</span>
-        {localized(item.label, locale)}
-        {item.required ? <span className="ml-1 text-red-600">*</span> : null}
-      </label>
-      {item.help ? (
-        <p className="text-xs text-muted-foreground">{localized(item.help, locale)}</p>
-      ) : null}
-      {renderControl(
-        item,
-        register,
-        showSpecify,
-        t,
-        locale,
-        errors,
-        visibleChoices,
-        currentValue,
-        (next) => setValue(item.id, next, { shouldValidate: true, shouldDirty: true }),
-      )}
-      {errorMessage ? (
-        <p role="alert" className="text-xs text-red-600">
-          {errorMessage}
-        </p>
-      ) : error ? (
-        <p role="alert" className="text-xs text-red-600">
-          {t('question.requiredFallback')}
-        </p>
-      ) : null}
+    <div className="grid grid-cols-1 gap-y-2 py-3 sm:grid-cols-[80px_1fr]">
+      <span
+        aria-hidden="true"
+        className="font-mono text-sm text-muted-foreground sm:pt-1 sm:pr-4 sm:text-right sm:text-base sm:leading-snug"
+      >
+        {item.id}
+      </span>
+      <div className="flex min-w-0 flex-col gap-2">
+        <label htmlFor={item.id} className="text-base font-medium leading-snug">
+          <span className="sr-only">
+            {item.id}
+            {'. '}
+          </span>
+          {localized(item.label, locale)}
+          {item.required ? <span className="ml-1 text-destructive">*</span> : null}
+        </label>
+        {item.help ? (
+          <p className="text-xs text-muted-foreground">{localized(item.help, locale)}</p>
+        ) : null}
+        {renderControl(
+          item,
+          register,
+          showSpecify,
+          t,
+          locale,
+          errors,
+          visibleChoices,
+          currentValue,
+          (next) => setValue(item.id, next, { shouldValidate: true, shouldDirty: true }),
+        )}
+        {errorMessage ? (
+          <p role="alert" className="text-xs text-destructive">
+            {errorMessage}
+          </p>
+        ) : error ? (
+          <p role="alert" className="text-xs text-destructive">
+            {t('question.requiredFallback')}
+          </p>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -91,18 +102,26 @@ function blockNonNumericKeys(event: React.KeyboardEvent<HTMLInputElement>) {
 //   is no longer accurate).
 export function nextMultiValue(
   current: string[],
-  clicked: { value: string; isExclusive?: boolean; isSelectAll?: boolean; isOtherSpecify?: boolean },
+  clicked: {
+    value: string;
+    isExclusive?: boolean;
+    isSelectAll?: boolean;
+    isOtherSpecify?: boolean;
+  },
   willBeChecked: boolean,
-  allChoices: ReadonlyArray<{ value: string; isExclusive?: boolean; isSelectAll?: boolean; isOtherSpecify?: boolean }>,
+  allChoices: ReadonlyArray<{
+    value: string;
+    isExclusive?: boolean;
+    isSelectAll?: boolean;
+    isOtherSpecify?: boolean;
+  }>,
 ): string[] {
   const findChoice = (v: string) => allChoices.find((c) => c.value === v);
 
   if (willBeChecked) {
     if (clicked.isExclusive) return [clicked.value];
     if (clicked.isSelectAll) {
-      return allChoices
-        .filter((c) => !c.isExclusive && !c.isOtherSpecify)
-        .map((c) => c.value);
+      return allChoices.filter((c) => !c.isExclusive && !c.isOtherSpecify).map((c) => c.value);
     }
     const filtered = current.filter((v) => {
       const c = findChoice(v);
@@ -144,7 +163,7 @@ function renderControl(
         <input
           id={item.id}
           type="text"
-          className="rounded border border-input bg-background px-3 py-2"
+          className="rounded-md border border-input bg-background px-3 py-2"
           {...register(item.id)}
         />
       );
@@ -153,7 +172,7 @@ function renderControl(
         <textarea
           id={item.id}
           rows={4}
-          className="rounded border border-input bg-background px-3 py-2"
+          className="rounded-md border border-input bg-background px-3 py-2"
           {...register(item.id)}
         />
       );
@@ -166,7 +185,7 @@ function renderControl(
           max={item.max}
           inputMode="numeric"
           onKeyDown={blockNonNumericKeys}
-          className="rounded border border-input bg-background px-3 py-2"
+          className="rounded-md border border-input bg-background px-3 py-2"
           {...register(item.id)}
         />
       );
@@ -194,7 +213,7 @@ function renderControl(
               <input
                 id={`${item.id}_other`}
                 type="text"
-                className="rounded border border-input bg-background px-3 py-2"
+                className="rounded-md border border-input bg-background px-3 py-2"
                 {...register(`${item.id}_other`)}
               />
             </div>
@@ -222,16 +241,13 @@ function renderControl(
                     checked={isChecked}
                     onChange={(e) => {
                       if (!onChange) return;
-                      const next = nextMultiValue(
-                        selected,
-                        choice,
-                        e.target.checked,
-                        allChoices,
-                      );
+                      const next = nextMultiValue(selected, choice, e.target.checked, allChoices);
                       onChange(next);
                     }}
                     onBlur={reg.onBlur}
-                    {...(idx === 0 ? { id: item.id, ref: reg.ref, name: reg.name } : { name: reg.name })}
+                    {...(idx === 0
+                      ? { id: item.id, ref: reg.ref, name: reg.name }
+                      : { name: reg.name })}
                   />
                   {localized(choice.label, locale)}
                 </label>
@@ -246,7 +262,7 @@ function renderControl(
               <input
                 id={`${item.id}_other`}
                 type="text"
-                className="rounded border border-input bg-background px-3 py-2"
+                className="rounded-md border border-input bg-background px-3 py-2"
                 {...register(`${item.id}_other`)}
               />
             </div>
@@ -259,7 +275,7 @@ function renderControl(
         <input
           id={item.id}
           type="date"
-          className="rounded border border-input bg-background px-3 py-2"
+          className="rounded-md border border-input bg-background px-3 py-2"
           {...register(item.id)}
         />
       );
@@ -283,15 +299,15 @@ function renderControl(
                   {...(sf.kind === 'number'
                     ? { inputMode: 'numeric', onKeyDown: blockNonNumericKeys }
                     : {})}
-                  className="rounded border border-input bg-background px-3 py-2"
+                  className="rounded-md border border-input bg-background px-3 py-2"
                   {...register(sf.id)}
                 />
                 {sfErrorMessage ? (
-                  <p role="alert" className="text-xs text-red-600">
+                  <p role="alert" className="text-xs text-destructive">
                     {sfErrorMessage}
                   </p>
                 ) : sfError ? (
-                  <p role="alert" className="text-xs text-red-600">
+                  <p role="alert" className="text-xs text-destructive">
                     {t('question.requiredFallback')}
                   </p>
                 ) : null}

--- a/deliverables/F2/PWA/app/src/components/survey/ReviewSection.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/ReviewSection.tsx
@@ -74,11 +74,14 @@ function rowsForItem(
   return rows;
 }
 
+// Hairline-bordered alerts with a colored left border (no full background fill).
+// `warn` keeps amber pending a `--warning` Tailwind binding (TODO: extend
+// theme.colors with `warning` from --warning, see DESIGN.md § Color).
 const SEVERITY_STYLES: Record<Warning['severity'], string> = {
-  error: 'border-red-300 bg-red-50 text-red-900',
-  warn: 'border-amber-300 bg-amber-50 text-amber-900',
-  clean: 'border-blue-300 bg-blue-50 text-blue-900',
-  info: 'border-slate-200 bg-slate-50 text-slate-700',
+  error: 'border-border border-l-4 border-l-destructive text-foreground',
+  warn: 'border-border border-l-4 border-l-amber-600 text-foreground',
+  clean: 'border-border border-l-4 border-l-primary text-foreground',
+  info: 'border-border border-l-4 border-l-muted-foreground text-foreground',
 };
 
 export function ReviewSection({ values, onEdit, onSubmit }: ReviewSectionProps) {
@@ -88,16 +91,13 @@ export function ReviewSection({ values, onEdit, onSubmit }: ReviewSectionProps) 
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-6 p-6">
-      <h2 className="text-2xl font-semibold tracking-tight">{t('review.heading')}</h2>
+      <h2 className="font-serif text-2xl font-medium tracking-tight">{t('review.heading')}</h2>
 
       {warnings.length > 0 ? (
         <section aria-label={t('review.crossFieldRegion')} className="flex flex-col gap-2">
           {warnings.map((w) => (
-            <div
-              key={w.id}
-              className={`rounded-md border px-3 py-2 text-sm ${SEVERITY_STYLES[w.severity]}`}
-            >
-              <strong className="mr-2">{w.id}</strong>
+            <div key={w.id} className={`border px-3 py-2 text-sm ${SEVERITY_STYLES[w.severity]}`}>
+              <strong className="mr-2 font-mono text-xs uppercase tracking-wide">{w.id}</strong>
               {t(w.message.key, w.message.values ?? {})}
             </div>
           ))}
@@ -106,7 +106,9 @@ export function ReviewSection({ values, onEdit, onSubmit }: ReviewSectionProps) 
 
       {SECTIONS.map((section) => {
         const grouped = groupVisibleItems(section.items);
-        type Block = { kind: 'rows'; rows: ReturnType<typeof rowsForItem> } | { kind: 'matrix'; group: MatrixGroup };
+        type Block =
+          | { kind: 'rows'; rows: ReturnType<typeof rowsForItem> }
+          | { kind: 'matrix'; group: MatrixGroup };
         const blocks: Block[] = [];
         for (const entry of grouped) {
           if (isMatrixGroup(entry)) {
@@ -132,34 +134,29 @@ export function ReviewSection({ values, onEdit, onSubmit }: ReviewSectionProps) 
                 {t('review.edit')}
               </Button>
             </header>
-            <div className="divide-y divide-slate-200 rounded border border-slate-200">
+            <div className="divide-y divide-border border border-border">
               {blocks.map((block, blockIdx) =>
                 block.kind === 'matrix' ? (
-                  <div
-                    key={`matrix-${block.group.items[0].id}`}
-                    className="px-3 py-2"
-                  >
+                  <div key={`matrix-${block.group.items[0].id}`} className="px-3 py-2">
                     <table className="w-full text-sm">
                       <tbody>
                         {block.group.items.map((it) => (
                           <tr key={it.id}>
-                            <td className="py-1 pr-2 text-slate-700">
+                            <td className="py-1 pr-2 text-muted-foreground">
                               {it.id} {localized(it.label, locale)}
                             </td>
-                            <td className="py-1 text-slate-900">
-                              {formatValue(values[it.id])}
-                            </td>
+                            <td className="py-1 text-foreground">{formatValue(values[it.id])}</td>
                           </tr>
                         ))}
                       </tbody>
                     </table>
                   </div>
                 ) : (
-                  <dl key={`rows-${blockIdx}`} className="divide-y divide-slate-200">
+                  <dl key={`rows-${blockIdx}`} className="divide-y divide-border">
                     {block.rows.map((r) => (
                       <div key={r.key} className="grid grid-cols-3 gap-3 px-3 py-2 text-sm">
-                        <dt className="col-span-2 text-slate-700">{r.label}</dt>
-                        <dd className="text-slate-900">{r.value}</dd>
+                        <dt className="col-span-2 text-muted-foreground">{r.label}</dt>
+                        <dd className="text-foreground">{r.value}</dd>
                       </div>
                     ))}
                   </dl>

--- a/deliverables/F2/PWA/app/src/components/sync/SyncPage.tsx
+++ b/deliverables/F2/PWA/app/src/components/sync/SyncPage.tsx
@@ -58,7 +58,7 @@ export function SyncPage({ runSync }: SyncPageProps) {
   if (rows.length === 0) {
     return (
       <section className="mx-auto flex max-w-xl flex-col gap-4 p-6">
-        <h2 className="text-2xl font-semibold">{t('sync.heading')}</h2>
+        <h2 className="font-serif text-2xl font-medium tracking-tight">{t('sync.heading')}</h2>
         <p className="text-sm text-muted-foreground">{t('sync.none')}</p>
         <SyncButton runSync={runSync} />
         <ChangeEnrollmentButton />
@@ -72,7 +72,7 @@ export function SyncPage({ runSync }: SyncPageProps) {
 
   return (
     <section className="mx-auto flex max-w-xl flex-col gap-4 p-6">
-      <h2 className="text-2xl font-semibold">{t('sync.heading')}</h2>
+      <h2 className="font-serif text-2xl font-medium tracking-tight">{t('sync.heading')}</h2>
       <SyncButton runSync={runSync} />
       <ChangeEnrollmentButton />
       {STATUS_ORDER.map((s) => {


### PR DESCRIPTION
## Summary

PR **3 of 3** from the DESIGN.md migration plan. Lands the structural moves [DESIGN.md](./deliverables/F2/PWA/app/DESIGN.md) calls out: **marginal mono question numbers**, **typographic ledger progress**, **kill-the-card refactor**, and the editorial typefaces (Newsreader + JetBrains Mono) finally showing up on screen.

After this lands, F2 PWA's visual identity matches DESIGN.md end-to-end. The memorable-thing anchor — *"This is real software, not a government form"* — should now be visible in pixels.

## Changes

| File | What |
|---|---|
| `src/components/survey/ProgressBar.tsx` | Graphical bar replaced with **typographic ledger** (`04  ━━━━━━━╴╴╴╴╴╴╴╴  35`) in JetBrains Mono. `--primary` for filled, `--muted` at `opacity-45` for unfilled. `aria-valuenow` + `role='progressbar'` preserved for screen readers. Counters zero-padded to total's width. |
| `src/components/survey/Question.tsx` | `sm+` grid layout with 80px gutter for the JetBrains Mono **question id in the margin**; mobile stacks above. Prompt bumped to `text-base font-medium`. Required asterisk + error text → `text-destructive`. Inputs use `rounded-md` (= 2px via `--radius`) not `rounded` (= fixed 4px). |
| `src/components/enrollment/EnrollmentScreen.tsx` | **Kill-the-card:** `rounded-md border border-border p-4` → hairline `border-t` + whitespace. Step headings rendered as **JetBrains Mono uppercase eyebrows** ("STEP 1: TABLET TOKEN"). Raw colors → tokens. h2 in Newsreader. |
| `src/components/survey/ReviewSection.tsx` | Warning rows: full background tint → **hairline-bordered + colored left-border (`border-l-4`)** alert pattern. `divide-slate-*` → `divide-border`. Warning id in JetBrains Mono uppercase. h2 in Newsreader. |
| `src/components/survey/MatrixQuestion.tsx` | `text-red-600` → `text-destructive` (4 occurrences). |
| `src/components/survey/Navigator.tsx` | `text-green-600` → `text-primary`. |
| `src/components/survey/MultiSectionForm.tsx` | `text-green-600` → `text-primary`; section title h2 in Newsreader. |
| `src/components/sync/SyncPage.tsx` | h2 in Newsreader (both states). |
| `src/App.tsx` | Main app title h1 + thank-you h2 + submit-failed h2 in Newsreader; version subtitle in JetBrains Mono. `text-red-700` → `text-destructive`. |

## Validation

- ✅ `npm run typecheck` clean
- ✅ `npm run lint` 0 errors (6 pre-existing warnings unchanged)
- ✅ `npm run format:check` clean on edited files
- ✅ `npm run test` 308/308 passing (existing tests + 1 new test for the ledger zero-padding behavior)
- ✅ Visual smoke: `document.fonts` API confirms **Newsreader/500, Public Sans/400+500, JetBrains Mono/400 all loaded**; h1/h2 resolve to `Newsreader, Georgia, "Times New Roman", serif`. Live app shows the editorial-serif headlines, mono eyebrows, killed cards, and ledger progress.

## Out of scope (deferred follow-ups)

These are tracked under `E3-F2-PWA-DESIGN-*` in `scrum/epics/epic-03-capi-application.md` or as new items below:

- **`PendingCount.tsx` / `BroadcastBanner.tsx` / `SectionTree.tsx`** still use raw amber/green/red Tailwind colors. Needs a `--warning` Tailwind binding before clean migration. (Add as `E3-F2-PWA-DESIGN-006`.)
- **ReviewSection `warn` severity** keeps `amber-600` for the same reason — TODO comment in the file points at the binding work.
- **`SpecDriftOverlay` / `KillSwitchOverlay`** overlay modals untouched. They ARE modals, not "cards" the spec targets — separate polish PR if shadows ever feel off-spec.
- **`Button.tsx` shadcn primitive** untouched. It's foundational; refactoring its `shadow-sm` and `rounded-md` defaults is a separate PR if visual review wants tighter restraint.
- **Self-host fonts** (`E3-F2-PWA-DESIGN-004`) still gated on `pyftsubset` tooling.
- **Refine Verde hex from official DOH brand-book PDF** (`E3-F2-PWA-DESIGN-005`) still `blocked-external`.

## Test plan

- [ ] Pull, `npm run dev`, verify on `localhost:5173`:
  - h1 + h2 are Newsreader serif
  - Version subtitle is JetBrains Mono
  - "STEP 1: TABLET TOKEN" eyebrow is JetBrains Mono uppercase
  - No `border-radius`-with-shadow card around the Step 1 form (hairline only)
- [ ] Enroll with a valid token, navigate into a section. Verify:
  - Question IDs hang in left gutter on desktop, stack above on mobile
  - Required asterisk is rust/cherry, not generic red
  - Progress reads `04  ━━━━━━━╴╴╴╴╴╴╴╴  35` style
- [ ] Submit and trip a cross-field warning. Verify alert is left-bordered, not full-fill.
- [ ] Toggle DevTools → Application → Service Workers → Offline; reload. Fonts should still load from cache.
- [ ] Resize to mobile (375px). Verify Question gutter collapses to stacked layout.

## Closes the migration

After this lands, the Verde Manual visual-identity migration is complete end-to-end. Round 3 (v1.2.0) UX enhancements (#16/#17/#18) can ship in their own focused PRs against the new visual baseline.