### PR TITLE
chore(ci): replace CF Pages auto-deploy with GitHub Actions wrangler workflow (#34)

### DIFF
--- a/.github/workflows/cf-pages-deploy.yml
+++ b/.github/workflows/cf-pages-deploy.yml
@@ -1,0 +1,62 @@
+name: CF Pages deploy — F2 PWA
+
+# Replaces Cloudflare Pages' native git-integration auto-deploy, which is
+# broken on this account (Issue #34: `wrangler pages project list` shows
+# `Git Provider: No` for both projects, so pushes to staging/main don't
+# trigger any build). Until/unless the dashboard integration is restored,
+# this workflow IS the deploy mechanism.
+#
+# Triggers on push to staging/main only — not on PRs (deploys must be
+# of merged code). Gated on the CI workflow succeeding via `workflow_run`
+# so we don't ship a build that failed typecheck/lint/tests.
+
+on:
+  workflow_run:
+    workflows: ["CI — F2 PWA"]
+    types: [completed]
+    branches: [main, staging]
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: deliverables/F2/PWA/app/package-lock.json
+
+      - name: Install
+        working-directory: deliverables/F2/PWA/app
+        run: npm ci
+
+      - name: Build
+        working-directory: deliverables/F2/PWA/app
+        run: npm run build
+
+      - name: Resolve project name from branch
+        id: project
+        run: |
+          if [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
+            echo "name=f2-pwa" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=f2-pwa-staging" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: deliverables/F2/PWA/app
+          command: pages deploy dist --project-name=${{ steps.project.outputs.name }} --branch=${{ github.event.workflow_run.head_branch }} --commit-hash=${{ github.event.workflow_run.head_sha }}

--- a/docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md
+++ b/docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md
@@ -254,13 +254,35 @@ Or merge via GitHub UI if you prefer.
 
 ### D.4 — Watch the Cloudflare Pages deploy
 
+CF Pages' native git integration is broken on this account (Issue #34 —
+`wrangler pages project list` shows `Git Provider: No`). The `CF Pages
+deploy — F2 PWA` GitHub Actions workflow at
+`.github/workflows/cf-pages-deploy.yml` is the deploy mechanism: it runs
+`wrangler pages deploy` after CI succeeds on push to staging/main. Watch:
+
 ```bash
-# Cloudflare Pages auto-deploys on push to staging branch.
-# Watch the deploy via the dashboard or:
-gh run watch
+# Watch the most recent run on this branch.
+gh run watch --exit-status
 ```
 
-Wait until staging shows the new deploy is live (~3 min). The Pages URL is `https://f2-pwa-staging.pages.dev` per `wiki/sources` notes (or whatever's in your Cloudflare Pages config).
+The workflow needs `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repo
+secrets (see Settings → Secrets → Actions). If the deploy step fails with
+an auth error, those are missing or wrong.
+
+Wait until staging shows the new deploy is live (~4–6 min: CI + build +
+deploy). The Pages URL is `https://f2-pwa-staging.pages.dev` per
+`wiki/sources` notes (or whatever's in your Cloudflare Pages config).
+
+**Fallback if GitHub Actions is unavailable** (account suspension, action
+quota, network issue): manual `wrangler pages deploy` works the same way.
+From `deliverables/F2/PWA/app/`:
+
+```bash
+npm ci && npm run build
+npx wrangler pages deploy dist --project-name=f2-pwa-staging --branch=staging --commit-hash=$(git rev-parse HEAD)
+```
+
+(For production cutover: `--project-name=f2-pwa --branch=main`.)
 
 ### D.5 — STOP YOUR STOPWATCH
 


### PR DESCRIPTION
Closes #34.

## Summary
- Add `.github/workflows/cf-pages-deploy.yml` — runs after CI succeeds on push to main/staging, builds, calls `wrangler pages deploy` against the matching project. Replaces CF Pages' broken native git-integration auto-deploy.
- Update Phase D.4 of `docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md` to document the new flow plus a manual `wrangler pages deploy` fallback for when GitHub Actions is unavailable.

## Why a CI workflow instead of reconnecting the CF dashboard
\`wrangler pages project list\` confirms \`Git Provider: No\` for both \`f2-pwa\` and \`f2-pwa-staging\` — pushes to staging/main fire nothing. We could try to reconnect the dashboard, but the same opaque Cloudflare↔GitHub bridge just failed silently with no signal we'd notice in time for Phase F. Owning the deploy in CI is durable: we control the trigger, the build env, and the auth token; failures show up in Actions runs, not in someone manually noticing the staging URL is stale.

## Required follow-up before this workflow can run
**Repo Settings → Secrets and variables → Actions → New repository secret:**
- \`CLOUDFLARE_API_TOKEN\` — scoped to *Cloudflare Pages: Edit* on this account. (Create at https://dash.cloudflare.com/profile/api-tokens.)
- \`CLOUDFLARE_ACCOUNT_ID\` — visible top-right of the CF dashboard or via \`wrangler whoami\`.

Without these the workflow runs but the deploy step fails with an auth error.

## Test plan
- [ ] Add the two repo secrets above
- [ ] Merge this PR
- [ ] First push to staging after merge: confirm \`gh run list --workflow="CF Pages deploy — F2 PWA"\` shows a successful run within ~5 min
- [ ] Verify the deploy is live at \`f2-pwa-staging.pages.dev\` with the new commit SHA
- [ ] Repeat for main when the next prod release lands

## Phase F implication
This is the second of two gating issues for the F2 PWA auth re-arch production cutover (the other is #33). Once both close and a 24 h clean staging soak holds, Phase F unblocks per the auth cutover runbook. Note: this PR doesn't *do* Phase F — it just unblocks the deploy mechanism Phase F depends on.