### PR TITLE
fix(survey): multi-select state pollution across questions (#33)

### DIFF
--- a/deliverables/F2/PWA/app/src/components/survey/Question.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Question.tsx
@@ -221,12 +221,22 @@ function renderControl(
         </div>
       );
     case 'multi': {
-      // Controlled checkboxes — exclusivity ("I don't know") and select-all
-      // ("All of the above") rules computed via nextMultiValue().
+      // Fully controlled checkboxes. Exclusivity ("I don't know") and
+      // select-all ("All of the above") rules are computed in nextMultiValue().
+      //
+      // Issue #33: do NOT attach RHF's `name`/`ref` (from register()) to
+      // these checkbox inputs. When several inputs share a single `name`,
+      // RHF treats them as a checkbox group and re-derives the field value
+      // from the DOM during its internal updateValid pass — which fires on
+      // *any* other field's change. That re-derivation clobbers the array
+      // we set via setValue() back to `false`/`[]`, wiping previous
+      // selections when the user answers a different question in the same
+      // section. We register the field (so dirty/validation state is
+      // tracked) but bind the ref to a focus-only sentinel (the first
+      // checkbox carries `id={item.id}` so the question's <label> still
+      // focuses it on click).
       const selected: string[] = Array.isArray(currentValue) ? (currentValue as string[]) : [];
       const allChoices = choices ?? [];
-      // Register the array field so RHF knows about it (default value handling
-      // + form lifecycle), but skip the rendered input via `style: hidden`.
       const reg = register(item.id);
       return (
         <div className="flex flex-col gap-1">
@@ -244,10 +254,8 @@ function renderControl(
                       const next = nextMultiValue(selected, choice, e.target.checked, allChoices);
                       onChange(next);
                     }}
-                    onBlur={reg.onBlur}
-                    {...(idx === 0
-                      ? { id: item.id, ref: reg.ref, name: reg.name }
-                      : { name: reg.name })}
+                    onBlur={idx === 0 ? reg.onBlur : undefined}
+                    {...(idx === 0 ? { id: item.id, ref: reg.ref } : {})}
                   />
                   {localized(choice.label, locale)}
                 </label>

--- a/deliverables/F2/PWA/app/src/components/survey/Section.cross-question.test.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Section.cross-question.test.tsx
@@ -1,0 +1,168 @@
+// Regression repro for Issue #33 — multi-select / matrix state pollution across
+// questions in the same section. Surfaced during 2026-04-26 cutover smoke test.
+//
+// Hypothesis pool (none confirmed at write time):
+//  H1: register(item.id) re-call on Question re-render resets multi-select array
+//  H2: matrix grouping (Q75-Q81 in G) shares state via the radio-name mechanism
+//  H3: nextMultiValue closure captures stale `selected` when Question re-renders
+//  H4: visibleChoices recomputation orphans previously-selected values
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { z } from 'zod';
+import type * as React from 'react';
+import type { Section as SectionModel } from '@/types/survey';
+import { LocaleProvider } from '@/i18n/locale-context';
+import { Section } from './Section';
+
+const dual = (en: string) => ({ en, fil: en });
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(<LocaleProvider>{ui}</LocaleProvider>);
+}
+
+// Note: MatrixQuestion renders BOTH desktop <table> and mobile <div> in jsdom
+// (media queries are not applied), so radios with the same aria-label appear
+// twice. Pick by index via getAllByLabelText to disambiguate.
+
+describe('<Section> cross-question state isolation (Issue #33)', () => {
+  // Section F-style fixture: multi-select with distinct choice labels per item
+  // so getByLabelText is unambiguous.
+  const sectionF: SectionModel = {
+    id: 'F',
+    title: dual('Referrals'),
+    items: [
+      {
+        id: 'Q56',
+        section: 'F',
+        type: 'multi',
+        required: true,
+        label: dual('How do you SEND referrals?'),
+        choices: [
+          { label: dual('Send-Slip'), value: 'Send-Slip' },
+          { label: dual('Send-EReferral'), value: 'Send-EReferral' },
+          { label: dual('Send-Phone'), value: 'Send-Phone' },
+        ],
+      },
+      {
+        id: 'Q57',
+        section: 'F',
+        type: 'single',
+        required: true,
+        label: dual('Form type?'),
+        choices: [
+          { label: dual('DOH-standard'), value: 'DOH-standard' },
+          { label: dual('No-standard'), value: 'No-standard' },
+        ],
+      },
+      {
+        id: 'Q60',
+        section: 'F',
+        type: 'multi',
+        required: true,
+        label: dual('How do you RECEIVE referrals?'),
+        choices: [
+          { label: dual('Recv-Slip'), value: 'Recv-Slip' },
+          { label: dual('Recv-EReferral'), value: 'Recv-EReferral' },
+          { label: dual('Recv-Phone'), value: 'Recv-Phone' },
+        ],
+      },
+    ],
+  };
+
+  const fSchema = z.object({
+    Q56: z.array(z.string()).min(1),
+    Q57: z.string().min(1),
+    Q60: z.array(z.string()).min(1),
+  });
+
+  it('Q56 multi-select retains selections after answering Q57 single', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Section section={sectionF} schema={fSchema} onSubmit={() => {}} />);
+
+    const slip = screen.getByLabelText('Send-Slip') as HTMLInputElement;
+    const eref = screen.getByLabelText('Send-EReferral') as HTMLInputElement;
+    await user.click(slip);
+    await user.click(eref);
+    expect(slip.checked).toBe(true);
+    expect(eref.checked).toBe(true);
+
+    await user.click(screen.getByLabelText('DOH-standard'));
+
+    expect(slip.checked).toBe(true);
+    expect(eref.checked).toBe(true);
+  });
+
+  it('Q56 retains selections after toggling another multi-select Q60', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Section section={sectionF} schema={fSchema} onSubmit={() => {}} />);
+
+    const q56Slip = screen.getByLabelText('Send-Slip') as HTMLInputElement;
+    const q56Eref = screen.getByLabelText('Send-EReferral') as HTMLInputElement;
+    await user.click(q56Slip);
+    await user.click(q56Eref);
+    expect(q56Slip.checked).toBe(true);
+    expect(q56Eref.checked).toBe(true);
+
+    const q60Phone = screen.getByLabelText('Recv-Phone') as HTMLInputElement;
+    await user.click(q60Phone);
+    expect(q60Phone.checked).toBe(true);
+
+    expect(q56Slip.checked).toBe(true);
+    expect(q56Eref.checked).toBe(true);
+  });
+
+  // Section G fixture: 4 single-type rating items with shared 1-5 choices.
+  // groupVisibleItems will collapse them into a matrix because they're all
+  // `single` with the same choice values.
+  const sectionG: SectionModel = {
+    id: 'G',
+    title: dual('KAP'),
+    items: ['Q75', 'Q76', 'Q77', 'Q78'].map((id) => ({
+      id,
+      section: 'G',
+      type: 'single' as const,
+      required: true,
+      label: dual(`${id} rating?`),
+      choices: ['1', '2', '3', '4', '5'].map((v) => ({ label: dual(v), value: v })),
+    })),
+  };
+
+  const gSchema = z.object({
+    Q75: z.string().min(1),
+    Q76: z.string().min(1),
+    Q77: z.string().min(1),
+    Q78: z.string().min(1),
+  });
+
+  it('Q75 matrix radio retains selection after answering Q76 (matrix-grouped)', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Section section={sectionG} schema={gSchema} onSubmit={() => {}} />);
+
+    // Desktop matrix is the first occurrence (rendered before mobile in MatrixQuestion).
+    const q75Three = screen.getAllByLabelText(/Q75 3/)[0] as HTMLInputElement;
+    const q76Five = screen.getAllByLabelText(/Q76 5/)[0] as HTMLInputElement;
+
+    await user.click(q75Three);
+    expect(q75Three.checked).toBe(true);
+
+    await user.click(q76Five);
+    expect(q76Five.checked).toBe(true);
+
+    expect(q75Three.checked).toBe(true);
+  });
+
+  it('Q75 retains selection after answering Q77 then Q78 (longer matrix sequence)', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Section section={sectionG} schema={gSchema} onSubmit={() => {}} />);
+
+    const q75Three = screen.getAllByLabelText(/Q75 3/)[0] as HTMLInputElement;
+    await user.click(q75Three);
+    expect(q75Three.checked).toBe(true);
+
+    await user.click(screen.getAllByLabelText(/Q77 4/)[0]);
+    await user.click(screen.getAllByLabelText(/Q78 2/)[0]);
+
+    expect(q75Three.checked).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #33.

## Summary
- Drop `name={reg.name}` from every multi-select checkbox; keep `id={item.id}` + `ref={reg.ref}` + `onBlur` on the first only. The field is still RHF-registered via `register(item.id)`; the array is fully managed by our existing controlled `checked={selected.includes(...)}` + custom `onChange → setValue` path.
- Add `Section.cross-question.test.tsx` — 4 regression tests covering F multi-selects (Q56→Q57, Q56→Q60) and G matrix radios (Q75→Q76, Q75→Q77→Q78).

## Root cause
Each checkbox in a multi-select shared `name={item.id}`. RHF's checkbox-group handling re-derives the field value from the DOM during its internal `updateValid` pass — which fires on *any* other field's onChange. With a single ref'd checkbox in the "group", RHF reads `target.checked` (boolean) and clobbers the array we wrote via `setValue`, wiping previous selections. Section F multi-selects (Q56 / Q60 / Q62) lost all state any time the user answered a different question in the section; Section G's matrix radios were unaffected because radios use `target.value`, not the boolean re-read path.

## Test plan
- [x] `npm test` — full vitest suite 312/312 green (vs 307/308 baseline; +4 new tests, +1 unrelated flake cleared)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (1 pre-existing warning unrelated to this change)
- [ ] Manual smoke on staging after merge: walk Section F, select 2 options in Q56, answer Q57, return to Q56 — selections must still be checked. Same for Section G's Q75–Q81 matrix.

## Phase F implication
This is one of two gating issues for the F2 PWA auth re-arch production cutover (the other is #34). Once both close and a 24 h clean staging soak holds, Phase F unblocks per `docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md`.