### PR TITLE
feat(F2 PWA): polish PR3 punts — flatten buttons, simplify modal chrome

### DIFF
--- a/deliverables/F2/PWA/app/src/components/chrome/KillSwitchOverlay.tsx
+++ b/deliverables/F2/PWA/app/src/components/chrome/KillSwitchOverlay.tsx
@@ -14,8 +14,8 @@ export function KillSwitchOverlay({ active }: Props) {
       aria-describedby="kill-switch-body"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6"
     >
-      <div className="max-w-md rounded bg-white p-6 shadow-lg">
-        <h2 id="kill-switch-title" className="mb-2 text-lg font-semibold">
+      <div className="max-w-md rounded-md border border-border bg-background p-6">
+        <h2 id="kill-switch-title" className="mb-2 font-serif text-lg font-medium tracking-tight">
           {t('chrome.killSwitchTitle')}
         </h2>
         <p id="kill-switch-body" className="text-sm text-muted-foreground">

--- a/deliverables/F2/PWA/app/src/components/chrome/SpecDriftOverlay.tsx
+++ b/deliverables/F2/PWA/app/src/components/chrome/SpecDriftOverlay.tsx
@@ -25,8 +25,8 @@ export function SpecDriftOverlay({ drift, localVersion, serverMin }: Props) {
       aria-describedby="spec-drift-body"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6"
     >
-      <div className="max-w-md rounded bg-white p-6 shadow-lg">
-        <h2 id="spec-drift-title" className="mb-2 text-lg font-semibold">
+      <div className="max-w-md rounded-md border border-border bg-background p-6">
+        <h2 id="spec-drift-title" className="mb-2 font-serif text-lg font-medium tracking-tight">
           {t('chrome.specDriftTitle')}
         </h2>
         <p id="spec-drift-body" className="mb-4 text-sm text-muted-foreground">

--- a/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
@@ -330,7 +330,7 @@ export function MultiSectionForm({
         aria-label="Previous section"
         onClick={handlePrev}
         className={cn(
-          'fixed top-1/2 left-1 z-30 -translate-y-1/2 rounded-full border bg-background/90 p-2 shadow-md transition-colors hover:bg-muted lg:left-[232px]',
+          'fixed top-1/2 left-1 z-30 -translate-y-1/2 rounded-full border border-border bg-background/90 p-2 shadow-sm transition-colors hover:bg-muted lg:left-[232px]',
           isFirst && 'invisible',
         )}
       >
@@ -353,7 +353,7 @@ export function MultiSectionForm({
         aria-label="Next section"
         onClick={handleNext}
         className={cn(
-          'fixed top-1/2 right-1 z-30 -translate-y-1/2 rounded-full border p-2 shadow-md transition-colors',
+          'fixed top-1/2 right-1 z-30 -translate-y-1/2 rounded-full border border-border p-2 shadow-sm transition-colors',
           isLastSection
             ? 'bg-primary text-primary-foreground hover:bg-primary/90'
             : 'bg-background/90 hover:bg-muted',

--- a/deliverables/F2/PWA/app/src/components/ui/button.tsx
+++ b/deliverables/F2/PWA/app/src/components/ui/button.tsx
@@ -2,16 +2,17 @@ import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
+// Verde Manual: buttons are flat. Solid color (primary, destructive) carries
+// prominence; outline uses the hairline border. No shadows on chrome — see DESIGN.md.
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none disabled:hover:bg-muted',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground disabled:hover:bg-muted',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
-        outline:
-          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
       },


### PR DESCRIPTION
## Summary

Tightens the chrome corners that PR #39 deferred. No new components, no new tokens — just removes off-spec elevation and tokenises the modals.

(Heads-up: the commit subject has a typo — "retreive" instead of "remove". Squash-merging this PR will use the PR title above instead, so the squashed commit on staging stays clean.)

### `Button.tsx` shadcn primitive — flat buttons

| Variant | Before | After |
|---|---|---|
| default | `bg-primary ... shadow hover:bg-primary/90` | `bg-primary ... hover:bg-primary/90` |
| destructive | `bg-destructive ... shadow-sm hover:bg-destructive/90` | `bg-destructive ... hover:bg-destructive/90` |
| outline | `border border-input bg-background shadow-sm ...` | `border border-input bg-background ...` |
| secondary | `bg-secondary ... shadow-sm hover:bg-secondary/80` | `bg-secondary ... hover:bg-secondary/80` |

Verde Manual is flat-button discipline: solid-color variants carry prominence via the fill, outline carries it via the hairline border. The `shadow-sm` was carryover from generic shadcn. Also dropped `disabled:shadow-none` (redundant now). Added a one-line comment in the file documenting the rule for future-Carl.

### `SpecDriftOverlay` + `KillSwitchOverlay` — modals

| Aspect | Before | After |
|---|---|---|
| Background | `bg-white` | `bg-background` (token, works in dark mode for free) |
| Elevation | `shadow-lg` | hairline `border border-border` (the `bg-black/50` scrim provides separation) |
| Radius | `rounded` (Tailwind hardcoded 0.25rem) | `rounded-md` (consumes `--radius` = 4px max) |
| Title | `text-lg font-semibold` | `font-serif text-lg font-medium tracking-tight` (Newsreader, matches rest of app chrome) |

A Verde Manual modal is just a paper rectangle with a hairline edge — no faux elevation needed against a dark scrim.

### `MultiSectionForm` fixed-side nav arrows — softer

`shadow-md` → `shadow-sm`. These ARE genuinely floating UI chrome on top of scrolling content (prev/next buttons fixed to viewport edges), so they need *some* elevation to read. `shadow-sm` is the lighter cue that fits Verde restraint. Also added explicit `border-border` (was just `border`) for token consistency.

## Validation

- ✅ `npm run typecheck` clean
- ✅ `npm run lint` 0 errors (6 pre-existing warnings unchanged)
- ✅ `npm run format:check` clean on edited files
- ✅ `npm run test` 308/308 passing
- ✅ `npm run build` succeeds — no broken Tailwind classes
- ✅ Visual smoke on dev server: Enroll screen renders identically (the only Button on that screen is the disabled Verify button which uses `disabled:bg-muted` regardless of variant shadow). Modal + active button + nav arrow visual changes only manifest on conditional states — they were verified at the Tailwind class level via `npm run build`.

## Test plan

- [ ] Pull, `npm run dev`, complete enroll. Verify the active "Verify token" button + Enroll button + Submit button all sit flat against the Verde paper, no faux elevation.
- [ ] Trigger the kill switch (set `kill_switch: true` in `F2_Config`). Verify the modal is a clean paper rectangle with a hairline edge against the dark scrim — no `shadow-lg` halo.
- [ ] Bump `min_accepted_spec_version` to force a spec drift. Verify `SpecDriftOverlay` renders with the same flat treatment.
- [ ] On a section view (≥ 2 sections), look at the fixed-side prev/next arrows. They should still be visible against scrolling content but with a softer `shadow-sm` instead of `shadow-md`.

## Closes the design lane

After this lands, the design migration is genuinely "really finished" — all Verde Manual deferrals from #37/#38/#39/#40 are now closed. Sprint 003 starts tomorrow with F1 sign-off as the priority; design lane goes dark.