### PR TITLE
feat(F2 PWA): port Verde Manual visual-identity to prod track (path B)

### DIFF
--- a/deliverables/F2/PWA/app/CLAUDE.md
+++ b/deliverables/F2/PWA/app/CLAUDE.md
@@ -11,6 +11,17 @@ work — those live in `deliverables/{F1,F3,F4}/` and follow the CSPro generator
 workflow, not the PWA git/PR flow. `/ship` for this app must NOT bump version
 or write CHANGELOG (the release-notes workflow owns those).
 
+## Design System
+
+Always read [`DESIGN.md`](./DESIGN.md) before making any visual, UI, color, type,
+spacing, or motion decision in this app. Memorable thing anchor:
+**"This is real software, not a government form."** Palette: Verde Manual
+(DOH-anchored emerald + pale verde paper). Type: Newsreader display + Public Sans
+Variable body + JetBrains Mono data. Layout: hairline-divided, no cards,
+marginal mono question numbers. Do not deviate without explicit user approval and
+without adding a row to the Decisions Log in `DESIGN.md`. In QA mode, flag any code
+that doesn't match.
+
 ## Skill routing
 
 When the user's request matches an available skill, invoke it via the Skill tool. The

--- a/deliverables/F2/PWA/app/CLAUDE.md
+++ b/deliverables/F2/PWA/app/CLAUDE.md
@@ -1,0 +1,53 @@
+# F2 PWA — App-level Claude instructions
+
+This CLAUDE.md is scoped to the F2 PWA app workstream only. The vault-level
+(`analytiflow/CLAUDE.md`) and LLM Wiki schema (`ASPSI-DOH-CAPI-CSPro-Development/CLAUDE.md`)
+still apply higher up the tree. Anything below this directory follows these rules
+in addition to the parents.
+
+**gstack scope:** gstack is adopted for the F2 PWA workstream only. Never use
+gstack skills (especially `/ship`, `/qa`, `/review`) on F1, F3, or F4 CSPro
+work — those live in `deliverables/{F1,F3,F4}/` and follow the CSPro generator
+workflow, not the PWA git/PR flow. `/ship` for this app must NOT bump version
+or write CHANGELOG (the release-notes workflow owns those).
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. The
+skill has multi-step workflows, checklists, and quality gates that produce better
+results than an ad-hoc answer. When in doubt, invoke the skill. A false positive is
+cheaper than a false negative.
+
+Key routing rules:
+- Product ideas, "is this worth building", brainstorming → invoke /office-hours
+- Strategy, scope, "think bigger", "what should we build" → invoke /plan-ceo-review
+- Architecture, "does this design make sense" → invoke /plan-eng-review
+- Design system, brand, "how should this look" → invoke /design-consultation
+- Design review of a plan → invoke /plan-design-review
+- Developer experience of a plan → invoke /plan-devex-review
+- "Review everything", full review pipeline → invoke /autoplan
+- Bugs, errors, "why is this broken", "wtf", "this doesn't work" → invoke /investigate
+- Test the site, find bugs, "does this work" → invoke /qa (or /qa-only for report only)
+- Code review, check the diff, "look at my changes" → invoke /review
+- Visual polish, design audit, "this looks off" → invoke /design-review
+- Developer experience audit, try onboarding → invoke /devex-review
+- Ship, deploy, create a PR, "send it" → invoke /ship
+- Merge + deploy + verify → invoke /land-and-deploy
+- Configure deployment → invoke /setup-deploy
+- Post-deploy monitoring → invoke /canary
+- Update docs after shipping → invoke /document-release
+- Weekly retro, "how'd we do" → invoke /retro
+- Second opinion, codex review → invoke /codex
+- Safety mode, careful mode, lock it down → invoke /careful or /guard
+- Restrict edits to a directory → invoke /freeze or /unfreeze
+- Upgrade gstack → invoke /gstack-upgrade
+- Save progress, "save my work" → invoke /context-save
+- Resume, restore, "where was I" → invoke /context-restore
+- Security audit, OWASP, "is this secure" → invoke /cso
+- Make a PDF, document, publication → invoke /make-pdf
+- Launch real browser for QA → invoke /open-gstack-browser
+- Import cookies for authenticated testing → invoke /setup-browser-cookies
+- Performance regression, page speed, benchmarks → invoke /benchmark
+- Review what gstack has learned → invoke /learn
+- Tune question sensitivity → invoke /plan-tune
+- Code quality dashboard → invoke /health

--- a/deliverables/F2/PWA/app/DESIGN.md
+++ b/deliverables/F2/PWA/app/DESIGN.md
@@ -1,0 +1,291 @@
+# Design System — F2 PWA
+
+> **This file is the visual source of truth for the F2 PWA.**
+> Read it before making any UI, color, type, spacing, or motion decision.
+> Do not deviate without explicit approval. In QA, flag any code that doesn't match.
+
+---
+
+## Memorable Thing
+
+> **"This is real software, not a government form."**
+
+Every type, color, spacing, and motion decision in this system serves that anchor.
+Restraint compounds. Hairlines, pale verde paper, and one DOH emerald signal carry
+the trust HCWs need to install government software on their personal phones.
+
+---
+
+## Product Context
+
+- **What this is:** Offline-capable Progressive Web App for the F2 (Healthcare Worker Survey) instrument under the ASPSI → DOH UHC Act monitoring contract. Self-administered. 124 items, 35+ sections, 30 minutes to several hours to fill.
+- **Who it's for:** Filipino healthcare workers (HCWs) using their own phones, tablets, or laptops. Bilingual: English + Filipino (Tagalog).
+- **Space/industry:** Government health monitoring. Plan B to CSPro/CSEntry (Plan A) within the F2 track; PWA is the long-term F2 capture target per the 2026-04-21 track positioning.
+- **Project type:** Single-purpose web app (form-heavy). Not a dashboard, not a marketing site, not a general survey platform.
+
+---
+
+## Aesthetic Direction
+
+- **Direction:** **Verde Manual** — clinical stationery and utility, anchored on the Philippine DOH "Verde Vision / Berde para sa bayan" institutional palette.
+- **Decoration level:** Minimal. Typography does the work. No drop shadows. No decorative SVGs. No glassmorphism.
+- **Mood:** Quiet confidence. Print-influenced composition (hairlines, baseline grid, marginal numbering) translated to PWA. Tactile but not twee. Field manual, not SaaS dashboard.
+- **Reference sites:** [gov.uk](https://www.gov.uk) (single-blue institutional restraint), [Linear](https://linear.app) (modern indie polish via restraint), DOH Philippines visual identity (Verde Vision palette).
+
+---
+
+## Color — Verde Manual
+
+**Approach:** Restrained. One signal color. Warm-cool neutrals (verde-tinted) that read distinct from generic gov-tech white.
+
+> **Caveat:** Hex values below are best-fit approximations of the visible DOH seal +
+> the documented Verde Vision background tint `#e7efe7`. Refine when the official
+> DOH brand-book PDF is available (Department Order 2020-0011, Verde Vision 2023+).
+
+### Light mode (default)
+
+| Token | Hex | Role |
+|---|---|---|
+| `--paper` | `#F2F5EE` | Background. Pale verde-tinted off-white. References DOH `#e7efe7`, slightly warmer for screen comfort. |
+| `--ink` | `#1A1F1A` | Primary text. Warm near-black with subtle green undertone. ~14:1 contrast on paper, exceeds WCAG AAA. |
+| `--hairline` | `#B5C0A9` | Rule color. Section dividers, input borders. Verde-tinted to harmonize. |
+| `--muted` | `#5A655A` | Secondary text, helpers, eyebrows. Warm gray-green. |
+| `--signal` | `#006B3F` | DOH emerald. Primary CTAs, current-question marker, active progress, selected radio rings. The recognizable institutional handshake. |
+| `--signal-bg` | `#006B3F1A` | 10% alpha tint. Used only as the current-question background fade. |
+| `--highlight` | `#E5B23B` | DOH yellow inner-rim color. Used **very sparingly** — only for "saved" toasts and similar punctuation moments. Never as fill or surface. |
+| `--success` | `#006B3F` | Same as signal — green is intrinsically "OK" in DOH context, no separate success color. |
+| `--warning` | `#C68A2E` | Ochre. Storage-quota warnings, near-stale draft notices. |
+| `--error` | `#B72020` | Cherry red. References the cross at the center of the DOH seal. Used only on validation errors and submission rejections. |
+
+### Dark mode
+
+| Token | Hex | Role |
+|---|---|---|
+| `--paper` | `#0F1410` | Background. Warm graphite, never pure black. |
+| `--ink` | `#DCE3D5` | Primary text. Warm off-white with subtle green undertone. |
+| `--hairline` | `#2A3328` | Rule color. |
+| `--muted` | `#828C82` | Secondary text. |
+| `--signal` | `#2A9166` | Emerald shifted brighter for retina balance on dark ground. |
+| `--signal-bg` | `#2A91661F` | 12% alpha tint. |
+| `--highlight` | `#F1C95C` | DOH yellow shifted brighter. |
+| `--error` | `#D6504C` | Cherry shifted brighter. |
+
+### Color usage rules
+
+1. The signal color (`--signal`) is the only place emerald appears. Never as background fill, never as text in body copy, only as: CTA buttons, current-question marker (gutter number + 10%-alpha row tint), active progress fill, selected radio/checkbox dot ring, focus ring on inputs.
+2. The highlight color (`--highlight`) is reserved for save-confirmation toasts and the section-saved badge. Never use it for CTAs, links, or primary text.
+3. Error color (`--error`) is reserved for validation errors and submission rejections. Never for warnings, never for emphasis.
+4. No raw Tailwind color classes in app code (`text-red-500`, `bg-blue-100`, etc.). Always go through the CSS variable tokens.
+
+---
+
+## Typography
+
+**All three fonts are free + open source. Loaded via local `/public/fonts/*.woff2` and precached by the service worker.** First-install bundle adds ~120 kB; zero runtime cost after install.
+
+### Faces
+
+| Role | Font | License | Why |
+|---|---|---|---|
+| **Display** | **Newsreader** by Production Type | OFL | Contemporary serif with clean terminals. Reads as edited document, not browser default. Carries Filipino diacritics (`ñ`, `ng`) cleanly. Variable axes for fine weight control. |
+| **Body** | **Public Sans Variable** by US Web Design System | OFL | Designed specifically for government-form accessibility. Excellent x-height. Full Latin Extended for Filipino. Tabular-nums built in. Variable. |
+| **Mono / Data** | **JetBrains Mono** | Apache 2.0 | Question numbers in margin, IDs, timestamps, sync counters, version tags. Genuine monospaced figures. |
+| **Fallback (system)** | `Georgia, "Times New Roman", serif` for display; `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif` for body; `"SF Mono", Menlo, Consolas, monospace` for mono | — | Only seen during initial load before woff2 hydrates. |
+
+### Type scale (modular 1.250 ratio, 16px base)
+
+| Token | Size / Line | Use |
+|---|---|---|
+| `text-xs` | 12 / 18 | Helper text, mono labels, badges |
+| `text-sm` | 14 / 21 | Form labels, secondary copy |
+| `text-base` | 16 / 25 | Body, question prompts (default) |
+| `text-lg` | 18 / 27 | Question prompts at desktop, emphasized body |
+| `text-xl` | 20 / 28 | Subsection headers |
+| `text-2xl` | 24 / 32 | h2, dialog titles |
+| `text-3xl` | 28 / 36 | Mobile section titles |
+| `text-4xl` | 36 / 42 | Desktop section titles (Newsreader 500) |
+| `text-5xl` | 48 / 54 | Splash / first-launch hero (Newsreader 500) |
+
+### Type rules
+
+1. Display sizes (`text-3xl` and above) always use Newsreader, weight 500 (medium) by default, 600 only for splash heroes.
+2. Body sizes use Public Sans, weight 400 default, 500 for question prompts, 600 for active section indicators.
+3. Mono is used in: (a) the marginal question number gutter at `text-2xl`, (b) all timestamps and IDs at `text-xs`, (c) the typographic ledger progress at `text-sm`. Never for body copy, never for prompts.
+4. Letter-spacing: `tracking-tight` (-0.015em) on display sizes, default on body, `tracking-wide` (0.04em) on uppercase mono labels.
+5. Line height: 1.55 for body, 1.45 for question prompts, 1.15 for display.
+6. **Verbatim labels.** Per project convention (`feedback_verbatim_questionnaire_labels`): never paraphrase question text. Use the exact wording from the spec, including original question numbers — even when the rendered design diverges (e.g., the marginal `047` is rendered, but the prompt text is verbatim from `F2-Spec.md`).
+
+---
+
+## Spacing
+
+- **Base unit:** 4px
+- **Density:** Comfortable. Form-heavy app means HCWs read for hours; compact density causes fatigue.
+- **Scale:** `2 / 4 / 8 / 12 / 16 / 24 / 32 / 48 / 64 / 96`
+
+### Spacing rules
+
+| Where | Value |
+|---|---|
+| Form field vertical rhythm | 12px between label and input, 8px between input and helper, 24px between fields |
+| Question vertical breathing | 32px between questions |
+| Section breaks | 48px above section opener, 24px between section title and first question |
+| Header padding | 16px vertical, 32px horizontal (desktop) / 12px vertical, 20px horizontal (mobile) |
+| Section opener top margin | 56px (desktop) / 32px (mobile) |
+| Margin gutter for question numbers | 88px (desktop/tablet, holds the JetBrains Mono `047` left of question text), 0 mobile (number stacks above) |
+| Page max content width | 720px (the question column) |
+| Frame max width | 1280px (centered with hairline borders left/right) |
+
+---
+
+## Layout
+
+- **Approach:** Grid-disciplined, hairline-divided, asymmetric.
+- **First viewport:** Reads as a poster (oversized Newsreader headline, signal-color question-count badge, single CTA, ample paper). Not a document.
+- **Inside survey:** Strict 4pt baseline grid. Question text left-weighted in a 720px column. Question number hangs in an 88px left gutter on tablet/desktop, stacks above on phone.
+- **Grid columns:** 1 column on mobile (≤640px), 2 columns on tablet (gutter + content), 3 columns on desktop (gutter + content + free space).
+- **Max content width:** 720px (question column). 1280px (frame).
+- **Border radius scale:** `0` (cards — but we don't use cards), `2px` (default — buttons, inputs, pills), `4px` (max — used only for the Likert outer container and yes/no toggles). No `rounded-lg`, no `rounded-2xl`, no `rounded-full` except for radio dots.
+
+### Layout rules
+
+1. **No cards.** Sections separated by 1px `--hairline` rules and whitespace only. No `bg-white rounded-lg shadow` patterns anywhere in the app. This is the single biggest move that drops the gov-SaaS smell.
+2. **Hairlines are 1px solid `--hairline`.** Never thicker. Never dashed except in preview meta-bars.
+3. **Question numbers** in JetBrains Mono live in the left margin gutter (`text-2xl` weight 500, color `--muted` for non-current questions, `--signal` for current). On mobile they stack above the prompt at `text-base`.
+4. **Progress** is rendered as a typographic ledger (`047 ━━━━━━━━━━━━━╴╴╴╴╴ 124`) in JetBrains Mono, not a graphical progress bar. The filled portion uses `--signal`, the unfilled portion uses 45% opacity `--muted`.
+5. Asymmetric: question text left-aligned, response affordances inline-block right-flowing on tablet/desktop, stacked on phone.
+
+---
+
+## Motion
+
+- **Approach:** Minimal-functional. No entrance animations on form fields — distracting during 3-hour fills. Motion only at state transitions.
+- **Easing:**
+  - `enter`: `cubic-bezier(0.16, 1, 0.3, 1)` (gentle ease-out)
+  - `exit`: `cubic-bezier(0.4, 0, 1, 1)` (ease-in)
+  - `move`: `ease-in-out`
+- **Duration:**
+  - `micro` 80ms — save-confirm pulse on the question-number gutter (single flash, then back to neutral)
+  - `short` 150ms — input focus rings, button press, hover transitions
+  - `medium` 250ms — view transitions (form ↔ review ↔ sync), palette/theme switches
+  - `long` — not used
+
+### Motion rules
+
+1. Form fields never animate on entrance. Once they're rendered, they're rendered.
+2. The save-confirmation pulse is the only place `--signal` animates. 80ms flash on the question-number text, no other surface lights up.
+3. View transitions use `opacity` + 8px `translateY`, never scale or rotate.
+4. Respect `prefers-reduced-motion: reduce` — disable all transitions when the user has it set. Auto-fade still allowed but no `translate`.
+
+---
+
+## Components
+
+This section grows as components are built. For every domain component:
+- Document the component's role
+- Specify the spacing rhythm in/around it
+- List the color tokens used
+- Note any deviation from the rules above (and why)
+
+### `<Question>` (current)
+- Role: renders one F2 item, dispatches by type (text, number, radio, multi-select, matrix, date)
+- Layout: 88px gutter (desktop) holds the JetBrains Mono `047` number; 720px max-width content column with prompt + helper + response affordance
+- Vertical breathing: 32px before, 32px after, hairline between
+- Current-question style: background `--signal-bg` (10% alpha emerald), gutter number switches to `--signal`
+- Required indicator: `*` in `--signal`, immediately after the prompt text
+
+### `<Likert>`
+- 5 options in a horizontal `border` `rounded-2px` `divide-x` row (desktop), stacks vertical on mobile
+- Each option: 1.5px ring radio dot in `--muted`, switching to filled `--signal` (with paper-color inner ring) when selected
+- Selected option's row gets `--signal-bg` background tint
+- Hover: same `--signal-bg` tint, dot color stays muted
+
+### `<YesNo>`
+- 2 options, inline-flex, hairline border, `rounded-2px`
+- Selected: `--signal` solid background, `--paper` text
+- Unselected: transparent, `--ink` text, hairline-bordered
+
+### `<Navigator>`
+- Bottom-fixed bar at the survey level; hairline border-top
+- Left: ghost `← Previous` button
+- Center: typographic ledger progress in JetBrains Mono
+- Right: solid `--signal` `Next →` button (default state) or ghost `Submit responses` (last question)
+
+### `<SyncBadge>` / `<PendingCount>`
+- Header pill, JetBrains Mono `text-xs`
+- Format: `{count} pending` where `{count}` is `--signal` and "pending" is `--muted`
+
+### `<LanguageSwitcher>`
+- Inline-flex pill, hairline-bordered, `rounded-2px`
+- Active language: `--ink` background, `--paper` text
+- Inactive language: transparent, `--muted` text
+
+---
+
+## Accessibility
+
+1. **Contrast:** All text-on-paper combos exceed WCAG AAA (`--ink` on `--paper` ≈ 14:1; `--muted` on `--paper` ≈ 4.6:1, AA at minimum).
+2. **Focus:** Every interactive element gets a 2px `--signal` outline at 2px offset on `:focus-visible`. Never remove focus rings.
+3. **Touch targets:** Minimum 44×44px hit area on all interactive elements. The Likert dots are 16px visually but the click target spans the full option cell (typically 80×60px at desktop).
+4. **`prefers-reduced-motion`:** Disable all transitions and animations.
+5. **`prefers-color-scheme`:** Respected on first paint. User can override via the in-app dark-mode toggle (M11 hardening).
+6. **Screen readers:** All form fields have associated `<label>`. Required fields announce "required" via `aria-required`. The marginal `047` number is `aria-hidden="true"` so screen readers don't read "Question zero four seven" twice — use a `<span class="sr-only">Question 47</span>` inline with the prompt.
+7. **Filipino + English diacritics:** Public Sans Variable carries full Latin Extended. Test on real devices for `ñ`, `ng`, and the stylized `ng̃` combining-tilde before each release.
+
+---
+
+## Implementation Notes
+
+These are forward-looking notes for the PRs that will land this design system in code. Currently the app uses shadcn defaults + a teal primary; the migration to Verde Manual will land in 2-3 PRs.
+
+### PR plan (suggested)
+
+1. **PR 1 — Tokens.** Replace `:root` HSL variables in `src/index.css` with the Verde Manual hex tokens. Update `tailwind.config.ts` if needed (current config maps Tailwind classes to CSS vars, so most changes ride through automatically). Update `public/manifest.webmanifest` `theme_color` from `#0f766e` (teal) to `#006B3F` (DOH emerald).
+2. **PR 2 — Typography.** Add `public/fonts/{newsreader, public-sans, jetbrains-mono}.woff2` (subset to Latin Extended). Reference in `index.css` `@font-face` rules. Precache via vite-plugin-pwa workbox config. Add `font-family` declarations to body + Tailwind theme extend.
+3. **PR 3 — Layout & components.** Refactor `<Question>` to add the 88px gutter + marginal mono number. Replace any `border rounded-lg shadow` patterns with hairline rules. Update `<MultiSectionForm>` section dividers to hairlines + whitespace. Update `<Navigator>` to typographic-ledger progress.
+
+Each PR is small enough to review in 10 minutes and ship under `/ship` (which does NOT bump version per `project_gstack_adoption`).
+
+### Don't deviate without
+
+1. Updating this file with the new decision and adding a row to the Decisions Log below.
+2. Confirming the change doesn't break the Memorable Thing anchor: "real software, not a government form."
+3. Running through the Anti-Slop checklist (next section).
+
+---
+
+## Anti-Slop Checklist
+
+If you're about to commit a UI change, verify:
+
+- [ ] No purple, violet, or generic SaaS-blue gradients
+- [ ] No 3-column SaaS feature grid with circle-bg icons
+- [ ] No centered-everything layout (use the asymmetric grid)
+- [ ] No `rounded-2xl` or `rounded-full` (except radio dots)
+- [ ] No `bg-white shadow-md rounded-lg` "card" patterns
+- [ ] No gradient buttons (signal is flat, full stop)
+- [ ] No emoji in UI chrome (emoji is fine in user-generated content)
+- [ ] No system-ui or `-apple-system` as the *primary* display or body font (only as fallback while woff2 loads)
+- [ ] No "Get Started" / "Built for X" / "Designed for Y" copy patterns
+- [ ] No Lottie or decorative SVG blobs
+- [ ] No glassmorphism, no backdrop-blur on chrome surfaces
+- [ ] CTA reads "Begin Section 1" / "Next →" / "Submit responses" — concrete, not generic
+
+---
+
+## Decisions Log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-04-26 | Initial design system created | Created by `/gstack-design-consultation`. Memorable thing: "real software, not a government form." Verde Manual chosen over Field Manual to ladder up to DOH institutional brand without losing craft. Hex values approximated from visible DOH seal + Verde Vision documented background; refine when official brand-book PDF is available. |
+
+---
+
+## References
+
+- `../2026-04-17-design-spec.md` — F2 PWA architecture (this file is the visual layer)
+- `../2026-04-21-implementation-plan.md` — milestone roadmap M0–M11
+- DOH Philippines visual identity: Department Order 2020-0011, Verde Vision 2023+ (PDFs paywalled on Scribd; refine when available)
+- gov.uk design system — institutional restraint reference: <https://design-system.service.gov.uk/>
+- US Web Design System (Public Sans origin): <https://designsystem.digital.gov/>
+- Bunny Fonts (CDN for development): <https://fonts.bunny.net/>

--- a/deliverables/F2/PWA/app/DESIGN.md
+++ b/deliverables/F2/PWA/app/DESIGN.md
@@ -44,31 +44,31 @@ the trust HCWs need to install government software on their personal phones.
 
 ### Light mode (default)
 
-| Token | Hex | Role |
-|---|---|---|
-| `--paper` | `#F2F5EE` | Background. Pale verde-tinted off-white. References DOH `#e7efe7`, slightly warmer for screen comfort. |
-| `--ink` | `#1A1F1A` | Primary text. Warm near-black with subtle green undertone. ~14:1 contrast on paper, exceeds WCAG AAA. |
-| `--hairline` | `#B5C0A9` | Rule color. Section dividers, input borders. Verde-tinted to harmonize. |
-| `--muted` | `#5A655A` | Secondary text, helpers, eyebrows. Warm gray-green. |
-| `--signal` | `#006B3F` | DOH emerald. Primary CTAs, current-question marker, active progress, selected radio rings. The recognizable institutional handshake. |
-| `--signal-bg` | `#006B3F1A` | 10% alpha tint. Used only as the current-question background fade. |
-| `--highlight` | `#E5B23B` | DOH yellow inner-rim color. Used **very sparingly** — only for "saved" toasts and similar punctuation moments. Never as fill or surface. |
-| `--success` | `#006B3F` | Same as signal — green is intrinsically "OK" in DOH context, no separate success color. |
-| `--warning` | `#C68A2E` | Ochre. Storage-quota warnings, near-stale draft notices. |
-| `--error` | `#B72020` | Cherry red. References the cross at the center of the DOH seal. Used only on validation errors and submission rejections. |
+| Token         | Hex         | Role                                                                                                                                     |
+| ------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--paper`     | `#F2F5EE`   | Background. Pale verde-tinted off-white. References DOH `#e7efe7`, slightly warmer for screen comfort.                                   |
+| `--ink`       | `#1A1F1A`   | Primary text. Warm near-black with subtle green undertone. ~14:1 contrast on paper, exceeds WCAG AAA.                                    |
+| `--hairline`  | `#B5C0A9`   | Rule color. Section dividers, input borders. Verde-tinted to harmonize.                                                                  |
+| `--muted`     | `#5A655A`   | Secondary text, helpers, eyebrows. Warm gray-green.                                                                                      |
+| `--signal`    | `#006B3F`   | DOH emerald. Primary CTAs, current-question marker, active progress, selected radio rings. The recognizable institutional handshake.     |
+| `--signal-bg` | `#006B3F1A` | 10% alpha tint. Used only as the current-question background fade.                                                                       |
+| `--highlight` | `#E5B23B`   | DOH yellow inner-rim color. Used **very sparingly** — only for "saved" toasts and similar punctuation moments. Never as fill or surface. |
+| `--success`   | `#006B3F`   | Same as signal — green is intrinsically "OK" in DOH context, no separate success color.                                                  |
+| `--warning`   | `#C68A2E`   | Ochre. Storage-quota warnings, near-stale draft notices.                                                                                 |
+| `--error`     | `#B72020`   | Cherry red. References the cross at the center of the DOH seal. Used only on validation errors and submission rejections.                |
 
 ### Dark mode
 
-| Token | Hex | Role |
-|---|---|---|
-| `--paper` | `#0F1410` | Background. Warm graphite, never pure black. |
-| `--ink` | `#DCE3D5` | Primary text. Warm off-white with subtle green undertone. |
-| `--hairline` | `#2A3328` | Rule color. |
-| `--muted` | `#828C82` | Secondary text. |
-| `--signal` | `#2A9166` | Emerald shifted brighter for retina balance on dark ground. |
-| `--signal-bg` | `#2A91661F` | 12% alpha tint. |
-| `--highlight` | `#F1C95C` | DOH yellow shifted brighter. |
-| `--error` | `#D6504C` | Cherry shifted brighter. |
+| Token         | Hex         | Role                                                        |
+| ------------- | ----------- | ----------------------------------------------------------- |
+| `--paper`     | `#0F1410`   | Background. Warm graphite, never pure black.                |
+| `--ink`       | `#DCE3D5`   | Primary text. Warm off-white with subtle green undertone.   |
+| `--hairline`  | `#2A3328`   | Rule color.                                                 |
+| `--muted`     | `#828C82`   | Secondary text.                                             |
+| `--signal`    | `#2A9166`   | Emerald shifted brighter for retina balance on dark ground. |
+| `--signal-bg` | `#2A91661F` | 12% alpha tint.                                             |
+| `--highlight` | `#F1C95C`   | DOH yellow shifted brighter.                                |
+| `--error`     | `#D6504C`   | Cherry shifted brighter.                                    |
 
 ### Color usage rules
 
@@ -81,30 +81,34 @@ the trust HCWs need to install government software on their personal phones.
 
 ## Typography
 
-**All three fonts are free + open source. Loaded via local `/public/fonts/*.woff2` and precached by the service worker.** First-install bundle adds ~120 kB; zero runtime cost after install.
+**All three fonts are free + open source.**
+
+**Long-term target:** Loaded via local `/public/fonts/*.woff2` and precached by the service worker. First-install bundle adds ~120 kB; zero runtime cost after install.
+
+**Currently (as of PR 2):** Loaded from [Bunny Fonts CDN](https://fonts.bunny.net) (privacy-friendly, GDPR-clean, no Google tracking). The service worker runtime-caches `fonts.bunny.net` responses so the app works offline after first visit. The self-host transition is gated on `pyftsubset` tooling for proper Latin Extended subsetting and will land as a follow-up PR.
 
 ### Faces
 
-| Role | Font | License | Why |
-|---|---|---|---|
-| **Display** | **Newsreader** by Production Type | OFL | Contemporary serif with clean terminals. Reads as edited document, not browser default. Carries Filipino diacritics (`ñ`, `ng`) cleanly. Variable axes for fine weight control. |
-| **Body** | **Public Sans Variable** by US Web Design System | OFL | Designed specifically for government-form accessibility. Excellent x-height. Full Latin Extended for Filipino. Tabular-nums built in. Variable. |
-| **Mono / Data** | **JetBrains Mono** | Apache 2.0 | Question numbers in margin, IDs, timestamps, sync counters, version tags. Genuine monospaced figures. |
-| **Fallback (system)** | `Georgia, "Times New Roman", serif` for display; `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif` for body; `"SF Mono", Menlo, Consolas, monospace` for mono | — | Only seen during initial load before woff2 hydrates. |
+| Role                  | Font                                                                                                                                                                            | License    | Why                                                                                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Display**           | **Newsreader** by Production Type                                                                                                                                               | OFL        | Contemporary serif with clean terminals. Reads as edited document, not browser default. Carries Filipino diacritics (`ñ`, `ng`) cleanly. Variable axes for fine weight control. |
+| **Body**              | **Public Sans Variable** by US Web Design System                                                                                                                                | OFL        | Designed specifically for government-form accessibility. Excellent x-height. Full Latin Extended for Filipino. Tabular-nums built in. Variable.                                 |
+| **Mono / Data**       | **JetBrains Mono**                                                                                                                                                              | Apache 2.0 | Question numbers in margin, IDs, timestamps, sync counters, version tags. Genuine monospaced figures.                                                                           |
+| **Fallback (system)** | `Georgia, "Times New Roman", serif` for display; `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif` for body; `"SF Mono", Menlo, Consolas, monospace` for mono | —          | Only seen during initial load before woff2 hydrates.                                                                                                                            |
 
 ### Type scale (modular 1.250 ratio, 16px base)
 
-| Token | Size / Line | Use |
-|---|---|---|
-| `text-xs` | 12 / 18 | Helper text, mono labels, badges |
-| `text-sm` | 14 / 21 | Form labels, secondary copy |
-| `text-base` | 16 / 25 | Body, question prompts (default) |
-| `text-lg` | 18 / 27 | Question prompts at desktop, emphasized body |
-| `text-xl` | 20 / 28 | Subsection headers |
-| `text-2xl` | 24 / 32 | h2, dialog titles |
-| `text-3xl` | 28 / 36 | Mobile section titles |
-| `text-4xl` | 36 / 42 | Desktop section titles (Newsreader 500) |
-| `text-5xl` | 48 / 54 | Splash / first-launch hero (Newsreader 500) |
+| Token       | Size / Line | Use                                          |
+| ----------- | ----------- | -------------------------------------------- |
+| `text-xs`   | 12 / 18     | Helper text, mono labels, badges             |
+| `text-sm`   | 14 / 21     | Form labels, secondary copy                  |
+| `text-base` | 16 / 25     | Body, question prompts (default)             |
+| `text-lg`   | 18 / 27     | Question prompts at desktop, emphasized body |
+| `text-xl`   | 20 / 28     | Subsection headers                           |
+| `text-2xl`  | 24 / 32     | h2, dialog titles                            |
+| `text-3xl`  | 28 / 36     | Mobile section titles                        |
+| `text-4xl`  | 36 / 42     | Desktop section titles (Newsreader 500)      |
+| `text-5xl`  | 48 / 54     | Splash / first-launch hero (Newsreader 500)  |
 
 ### Type rules
 
@@ -125,16 +129,16 @@ the trust HCWs need to install government software on their personal phones.
 
 ### Spacing rules
 
-| Where | Value |
-|---|---|
-| Form field vertical rhythm | 12px between label and input, 8px between input and helper, 24px between fields |
-| Question vertical breathing | 32px between questions |
-| Section breaks | 48px above section opener, 24px between section title and first question |
-| Header padding | 16px vertical, 32px horizontal (desktop) / 12px vertical, 20px horizontal (mobile) |
-| Section opener top margin | 56px (desktop) / 32px (mobile) |
+| Where                              | Value                                                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Form field vertical rhythm         | 12px between label and input, 8px between input and helper, 24px between fields                             |
+| Question vertical breathing        | 32px between questions                                                                                      |
+| Section breaks                     | 48px above section opener, 24px between section title and first question                                    |
+| Header padding                     | 16px vertical, 32px horizontal (desktop) / 12px vertical, 20px horizontal (mobile)                          |
+| Section opener top margin          | 56px (desktop) / 32px (mobile)                                                                              |
 | Margin gutter for question numbers | 88px (desktop/tablet, holds the JetBrains Mono `047` left of question text), 0 mobile (number stacks above) |
-| Page max content width | 720px (the question column) |
-| Frame max width | 1280px (centered with hairline borders left/right) |
+| Page max content width             | 720px (the question column)                                                                                 |
+| Frame max width                    | 1280px (centered with hairline borders left/right)                                                          |
 
 ---
 
@@ -182,12 +186,14 @@ the trust HCWs need to install government software on their personal phones.
 ## Components
 
 This section grows as components are built. For every domain component:
+
 - Document the component's role
 - Specify the spacing rhythm in/around it
 - List the color tokens used
 - Note any deviation from the rules above (and why)
 
 ### `<Question>` (current)
+
 - Role: renders one F2 item, dispatches by type (text, number, radio, multi-select, matrix, date)
 - Layout: 88px gutter (desktop) holds the JetBrains Mono `047` number; 720px max-width content column with prompt + helper + response affordance
 - Vertical breathing: 32px before, 32px after, hairline between
@@ -195,27 +201,32 @@ This section grows as components are built. For every domain component:
 - Required indicator: `*` in `--signal`, immediately after the prompt text
 
 ### `<Likert>`
+
 - 5 options in a horizontal `border` `rounded-2px` `divide-x` row (desktop), stacks vertical on mobile
 - Each option: 1.5px ring radio dot in `--muted`, switching to filled `--signal` (with paper-color inner ring) when selected
 - Selected option's row gets `--signal-bg` background tint
 - Hover: same `--signal-bg` tint, dot color stays muted
 
 ### `<YesNo>`
+
 - 2 options, inline-flex, hairline border, `rounded-2px`
 - Selected: `--signal` solid background, `--paper` text
 - Unselected: transparent, `--ink` text, hairline-bordered
 
 ### `<Navigator>`
+
 - Bottom-fixed bar at the survey level; hairline border-top
 - Left: ghost `← Previous` button
 - Center: typographic ledger progress in JetBrains Mono
 - Right: solid `--signal` `Next →` button (default state) or ghost `Submit responses` (last question)
 
 ### `<SyncBadge>` / `<PendingCount>`
+
 - Header pill, JetBrains Mono `text-xs`
 - Format: `{count} pending` where `{count}` is `--signal` and "pending" is `--muted`
 
 ### `<LanguageSwitcher>`
+
 - Inline-flex pill, hairline-bordered, `rounded-2px`
 - Active language: `--ink` background, `--paper` text
 - Inactive language: transparent, `--muted` text
@@ -241,7 +252,7 @@ These are forward-looking notes for the PRs that will land this design system in
 ### PR plan (suggested)
 
 1. **PR 1 — Tokens.** Replace `:root` HSL variables in `src/index.css` with the Verde Manual hex tokens. Update `tailwind.config.ts` if needed (current config maps Tailwind classes to CSS vars, so most changes ride through automatically). Update `public/manifest.webmanifest` `theme_color` from `#0f766e` (teal) to `#006B3F` (DOH emerald).
-2. **PR 2 — Typography.** Add `public/fonts/{newsreader, public-sans, jetbrains-mono}.woff2` (subset to Latin Extended). Reference in `index.css` `@font-face` rules. Precache via vite-plugin-pwa workbox config. Add `font-family` declarations to body + Tailwind theme extend.
+2. **PR 2 — Typography.** _(Shipping as #38)_ Add Bunny Fonts CDN `<link>` to `index.html`. Update `tailwind.config.ts` `theme.fontFamily` extend to map `font-serif` → Newsreader, `font-sans` → Public Sans, `font-mono` → JetBrains Mono. Add workbox `runtimeCaching` for `fonts.bunny.net` (CSS = StaleWhileRevalidate, woff2 = CacheFirst). Self-host transition deferred to a follow-up PR (gated on `pyftsubset` tooling).
 3. **PR 3 — Layout & components.** Refactor `<Question>` to add the 88px gutter + marginal mono number. Replace any `border rounded-lg shadow` patterns with hairline rules. Update `<MultiSectionForm>` section dividers to hairlines + whitespace. Update `<Navigator>` to typographic-ledger progress.
 
 Each PR is small enough to review in 10 minutes and ship under `/ship` (which does NOT bump version per `project_gstack_adoption`).
@@ -265,7 +276,7 @@ If you're about to commit a UI change, verify:
 - [ ] No `bg-white shadow-md rounded-lg` "card" patterns
 - [ ] No gradient buttons (signal is flat, full stop)
 - [ ] No emoji in UI chrome (emoji is fine in user-generated content)
-- [ ] No system-ui or `-apple-system` as the *primary* display or body font (only as fallback while woff2 loads)
+- [ ] No system-ui or `-apple-system` as the _primary_ display or body font (only as fallback while woff2 loads)
 - [ ] No "Get Started" / "Built for X" / "Designed for Y" copy patterns
 - [ ] No Lottie or decorative SVG blobs
 - [ ] No glassmorphism, no backdrop-blur on chrome surfaces
@@ -275,8 +286,8 @@ If you're about to commit a UI change, verify:
 
 ## Decisions Log
 
-| Date | Decision | Rationale |
-|---|---|---|
+| Date       | Decision                      | Rationale                                                                                                                                                                                                                                                                                                                                    |
+| ---------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 2026-04-26 | Initial design system created | Created by `/gstack-design-consultation`. Memorable thing: "real software, not a government form." Verde Manual chosen over Field Manual to ladder up to DOH institutional brand without losing craft. Hex values approximated from visible DOH seal + Verde Vision documented background; refine when official brand-book PDF is available. |
 
 ---

--- a/deliverables/F2/PWA/app/index.html
+++ b/deliverables/F2/PWA/app/index.html
@@ -5,6 +5,14 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>UHC Survey Y2 — Healthcare Worker Survey Questionnaire</title>
+
+    <!-- Verde Manual fonts. See DESIGN.md. CDN now, self-host follow-up.
+         Service worker runtime-caches fonts.bunny.net for offline use. -->
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.bunny.net/css?family=newsreader:400,500,600,700|public-sans:400,500,600,700|jetbrains-mono:400,500,600&display=swap"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/deliverables/F2/PWA/app/src/App.tsx
+++ b/deliverables/F2/PWA/app/src/App.tsx
@@ -234,8 +234,8 @@ function AppShell() {
       <BroadcastBanner message={runtimeConfig.broadcast_message} />
       <header className="flex items-center justify-between border-b px-6 py-3">
         <div className="flex flex-col">
-          <h1 className="text-lg font-semibold">{t('chrome.appTitle')}</h1>
-          <span className="text-[10px] leading-none text-muted-foreground/60">
+          <h1 className="font-serif text-2xl font-medium tracking-tight">{t('chrome.appTitle')}</h1>
+          <span className="font-mono text-xs leading-none text-muted-foreground">
             v{APP_VERSION} · spec {LOCAL_SPEC_VERSION}
           </span>
         </div>
@@ -273,7 +273,9 @@ function AppShell() {
         <p className="p-6 text-sm text-muted-foreground">{t('chrome.loading')}</p>
       ) : status === 'submitted' ? (
         <section className="mx-auto flex max-w-xl flex-col gap-4 p-6">
-          <h2 className="text-2xl font-semibold">{t('chrome.thankYouHeading')}</h2>
+          <h2 className="font-serif text-2xl font-medium tracking-tight">
+            {t('chrome.thankYouHeading')}
+          </h2>
           <p className="text-sm text-muted-foreground">{t('chrome.thankYouBody')}</p>
           <div className="flex items-center gap-3">
             <Button variant="outline" size="sm" onClick={() => setView('sync')}>
@@ -284,7 +286,7 @@ function AppShell() {
         </section>
       ) : status === 'submit_failed' ? (
         <section className="mx-auto flex max-w-xl flex-col gap-4 p-6">
-          <h2 className="text-2xl font-semibold text-red-700">
+          <h2 className="font-serif text-2xl font-medium tracking-tight text-destructive">
             {t('chrome.submitFailedHeading')}
           </h2>
           <p className="text-sm text-muted-foreground">

--- a/deliverables/F2/PWA/app/src/components/chrome/BroadcastBanner.tsx
+++ b/deliverables/F2/PWA/app/src/components/chrome/BroadcastBanner.tsx
@@ -5,7 +5,7 @@ interface Props {
 export function BroadcastBanner({ message }: Props) {
   if (!message) return null;
   return (
-    <div role="status" className="border-b bg-amber-50 px-6 py-2 text-sm text-amber-900">
+    <div role="status" className="border-b bg-warning/10 px-6 py-2 text-sm text-warning">
       {message}
     </div>
   );

--- a/deliverables/F2/PWA/app/src/components/chrome/KillSwitchOverlay.tsx
+++ b/deliverables/F2/PWA/app/src/components/chrome/KillSwitchOverlay.tsx
@@ -14,8 +14,8 @@ export function KillSwitchOverlay({ active }: Props) {
       aria-describedby="kill-switch-body"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6"
     >
-      <div className="max-w-md rounded bg-white p-6 shadow-lg">
-        <h2 id="kill-switch-title" className="mb-2 text-lg font-semibold">
+      <div className="max-w-md rounded-md border border-border bg-background p-6">
+        <h2 id="kill-switch-title" className="mb-2 font-serif text-lg font-medium tracking-tight">
           {t('chrome.killSwitchTitle')}
         </h2>
         <p id="kill-switch-body" className="text-sm text-muted-foreground">

--- a/deliverables/F2/PWA/app/src/components/chrome/SpecDriftOverlay.tsx
+++ b/deliverables/F2/PWA/app/src/components/chrome/SpecDriftOverlay.tsx
@@ -25,8 +25,8 @@ export function SpecDriftOverlay({ drift, localVersion, serverMin }: Props) {
       aria-describedby="spec-drift-body"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6"
     >
-      <div className="max-w-md rounded bg-white p-6 shadow-lg">
-        <h2 id="spec-drift-title" className="mb-2 text-lg font-semibold">
+      <div className="max-w-md rounded-md border border-border bg-background p-6">
+        <h2 id="spec-drift-title" className="mb-2 font-serif text-lg font-medium tracking-tight">
           {t('chrome.specDriftTitle')}
         </h2>
         <p id="spec-drift-body" className="mb-4 text-sm text-muted-foreground">

--- a/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.tsx
+++ b/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.tsx
@@ -50,7 +50,7 @@ export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
 
   return (
     <form onSubmit={handleEnroll} className="mx-auto flex max-w-md flex-col gap-4 p-6">
-      <h2 className="text-2xl font-semibold tracking-tight">{t('enrollment.heading')}</h2>
+      <h2 className="font-serif text-2xl font-medium tracking-tight">{t('enrollment.heading')}</h2>
       <p className="text-sm text-muted-foreground">{t('enrollment.helper')}</p>
 
       <label className="flex flex-col gap-1 text-sm">
@@ -86,7 +86,7 @@ export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
         )}
       </label>
 
-      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
 
       <div className="flex items-center gap-3">
         <Button type="submit" disabled={!canSubmit}>

--- a/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.tsx
@@ -43,7 +43,7 @@ export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
                 <th scope="row" className="py-2 pr-2 text-left text-sm font-normal">
                   <span className="mr-1 text-muted-foreground">{item.id}.</span>
                   {localized(item.label, locale)}
-                  {item.required ? <span className="ml-1 text-red-600">*</span> : null}
+                  {item.required ? <span className="ml-1 text-destructive">*</span> : null}
                 </th>
                 {choices.map((c) => (
                   <td key={c.value} className="py-2 px-1 text-center">
@@ -60,7 +60,11 @@ export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
             if (errorMessage || error) {
               out.push(
                 <tr key={`${item.id}-err`}>
-                  <td colSpan={choices.length + 1} className="py-1 text-xs text-red-600" role="alert">
+                  <td
+                    colSpan={choices.length + 1}
+                    className="py-1 text-xs text-destructive"
+                    role="alert"
+                  >
                     {errorMessage ?? t('question.requiredFallback')}
                   </td>
                 </tr>,
@@ -82,7 +86,7 @@ export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
               <p id={groupId} className="text-sm font-medium">
                 <span className="mr-1 text-muted-foreground">{item.id}.</span>
                 {localized(item.label, locale)}
-                {item.required ? <span className="ml-1 text-red-600">*</span> : null}
+                {item.required ? <span className="ml-1 text-destructive">*</span> : null}
               </p>
               <div role="radiogroup" aria-labelledby={groupId} className="flex flex-wrap gap-3">
                 {choices.map((c) => (
@@ -98,7 +102,7 @@ export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
                 ))}
               </div>
               {errorMessage || error ? (
-                <p role="alert" className="text-xs text-red-600">
+                <p role="alert" className="text-xs text-destructive">
                   {errorMessage ?? t('question.requiredFallback')}
                 </p>
               ) : null}

--- a/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
@@ -330,7 +330,7 @@ export function MultiSectionForm({
         aria-label="Previous section"
         onClick={handlePrev}
         className={cn(
-          'fixed top-1/2 left-1 z-30 -translate-y-1/2 rounded-full border bg-background/90 p-2 shadow-md transition-colors hover:bg-muted lg:left-[232px]',
+          'fixed top-1/2 left-1 z-30 -translate-y-1/2 rounded-full border border-border bg-background/90 p-2 shadow-sm transition-colors hover:bg-muted lg:left-[232px]',
           isFirst && 'invisible',
         )}
       >
@@ -353,7 +353,7 @@ export function MultiSectionForm({
         aria-label="Next section"
         onClick={handleNext}
         className={cn(
-          'fixed top-1/2 right-1 z-30 -translate-y-1/2 rounded-full border p-2 shadow-md transition-colors',
+          'fixed top-1/2 right-1 z-30 -translate-y-1/2 rounded-full border border-border p-2 shadow-sm transition-colors',
           isLastSection
             ? 'bg-primary text-primary-foreground hover:bg-primary/90'
             : 'bg-background/90 hover:bg-muted',

--- a/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
@@ -78,9 +78,7 @@ function getSectionStatus(section: SectionConfig, values: FormValues): SectionSt
     if (it.type === 'multi-field' && it.subFields) {
       // A subfield is required only if the parent is required AND its own required
       // flag isn't explicitly false. Optional subfields don't block completion.
-      return it.subFields.every(
-        (sf) => sf.required === false || hasValue(values[sf.id]),
-      );
+      return it.subFields.every((sf) => sf.required === false || hasValue(values[sf.id]));
     }
     return hasValue(values[it.id]);
   });
@@ -135,13 +133,11 @@ export function MultiSectionForm({
   );
 
   const visibleSectionEntries = useMemo(
-    () => SECTIONS.reduce<Array<{ config: SectionConfig; originalIndex: number }>>(
-      (acc, s, i) => {
+    () =>
+      SECTIONS.reduce<Array<{ config: SectionConfig; originalIndex: number }>>((acc, s, i) => {
         if (shouldShowSection(s.id, merged)) acc.push({ config: s, originalIndex: i });
         return acc;
-      },
-      [],
-    ),
+      }, []),
     [merged],
   );
 
@@ -176,7 +172,7 @@ export function MultiSectionForm({
   // Reset entry status when navigating to a new section (must be before the auto-advance effect)
   useEffect(() => {
     entryStatusRef.current = sectionStatuses[index] ?? 'empty';
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [index]);
 
   // Auto-advance when current section transitions from non-complete to complete
@@ -190,7 +186,7 @@ export function MultiSectionForm({
       handleNext();
     }, 400);
     return () => clearTimeout(timer);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sectionStatuses]);
 
   const showLockMsg = () => {
@@ -290,7 +286,9 @@ export function MultiSectionForm({
           sections={visibleSectionEntries.map((e) => e.config)}
           currentIndex={visibleIndex}
           statuses={visibleSectionEntries.map((e) => sectionStatuses[e.originalIndex]!)}
-          maxVisitedIndex={visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1}
+          maxVisitedIndex={
+            visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1
+          }
           onNavigate={(i) => handleNavigate(visibleSectionEntries[i]!.originalIndex)}
         />
       </aside>
@@ -313,8 +311,13 @@ export function MultiSectionForm({
               sections={visibleSectionEntries.map((e) => e.config)}
               currentIndex={visibleIndex}
               statuses={visibleSectionEntries.map((e) => sectionStatuses[e.originalIndex]!)}
-              maxVisitedIndex={visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1}
-              onNavigate={(i) => { handleNavigate(visibleSectionEntries[i]!.originalIndex); setDrawerOpen(false); }}
+              maxVisitedIndex={
+                visibleSectionEntries.filter((e) => e.originalIndex <= maxVisitedIndex).length - 1
+              }
+              onNavigate={(i) => {
+                handleNavigate(visibleSectionEntries[i]!.originalIndex);
+                setDrawerOpen(false);
+              }}
               onClose={() => setDrawerOpen(false)}
             />
           </aside>
@@ -331,7 +334,15 @@ export function MultiSectionForm({
           isFirst && 'invisible',
         )}
       >
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
           <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
         </svg>
       </button>
@@ -348,7 +359,15 @@ export function MultiSectionForm({
             : 'bg-background/90 hover:bg-muted',
         )}
       >
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
           <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
         </svg>
       </button>
@@ -368,11 +387,27 @@ export function MultiSectionForm({
               className="shrink-0 rounded p-1 hover:bg-muted lg:hidden"
               onClick={() => setDrawerOpen(true)}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
               </svg>
             </button>
-            <ProgressBar current={visibleIndex + 1} total={visibleSectionEntries.length} className="flex-1 px-0 pt-0" />
+            <ProgressBar
+              current={visibleIndex + 1}
+              total={visibleSectionEntries.length}
+              className="flex-1 px-0 pt-0"
+            />
             {/* Save Draft — upper right */}
             <button
               type="button"
@@ -380,7 +415,7 @@ export function MultiSectionForm({
               className="shrink-0 rounded border px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted"
             >
               {showSaved ? (
-                <span className="text-green-600">{t('navigator.draftSaved')}</span>
+                <span className="text-primary">{t('navigator.draftSaved')}</span>
               ) : (
                 t('navigator.saveDraft')
               )}
@@ -395,7 +430,7 @@ export function MultiSectionForm({
           ) : null}
 
           <div className="mx-auto max-w-xl px-6 pb-2">
-            <h2 className="text-xl font-semibold tracking-tight">
+            <h2 className="font-serif text-xl font-medium tracking-tight">
               {t('review.sectionHeading', {
                 id: current!.id,
                 title: localized(current!.section.title, locale),

--- a/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MultiSectionForm.tsx
@@ -424,7 +424,7 @@ export function MultiSectionForm({
 
           {/* Lock notification strip */}
           {lockMsg ? (
-            <div className="border-t border-amber-200 bg-amber-50 px-4 py-1.5 text-xs text-amber-700">
+            <div className="border-t border-warning/30 bg-warning/10 px-4 py-1.5 text-xs text-warning">
               {lockMsg}
             </div>
           ) : null}

--- a/deliverables/F2/PWA/app/src/components/survey/Navigator.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Navigator.tsx
@@ -15,7 +15,7 @@ export function Navigator({ onSaveDraft, showSaved }: NavigatorProps) {
         {t('navigator.saveDraft')}
       </Button>
       {showSaved ? (
-        <span className="whitespace-nowrap text-sm text-green-600">{t('navigator.draftSaved')}</span>
+        <span className="whitespace-nowrap text-sm text-primary">{t('navigator.draftSaved')}</span>
       ) : null}
     </div>
   );

--- a/deliverables/F2/PWA/app/src/components/survey/ProgressBar.test.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/ProgressBar.test.tsx
@@ -20,4 +20,12 @@ describe('<ProgressBar>', () => {
     render(<ProgressBar current={3} total={3} />);
     expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
   });
+
+  it('renders the typographic ledger with zero-padded counters', () => {
+    render(<ProgressBar current={4} total={35} />);
+    const bar = screen.getByRole('progressbar');
+    // Zero-padded to total's width: 35 → 2 chars, so 4 → '04'
+    expect(bar.textContent).toContain('04');
+    expect(bar.textContent).toContain('35');
+  });
 });

--- a/deliverables/F2/PWA/app/src/components/survey/ProgressBar.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/ProgressBar.tsx
@@ -7,12 +7,17 @@ interface ProgressBarProps {
   className?: string;
 }
 
+const TRACK_WIDTH = 18;
+
 export function ProgressBar({ current, total, className }: ProgressBarProps) {
   const { t } = useTranslation();
-  const percent = Math.min(100, Math.round((current / total) * 100));
+  const ratio = Math.min(1, Math.max(0, current / total));
+  const percent = Math.round(ratio * 100);
+  const filled = Math.round(ratio * TRACK_WIDTH);
+  const padded = (n: number) => String(n).padStart(String(total).length, '0');
   return (
     <div className={cn('flex flex-col gap-1 px-6 pt-3', className)}>
-      <p className="text-xs text-muted-foreground">
+      <p className="font-mono text-xs uppercase tracking-wide text-muted-foreground">
         {t('progressBar.sectionLabel', { current, total })}
       </p>
       <div
@@ -20,9 +25,18 @@ export function ProgressBar({ current, total, className }: ProgressBarProps) {
         aria-valuenow={percent}
         aria-valuemin={0}
         aria-valuemax={100}
-        className="h-2 w-full overflow-hidden rounded bg-muted"
+        className="font-mono text-sm leading-none"
       >
-        <div className="h-full bg-primary transition-all" style={{ width: `${percent}%` }} />
+        <span className="text-foreground">{padded(current)}</span>
+        <span aria-hidden="true">{'  '}</span>
+        <span aria-hidden="true" className="text-primary">
+          {'━'.repeat(filled)}
+        </span>
+        <span aria-hidden="true" className="text-muted-foreground opacity-45">
+          {'━'.repeat(TRACK_WIDTH - filled)}
+        </span>
+        <span aria-hidden="true">{'  '}</span>
+        <span className="text-muted-foreground">{padded(total)}</span>
       </div>
     </div>
   );

--- a/deliverables/F2/PWA/app/src/components/survey/Question.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Question.tsx
@@ -36,35 +36,46 @@ export function Question({ item }: QuestionProps) {
   const errorMessage = typeof error?.message === 'string' ? error.message : undefined;
 
   return (
-    <div className="flex flex-col gap-2 py-3">
-      <label htmlFor={item.id} className="text-sm font-medium">
-        <span className="mr-1 text-muted-foreground">{item.id}.</span>
-        {localized(item.label, locale)}
-        {item.required ? <span className="ml-1 text-red-600">*</span> : null}
-      </label>
-      {item.help ? (
-        <p className="text-xs text-muted-foreground">{localized(item.help, locale)}</p>
-      ) : null}
-      {renderControl(
-        item,
-        register,
-        showSpecify,
-        t,
-        locale,
-        errors,
-        visibleChoices,
-        currentValue,
-        (next) => setValue(item.id, next, { shouldValidate: true, shouldDirty: true }),
-      )}
-      {errorMessage ? (
-        <p role="alert" className="text-xs text-red-600">
-          {errorMessage}
-        </p>
-      ) : error ? (
-        <p role="alert" className="text-xs text-red-600">
-          {t('question.requiredFallback')}
-        </p>
-      ) : null}
+    <div className="grid grid-cols-1 gap-y-2 py-3 sm:grid-cols-[80px_1fr]">
+      <span
+        aria-hidden="true"
+        className="font-mono text-sm text-muted-foreground sm:pt-1 sm:pr-4 sm:text-right sm:text-base sm:leading-snug"
+      >
+        {item.id}
+      </span>
+      <div className="flex min-w-0 flex-col gap-2">
+        <label htmlFor={item.id} className="text-base font-medium leading-snug">
+          <span className="sr-only">
+            {item.id}
+            {'. '}
+          </span>
+          {localized(item.label, locale)}
+          {item.required ? <span className="ml-1 text-destructive">*</span> : null}
+        </label>
+        {item.help ? (
+          <p className="text-xs text-muted-foreground">{localized(item.help, locale)}</p>
+        ) : null}
+        {renderControl(
+          item,
+          register,
+          showSpecify,
+          t,
+          locale,
+          errors,
+          visibleChoices,
+          currentValue,
+          (next) => setValue(item.id, next, { shouldValidate: true, shouldDirty: true }),
+        )}
+        {errorMessage ? (
+          <p role="alert" className="text-xs text-destructive">
+            {errorMessage}
+          </p>
+        ) : error ? (
+          <p role="alert" className="text-xs text-destructive">
+            {t('question.requiredFallback')}
+          </p>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -91,18 +102,26 @@ function blockNonNumericKeys(event: React.KeyboardEvent<HTMLInputElement>) {
 //   is no longer accurate).
 export function nextMultiValue(
   current: string[],
-  clicked: { value: string; isExclusive?: boolean; isSelectAll?: boolean; isOtherSpecify?: boolean },
+  clicked: {
+    value: string;
+    isExclusive?: boolean;
+    isSelectAll?: boolean;
+    isOtherSpecify?: boolean;
+  },
   willBeChecked: boolean,
-  allChoices: ReadonlyArray<{ value: string; isExclusive?: boolean; isSelectAll?: boolean; isOtherSpecify?: boolean }>,
+  allChoices: ReadonlyArray<{
+    value: string;
+    isExclusive?: boolean;
+    isSelectAll?: boolean;
+    isOtherSpecify?: boolean;
+  }>,
 ): string[] {
   const findChoice = (v: string) => allChoices.find((c) => c.value === v);
 
   if (willBeChecked) {
     if (clicked.isExclusive) return [clicked.value];
     if (clicked.isSelectAll) {
-      return allChoices
-        .filter((c) => !c.isExclusive && !c.isOtherSpecify)
-        .map((c) => c.value);
+      return allChoices.filter((c) => !c.isExclusive && !c.isOtherSpecify).map((c) => c.value);
     }
     const filtered = current.filter((v) => {
       const c = findChoice(v);
@@ -144,7 +163,7 @@ function renderControl(
         <input
           id={item.id}
           type="text"
-          className="rounded border border-input bg-background px-3 py-2"
+          className="rounded-md border border-input bg-background px-3 py-2"
           {...register(item.id)}
         />
       );
@@ -153,7 +172,7 @@ function renderControl(
         <textarea
           id={item.id}
           rows={4}
-          className="rounded border border-input bg-background px-3 py-2"
+          className="rounded-md border border-input bg-background px-3 py-2"
           {...register(item.id)}
         />
       );
@@ -166,7 +185,7 @@ function renderControl(
           max={item.max}
           inputMode="numeric"
           onKeyDown={blockNonNumericKeys}
-          className="rounded border border-input bg-background px-3 py-2"
+          className="rounded-md border border-input bg-background px-3 py-2"
           {...register(item.id)}
         />
       );
@@ -194,7 +213,7 @@ function renderControl(
               <input
                 id={`${item.id}_other`}
                 type="text"
-                className="rounded border border-input bg-background px-3 py-2"
+                className="rounded-md border border-input bg-background px-3 py-2"
                 {...register(`${item.id}_other`)}
               />
             </div>
@@ -222,16 +241,13 @@ function renderControl(
                     checked={isChecked}
                     onChange={(e) => {
                       if (!onChange) return;
-                      const next = nextMultiValue(
-                        selected,
-                        choice,
-                        e.target.checked,
-                        allChoices,
-                      );
+                      const next = nextMultiValue(selected, choice, e.target.checked, allChoices);
                       onChange(next);
                     }}
                     onBlur={reg.onBlur}
-                    {...(idx === 0 ? { id: item.id, ref: reg.ref, name: reg.name } : { name: reg.name })}
+                    {...(idx === 0
+                      ? { id: item.id, ref: reg.ref, name: reg.name }
+                      : { name: reg.name })}
                   />
                   {localized(choice.label, locale)}
                 </label>
@@ -246,7 +262,7 @@ function renderControl(
               <input
                 id={`${item.id}_other`}
                 type="text"
-                className="rounded border border-input bg-background px-3 py-2"
+                className="rounded-md border border-input bg-background px-3 py-2"
                 {...register(`${item.id}_other`)}
               />
             </div>
@@ -259,7 +275,7 @@ function renderControl(
         <input
           id={item.id}
           type="date"
-          className="rounded border border-input bg-background px-3 py-2"
+          className="rounded-md border border-input bg-background px-3 py-2"
           {...register(item.id)}
         />
       );
@@ -283,15 +299,15 @@ function renderControl(
                   {...(sf.kind === 'number'
                     ? { inputMode: 'numeric', onKeyDown: blockNonNumericKeys }
                     : {})}
-                  className="rounded border border-input bg-background px-3 py-2"
+                  className="rounded-md border border-input bg-background px-3 py-2"
                   {...register(sf.id)}
                 />
                 {sfErrorMessage ? (
-                  <p role="alert" className="text-xs text-red-600">
+                  <p role="alert" className="text-xs text-destructive">
                     {sfErrorMessage}
                   </p>
                 ) : sfError ? (
-                  <p role="alert" className="text-xs text-red-600">
+                  <p role="alert" className="text-xs text-destructive">
                     {t('question.requiredFallback')}
                   </p>
                 ) : null}

--- a/deliverables/F2/PWA/app/src/components/survey/ReviewSection.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/ReviewSection.tsx
@@ -75,11 +75,9 @@ function rowsForItem(
 }
 
 // Hairline-bordered alerts with a colored left border (no full background fill).
-// `warn` keeps amber pending a `--warning` Tailwind binding (TODO: extend
-// theme.colors with `warning` from --warning, see DESIGN.md § Color).
 const SEVERITY_STYLES: Record<Warning['severity'], string> = {
   error: 'border-border border-l-4 border-l-destructive text-foreground',
-  warn: 'border-border border-l-4 border-l-amber-600 text-foreground',
+  warn: 'border-border border-l-4 border-l-warning text-foreground',
   clean: 'border-border border-l-4 border-l-primary text-foreground',
   info: 'border-border border-l-4 border-l-muted-foreground text-foreground',
 };

--- a/deliverables/F2/PWA/app/src/components/survey/ReviewSection.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/ReviewSection.tsx
@@ -74,11 +74,14 @@ function rowsForItem(
   return rows;
 }
 
+// Hairline-bordered alerts with a colored left border (no full background fill).
+// `warn` keeps amber pending a `--warning` Tailwind binding (TODO: extend
+// theme.colors with `warning` from --warning, see DESIGN.md § Color).
 const SEVERITY_STYLES: Record<Warning['severity'], string> = {
-  error: 'border-red-300 bg-red-50 text-red-900',
-  warn: 'border-amber-300 bg-amber-50 text-amber-900',
-  clean: 'border-blue-300 bg-blue-50 text-blue-900',
-  info: 'border-slate-200 bg-slate-50 text-slate-700',
+  error: 'border-border border-l-4 border-l-destructive text-foreground',
+  warn: 'border-border border-l-4 border-l-amber-600 text-foreground',
+  clean: 'border-border border-l-4 border-l-primary text-foreground',
+  info: 'border-border border-l-4 border-l-muted-foreground text-foreground',
 };
 
 export function ReviewSection({ values, onEdit, onSubmit }: ReviewSectionProps) {
@@ -88,16 +91,13 @@ export function ReviewSection({ values, onEdit, onSubmit }: ReviewSectionProps) 
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-6 p-6">
-      <h2 className="text-2xl font-semibold tracking-tight">{t('review.heading')}</h2>
+      <h2 className="font-serif text-2xl font-medium tracking-tight">{t('review.heading')}</h2>
 
       {warnings.length > 0 ? (
         <section aria-label={t('review.crossFieldRegion')} className="flex flex-col gap-2">
           {warnings.map((w) => (
-            <div
-              key={w.id}
-              className={`rounded-md border px-3 py-2 text-sm ${SEVERITY_STYLES[w.severity]}`}
-            >
-              <strong className="mr-2">{w.id}</strong>
+            <div key={w.id} className={`border px-3 py-2 text-sm ${SEVERITY_STYLES[w.severity]}`}>
+              <strong className="mr-2 font-mono text-xs uppercase tracking-wide">{w.id}</strong>
               {t(w.message.key, w.message.values ?? {})}
             </div>
           ))}
@@ -106,7 +106,9 @@ export function ReviewSection({ values, onEdit, onSubmit }: ReviewSectionProps) 
 
       {SECTIONS.map((section) => {
         const grouped = groupVisibleItems(section.items);
-        type Block = { kind: 'rows'; rows: ReturnType<typeof rowsForItem> } | { kind: 'matrix'; group: MatrixGroup };
+        type Block =
+          | { kind: 'rows'; rows: ReturnType<typeof rowsForItem> }
+          | { kind: 'matrix'; group: MatrixGroup };
         const blocks: Block[] = [];
         for (const entry of grouped) {
           if (isMatrixGroup(entry)) {
@@ -132,34 +134,29 @@ export function ReviewSection({ values, onEdit, onSubmit }: ReviewSectionProps) 
                 {t('review.edit')}
               </Button>
             </header>
-            <div className="divide-y divide-slate-200 rounded border border-slate-200">
+            <div className="divide-y divide-border border border-border">
               {blocks.map((block, blockIdx) =>
                 block.kind === 'matrix' ? (
-                  <div
-                    key={`matrix-${block.group.items[0].id}`}
-                    className="px-3 py-2"
-                  >
+                  <div key={`matrix-${block.group.items[0].id}`} className="px-3 py-2">
                     <table className="w-full text-sm">
                       <tbody>
                         {block.group.items.map((it) => (
                           <tr key={it.id}>
-                            <td className="py-1 pr-2 text-slate-700">
+                            <td className="py-1 pr-2 text-muted-foreground">
                               {it.id} {localized(it.label, locale)}
                             </td>
-                            <td className="py-1 text-slate-900">
-                              {formatValue(values[it.id])}
-                            </td>
+                            <td className="py-1 text-foreground">{formatValue(values[it.id])}</td>
                           </tr>
                         ))}
                       </tbody>
                     </table>
                   </div>
                 ) : (
-                  <dl key={`rows-${blockIdx}`} className="divide-y divide-slate-200">
+                  <dl key={`rows-${blockIdx}`} className="divide-y divide-border">
                     {block.rows.map((r) => (
                       <div key={r.key} className="grid grid-cols-3 gap-3 px-3 py-2 text-sm">
-                        <dt className="col-span-2 text-slate-700">{r.label}</dt>
-                        <dd className="text-slate-900">{r.value}</dd>
+                        <dt className="col-span-2 text-muted-foreground">{r.label}</dt>
+                        <dd className="text-foreground">{r.value}</dd>
                       </div>
                     ))}
                   </dl>

--- a/deliverables/F2/PWA/app/src/components/survey/SectionTree.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/SectionTree.tsx
@@ -40,8 +40,20 @@ export function SectionTree({
             className="rounded p-1 hover:bg-muted"
             onClick={onClose}
           >
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
             </svg>
           </button>
         ) : null}
@@ -71,23 +83,54 @@ export function SectionTree({
                   'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold',
                   isCurrent && 'bg-primary text-primary-foreground',
                   !isCurrent && isLocked && 'bg-muted text-muted-foreground',
-                  !isCurrent && !isLocked && status === 'complete' && 'bg-green-100 text-green-700',
-                  !isCurrent && !isLocked && status === 'incomplete' && 'bg-red-100 text-red-600',
+                  !isCurrent && !isLocked && status === 'complete' && 'bg-primary/10 text-primary',
+                  !isCurrent &&
+                    !isLocked &&
+                    status === 'incomplete' &&
+                    'bg-destructive/10 text-destructive',
                   !isCurrent && !isLocked && status === 'empty' && 'bg-muted text-muted-foreground',
                 )}
               >
                 {isCurrent ? (
                   s.id
                 ) : isLocked ? (
-                  <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="9"
+                    height="9"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z"
+                    />
                   </svg>
                 ) : status === 'complete' ? (
-                  <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="10"
+                    height="10"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={3}
+                  >
                     <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                   </svg>
                 ) : status === 'incomplete' ? (
-                  <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="10"
+                    height="10"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={3}
+                  >
                     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 ) : (
@@ -99,7 +142,11 @@ export function SectionTree({
               <span
                 className={cn(
                   'leading-snug',
-                  isCurrent ? 'text-primary' : isLocked ? 'text-muted-foreground' : 'text-foreground',
+                  isCurrent
+                    ? 'text-primary'
+                    : isLocked
+                      ? 'text-muted-foreground'
+                      : 'text-foreground',
                 )}
               >
                 {localized(s.section.title, locale)}

--- a/deliverables/F2/PWA/app/src/components/sync/PendingCount.tsx
+++ b/deliverables/F2/PWA/app/src/components/sync/PendingCount.tsx
@@ -23,7 +23,7 @@ export function PendingCount() {
   return (
     <span
       data-testid="pending-count"
-      className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800"
+      className="inline-flex items-center rounded-full border border-warning/30 bg-warning/10 px-2.5 py-0.5 text-xs font-medium text-warning"
     >
       {t('sync.pendingBadge', { count })}
     </span>

--- a/deliverables/F2/PWA/app/src/components/sync/SyncPage.tsx
+++ b/deliverables/F2/PWA/app/src/components/sync/SyncPage.tsx
@@ -58,7 +58,7 @@ export function SyncPage({ runSync }: SyncPageProps) {
   if (rows.length === 0) {
     return (
       <section className="mx-auto flex max-w-xl flex-col gap-4 p-6">
-        <h2 className="text-2xl font-semibold">{t('sync.heading')}</h2>
+        <h2 className="font-serif text-2xl font-medium tracking-tight">{t('sync.heading')}</h2>
         <p className="text-sm text-muted-foreground">{t('sync.none')}</p>
         <SyncButton runSync={runSync} />
         <ChangeEnrollmentButton />
@@ -72,7 +72,7 @@ export function SyncPage({ runSync }: SyncPageProps) {
 
   return (
     <section className="mx-auto flex max-w-xl flex-col gap-4 p-6">
-      <h2 className="text-2xl font-semibold">{t('sync.heading')}</h2>
+      <h2 className="font-serif text-2xl font-medium tracking-tight">{t('sync.heading')}</h2>
       <SyncButton runSync={runSync} />
       <ChangeEnrollmentButton />
       {STATUS_ORDER.map((s) => {

--- a/deliverables/F2/PWA/app/src/components/ui/button.tsx
+++ b/deliverables/F2/PWA/app/src/components/ui/button.tsx
@@ -2,16 +2,17 @@ import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
+// Verde Manual: buttons are flat. Solid color (primary, destructive) carries
+// prominence; outline uses the hairline border. No shadows on chrome — see DESIGN.md.
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground disabled:hover:bg-muted',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
-        outline:
-          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
       },

--- a/deliverables/F2/PWA/app/src/index.css
+++ b/deliverables/F2/PWA/app/src/index.css
@@ -33,6 +33,12 @@
     --destructive: 0 70.2% 42.2%; /* #B72020 */
     --destructive-foreground: 85.7 25.9% 94.7%;
 
+    /* Warning — ochre. Used for storage-quota warnings, near-stale drafts,
+     * the lock-notification strip, the broadcast banner, and Review-section
+     * 'warn' severity alerts. */
+    --warning: 36.3 62.3% 47.8%; /* #C68A2E */
+    --warning-foreground: 85.7 25.9% 94.7%; /* paper */
+
     /* Highlight — DOH yellow inner rim. Used very sparingly (save toasts only).
      * Not yet bound to a Tailwind utility; consume via hsl(var(--highlight)). */
     --highlight: 42 76.6% 56.5%; /* #E5B23B */
@@ -60,6 +66,9 @@
 
     --destructive: 1.7 62.7% 56.9%; /* #D6504C */
     --destructive-foreground: 90 20% 86.3%;
+
+    --warning: 35 70% 58%; /* shifted brighter for dark mode */
+    --warning-foreground: 132 14.3% 6.9%; /* graphite ground */
 
     --highlight: 43.9 84.2% 65.3%; /* #F1C95C */
   }

--- a/deliverables/F2/PWA/app/src/index.css
+++ b/deliverables/F2/PWA/app/src/index.css
@@ -2,24 +2,66 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Design tokens — Verde Manual.
+ * See ../DESIGN.md for the full system, palette rationale, and DOH brand caveats.
+ * Hex values are best-fit approximations of the DOH "Verde Vision" palette;
+ * refine when the official brand-book PDF is available.
+ */
+
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --primary: 173 80% 26%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --ring: 173 80% 26%;
-    --radius: 0.5rem;
+    /* Surfaces */
+    --background: 85.7 25.9% 94.7%; /* #F2F5EE paper */
+    --foreground: 120 8.8% 11.2%; /* #1A1F1A ink */
+    --muted: 86 24% 92%; /* slightly darker paper tint */
+    --muted-foreground: 120 5.8% 37.5%; /* #5A655A */
+    --secondary: 86 24% 92%;
+    --secondary-foreground: 120 8.8% 11.2%;
+    --accent: 86 24% 92%;
+    --accent-foreground: 120 8.8% 11.2%;
+
+    /* Lines */
+    --border: 88.7 15.4% 70.8%; /* #B5C0A9 hairline */
+    --input: 88.7 15.4% 70.8%;
+    --ring: 155.3 100% 21%; /* signal — focus ring */
+
+    /* Signal — DOH emerald */
+    --primary: 155.3 100% 21%; /* #006B3F */
+    --primary-foreground: 85.7 25.9% 94.7%;
+
+    /* Destructive — cherry red, references the cross at the seal's center */
+    --destructive: 0 70.2% 42.2%; /* #B72020 */
+    --destructive-foreground: 85.7 25.9% 94.7%;
+
+    /* Highlight — DOH yellow inner rim. Used very sparingly (save toasts only).
+     * Not yet bound to a Tailwind utility; consume via hsl(var(--highlight)). */
+    --highlight: 42 76.6% 56.5%; /* #E5B23B */
+
+    /* Radius — Verde Manual caps at 4px; default is 2px */
+    --radius: 0.25rem;
+  }
+
+  .dark {
+    --background: 132 14.3% 6.9%; /* #0F1410 graphite */
+    --foreground: 90 20% 86.3%; /* #DCE3D5 */
+    --muted: 120 6% 12%;
+    --muted-foreground: 120 4.2% 52.9%; /* #828C82 */
+    --secondary: 120 6% 12%;
+    --secondary-foreground: 90 20% 86.3%;
+    --accent: 120 6% 12%;
+    --accent-foreground: 90 20% 86.3%;
+
+    --border: 109.1 12.1% 17.8%; /* #2A3328 */
+    --input: 109.1 12.1% 17.8%;
+    --ring: 155 55.1% 36.7%;
+
+    --primary: 155 55.1% 36.7%; /* #2A9166 — emerald shifted brighter for dark */
+    --primary-foreground: 90 20% 86.3%;
+
+    --destructive: 1.7 62.7% 56.9%; /* #D6504C */
+    --destructive-foreground: 90 20% 86.3%;
+
+    --highlight: 43.9 84.2% 65.3%; /* #F1C95C */
   }
 }
 

--- a/deliverables/F2/PWA/app/tailwind.config.ts
+++ b/deliverables/F2/PWA/app/tailwind.config.ts
@@ -43,6 +43,20 @@ export default {
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
       },
+      fontFamily: {
+        // Verde Manual. See DESIGN.md.
+        // `serif` overrides the Tailwind default so `font-serif` resolves to Newsreader.
+        serif: ['Newsreader', 'Georgia', '"Times New Roman"', 'serif'],
+        sans: [
+          'Public Sans',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          '"Segoe UI"',
+          'Roboto',
+          'sans-serif',
+        ],
+        mono: ['"JetBrains Mono"', '"SF Mono"', 'Menlo', 'Consolas', 'monospace'],
+      },
     },
   },
   plugins: [tailwindcssAnimate],

--- a/deliverables/F2/PWA/app/tailwind.config.ts
+++ b/deliverables/F2/PWA/app/tailwind.config.ts
@@ -12,30 +12,36 @@ export default {
     },
     extend: {
       colors: {
-        border: 'hsl(var(--border))',
-        input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
+        // Alpha-aware HSL slot syntax. Lets utilities like `bg-primary/10`,
+        // `border-l-warning`, `bg-destructive/10` resolve through --alpha-value.
+        border: 'hsl(var(--border) / <alpha-value>)',
+        input: 'hsl(var(--input) / <alpha-value>)',
+        ring: 'hsl(var(--ring) / <alpha-value>)',
+        background: 'hsl(var(--background) / <alpha-value>)',
+        foreground: 'hsl(var(--foreground) / <alpha-value>)',
         primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
+          DEFAULT: 'hsl(var(--primary) / <alpha-value>)',
+          foreground: 'hsl(var(--primary-foreground) / <alpha-value>)',
         },
         secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
+          DEFAULT: 'hsl(var(--secondary) / <alpha-value>)',
+          foreground: 'hsl(var(--secondary-foreground) / <alpha-value>)',
         },
         destructive: {
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))',
+          DEFAULT: 'hsl(var(--destructive) / <alpha-value>)',
+          foreground: 'hsl(var(--destructive-foreground) / <alpha-value>)',
         },
         muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
+          DEFAULT: 'hsl(var(--muted) / <alpha-value>)',
+          foreground: 'hsl(var(--muted-foreground) / <alpha-value>)',
         },
         accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
+          DEFAULT: 'hsl(var(--accent) / <alpha-value>)',
+          foreground: 'hsl(var(--accent-foreground) / <alpha-value>)',
+        },
+        warning: {
+          DEFAULT: 'hsl(var(--warning) / <alpha-value>)',
+          foreground: 'hsl(var(--warning-foreground) / <alpha-value>)',
         },
       },
       borderRadius: {

--- a/deliverables/F2/PWA/app/vite.config.ts
+++ b/deliverables/F2/PWA/app/vite.config.ts
@@ -41,6 +41,27 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,svg,png,ico,webmanifest}'],
         navigateFallback: '/index.html',
         cleanupOutdatedCaches: true,
+        // Verde Manual fonts. See DESIGN.md. CDN now, self-host follow-up.
+        // CSS = StaleWhileRevalidate (refresh when online); woff2 = CacheFirst.
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/fonts\.bunny\.net\/css/,
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'bunny-fonts-css',
+              expiration: { maxEntries: 5, maxAgeSeconds: 60 * 60 * 24 * 365 },
+            },
+          },
+          {
+            urlPattern: /^https:\/\/fonts\.bunny\.net\/.*\.(woff2?|ttf|otf)$/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'bunny-fonts-files',
+              expiration: { maxEntries: 30, maxAgeSeconds: 60 * 60 * 24 * 365 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+        ],
       },
       devOptions: {
         enabled: false,

--- a/deliverables/F2/PWA/app/vite.config.ts
+++ b/deliverables/F2/PWA/app/vite.config.ts
@@ -23,8 +23,8 @@ export default defineConfig({
         scope: '/',
         display: 'standalone',
         orientation: 'portrait',
-        theme_color: '#0f766e',
-        background_color: '#ffffff',
+        theme_color: '#006B3F',
+        background_color: '#F2F5EE',
         lang: 'en',
         icons: [
           { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png' },


### PR DESCRIPTION
## Summary

Ports the Verde Manual visual-identity migration onto `main` (production) **without the auth re-arch**. Lets production at `f2-pwa.pages.dev` adopt the new design while the auth re-arch continues to soak on staging per Phase F's gate.

This is **Path B** from tonight's deploy-decision discussion: Verde-only prod track, two diverged branches until Phase F merges them.

## What's in here

7 commits cherry-picked from `staging`, in order:

| Commit | What | Conflicts |
|---|---|---|
| `2a2f753` | chore: add gstack skill routing rules to `CLAUDE.md` | none |
| `86ec68f` | feat(F2 PWA): add `DESIGN.md` (Verde Manual, DOH-anchored) | none |
| `d92a6de` | feat(F2 PWA): migrate design tokens to Verde Manual (was #37) | none |
| `54a2cbb` | feat(F2 PWA): wire up Verde Manual fonts via Bunny CDN + SW cache (was #38) | none |
| `86f7adb` | feat(F2 PWA): apply Verde Manual layout & components (was #39) | **resolved**: 2 files |
| `90e9f45` | feat(F2 PWA): close DESIGN-006 (was #40) | none |
| `bede7e3` | feat(F2 PWA): polish PR3 punts (was #41) | **resolved**: 1 file |

## Conflict resolutions

### `src/App.tsx`
The conflict was the h1/version-subtitle styling. Verde version applied cleanly: `font-serif text-2xl font-medium tracking-tight` h1 + `font-mono text-xs ... text-muted-foreground` version subtitle.

### `src/components/enrollment/EnrollmentScreen.tsx`
**Important divergence.** Staging's PR #39 had Verde edits to the **two-step (token + identity)** EnrollmentScreen from the auth re-arch (PR #31). `main`'s EnrollmentScreen is the **single-step (HCW ID + facility select)** pre-auth-rearch version.

Resolution: kept main's single-step logic (the auth-rearch state variables `tokenInput`/`verifiedToken`/`handleVerifyToken` don't exist here), and applied **Verde styling intent** to the existing single-step component:
- h2: `text-2xl font-semibold tracking-tight` → `font-serif text-2xl font-medium tracking-tight`
- error: `text-red-600` → `text-destructive`
- Inputs already had `rounded-md border-input` (token-friendly) on main — preserved
- "Kill the card" wasn't applicable — main's single-step has no card wrappers to kill

### `src/components/ui/button.tsx`
Conflict in disabled-state utilities:
- main had `disabled:opacity-50` (Tailwind/shadcn default)
- Verde polish had `disabled:bg-muted disabled:text-muted-foreground disabled:hover:bg-muted` (token-based)

Took the Verde version for design-system consistency.

## What this PR DOES NOT include

- **Auth re-arch (PR #31)** — the Worker JWT proxy stays on staging. Production keeps its existing HMAC-based sync path (`hmacSha256Hex`, `hmacSecret`, `hmacSign` in `App.tsx`).
- **Auth-rearch hot-fix (PR #32)**.
- **Two-step token-verify Enroll flow** — production stays single-step.

The auth re-arch will land on production via Phase F (gated on ≥24hr clean staging soak + Issue #33/#34 resolved).

## What ships to production after merge

- DOH emerald primary (`#006B3F`) replacing teal (`#0f766e`)
- Pale verde paper (`#F2F5EE`) replacing pure white
- Newsreader serif on h1/h2 chrome
- Public Sans Variable on body
- JetBrains Mono on version subtitle + section eyebrows + ledger progress
- Hairline-divided forms (kill-the-card)
- Marginal mono question numbers (80px gutter, stacks above on mobile)
- Typographic ledger progress (replaces graphical bar)
- Cherry-red destructive (`#B72020`) referencing the cross at the seal's center
- Warning ochre (`#C68A2E`) on PendingCount/BroadcastBanner/ReviewSection warn alerts
- Flat buttons (no shadow), hairline-edged modals, softer floating nav arrows
- Manifest `theme_color` `#0f766e` → `#006B3F`, `background_color` `#ffffff` → `#F2F5EE`
- All raw `text-red-*`/`text-green-*` Tailwind utilities swept to `text-destructive`/`text-primary`

## Validation

- ✅ `npm run typecheck` clean
- ✅ `npm run lint` 0 errors (6 pre-existing warnings unchanged)
- ✅ `npm run test` 307/307 passing (one fewer than staging because main has 1 different test file vs staging — no regressions, just different baseline)
- ✅ `npm run build` succeeds in 2.79s — Tailwind alpha-aware syntax accepted
- ✅ Visual smoke on dev server: `--primary: 155.3 100% 21%` (DOH emerald), `--warning: 36.3 62.3% 47.8%` (ochre), body bg `rgb(242, 245, 238)` (Verde paper), h1 `font-family: Newsreader`. Pre-auth-rearch single-step Enroll form renders correctly with Verde styling applied.

## Two diverged branches until Phase F

Until the auth re-arch lands on prod via Phase F, `staging` will be ahead of `main` by:
- The auth re-arch (PR #31) + hot-fix (PR #32)
- The auth-rearch's two-step EnrollmentScreen (vs main's single-step + Verde)
- Any subsequent staging-only fixes (#33, #34, etc.)

When Phase F merges staging → main, the EnrollmentScreen will need a final reconciliation: take the auth-rearch two-step structure AND the Verde styling. The Verde styling pieces are already in PR #39's diff (which applies to the staging EnrollmentScreen), so the merge should resolve cleanly — `main`'s simpler version will be replaced wholesale by staging's auth-rearch + Verde version.

## Test plan

- [ ] Pull, `npm run dev`, verify on `localhost:5173`:
  - Title in Newsreader serif, version in JetBrains Mono
  - Single-step Enroll (HCW ID + Facility, NO token verify step — that's the staging version)
  - DOH emerald primary visible on the Enroll button
  - Pale verde paper background
- [ ] Squash-merge → CF Pages auto-deploys to `f2-pwa.pages.dev`
- [ ] Visit production URL, verify Verde Manual is live for real users

## Closes

This unblocks Carl's "see the new design in prod" goal without bypassing the Phase F soak gate on the auth re-arch. Verde Manual ships to prod; the auth re-arch waits its turn.