### PR TITLE
fix(worker): cap PBKDF2 iterations at 100k for Cloudflare Workers (#35)

### DIFF
--- a/deliverables/F2/PWA/worker/scripts/hash-admin-password.mjs
+++ b/deliverables/F2/PWA/worker/scripts/hash-admin-password.mjs
@@ -8,11 +8,19 @@
  *
  * Output format: <saltB64url>:<iterations>:<hashB64url>
  * Verifier in the Worker is in src/admin.ts (verifyAdminPassword).
+ *
+ * Iteration count: capped at 100,000 because Cloudflare Workers'
+ * `crypto.subtle.deriveBits` rejects PBKDF2 above 100k with
+ * `NotSupportedError`. This is below NIST 2023's 600k recommendation, but
+ * required by the Workers runtime — see Issue #35 and the comment on
+ * `MAX_PBKDF2_ITERS` in `worker/src/admin.ts`. The verifier mirrors this
+ * cap and rejects any stored hash above it, so don't bump this value
+ * without coordinating both sides.
  */
 import { webcrypto } from 'node:crypto';
 import readline from 'node:readline';
 
-const ITERATIONS = 600_000;
+const ITERATIONS = 100_000;
 
 function b64url(bytes) {
   return Buffer.from(bytes).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');

--- a/deliverables/F2/PWA/worker/src/admin.ts
+++ b/deliverables/F2/PWA/worker/src/admin.ts
@@ -15,7 +15,12 @@ const ADMIN_SESSION_TABLET_ID = '__admin_session__';
 
 // ---------- Password hashing (PBKDF2-SHA256) ----------
 
-const PBKDF2_DEFAULT_ITERS = 600_000;
+// Cloudflare Workers caps `crypto.subtle.deriveBits` PBKDF2 iterations at 100,000;
+// values above throw `NotSupportedError: iteration counts above 100000 are not supported`
+// at runtime. NIST 2023 recommends 600k for SHA-256 — we accept 100k below that bar
+// because (a) admin password is high-entropy + rate-limited at the Worker, and
+// (b) anything higher silently soft-bricks `/admin/login`. Issue #35 tracked this.
+export const MAX_PBKDF2_ITERS = 100_000;
 
 function b64urlEncode(bytes: Uint8Array): string {
   let s = '';
@@ -53,13 +58,20 @@ async function pbkdf2Derive(password: string, salt: Uint8Array, iterations: numb
  * Verify a plaintext admin password against the stored hash.
  * Stored format: `<saltB64url>:<iterations>:<hashB64url>`.
  * Note: spec §7.3 says "bcrypt"; we use PBKDF2-SHA256 because it's native to Workers.
+ *
+ * Returns false (without throwing) for malformed hashes, iteration counts below
+ * the 10k floor, or iteration counts above the Workers cap (`MAX_PBKDF2_ITERS`).
+ * The Workers-cap check is a fail-fast guard: if a future operator generates a
+ * hash with too-high iterations and ships it as the secret, login fails cleanly
+ * rather than throwing `NotSupportedError` mid-request.
  */
-async function verifyAdminPassword(plaintext: string, storedHash: string): Promise<boolean> {
+export async function verifyAdminPassword(plaintext: string, storedHash: string): Promise<boolean> {
   const parts = storedHash.split(':');
   if (parts.length !== 3) return false;
   const [saltB64, iterStr, expectedB64] = parts as [string, string, string];
   const iterations = parseInt(iterStr, 10);
   if (!iterations || iterations < 10_000) return false;
+  if (iterations > MAX_PBKDF2_ITERS) return false;
   const salt = b64urlDecode(saltB64);
   const expected = b64urlDecode(expectedB64);
   const actual = await pbkdf2Derive(plaintext, salt, iterations);

--- a/deliverables/F2/PWA/worker/test/admin-pbkdf2.test.ts
+++ b/deliverables/F2/PWA/worker/test/admin-pbkdf2.test.ts
@@ -1,0 +1,78 @@
+/**
+ * verifyAdminPassword tests — Issue #35.
+ *
+ * Cloudflare Workers caps `crypto.subtle.deriveBits` PBKDF2 iterations at 100,000;
+ * values above throw NotSupportedError at runtime. The verifier is built to fail
+ * fast (return false, not throw) when a stored hash claims iterations above
+ * `MAX_PBKDF2_ITERS`, so a misconfigured secret degrades to "login denied"
+ * instead of "Internal Worker error".
+ *
+ * Note: Node's webcrypto in vitest does NOT enforce the 100k cap — it'll happily
+ * deriveBits at 600k. So we can't test "Workers throws on 600k" directly; instead
+ * we test the verifier's stored-iterations ceiling check, which makes the cap a
+ * test-enforced contract regardless of runtime.
+ */
+import { describe, expect, it } from 'vitest';
+import { webcrypto } from 'node:crypto';
+import { verifyAdminPassword, MAX_PBKDF2_ITERS } from '../src/admin';
+
+function b64url(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+async function makeHash(password: string, iterations: number): Promise<string> {
+  const salt = webcrypto.getRandomValues(new Uint8Array(16));
+  const baseKey = await webcrypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(password),
+    'PBKDF2',
+    false,
+    ['deriveBits'],
+  );
+  const bits = await webcrypto.subtle.deriveBits(
+    { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' },
+    baseKey,
+    256,
+  );
+  return `${b64url(salt)}:${iterations}:${b64url(new Uint8Array(bits))}`;
+}
+
+describe('verifyAdminPassword — Issue #35 PBKDF2 cap', () => {
+  it('verifies a 100k-iter hash for the correct password', async () => {
+    const stored = await makeHash('correct-password-123', 100_000);
+    expect(await verifyAdminPassword('correct-password-123', stored)).toBe(true);
+  });
+
+  it('rejects the wrong password against a 100k-iter hash', async () => {
+    const stored = await makeHash('correct-password-123', 100_000);
+    expect(await verifyAdminPassword('wrong-password', stored)).toBe(false);
+  });
+
+  it('rejects a hash with iterations above MAX_PBKDF2_ITERS without throwing', async () => {
+    // Generate a 600k hash with Node crypto (which has no cap), then prove the
+    // verifier refuses to attempt deriveBits against it (Workers would throw).
+    const stored = await makeHash('correct-password-123', 600_000);
+    expect(MAX_PBKDF2_ITERS).toBe(100_000);
+    expect(await verifyAdminPassword('correct-password-123', stored)).toBe(false);
+  });
+
+  it('rejects iterations below the 10k floor', async () => {
+    const stored = await makeHash('correct-password-123', 9_999);
+    expect(await verifyAdminPassword('correct-password-123', stored)).toBe(false);
+  });
+
+  it('rejects malformed hash strings', async () => {
+    expect(await verifyAdminPassword('any', 'no-colons')).toBe(false);
+    expect(await verifyAdminPassword('any', 'a:b')).toBe(false);
+    expect(await verifyAdminPassword('any', 'a:notanumber:c')).toBe(false);
+    expect(await verifyAdminPassword('any', '')).toBe(false);
+  });
+
+  it('rejects iterations of 0 (parseInt edge case)', async () => {
+    expect(await verifyAdminPassword('any', 'salt:0:hash')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #35.

## Summary
- `hash-admin-password.mjs` ITERATIONS 600_000 → 100_000 (Workers cap)
- `admin.ts` replaces dead `PBKDF2_DEFAULT_ITERS = 600_000` with exported `MAX_PBKDF2_ITERS = 100_000`; `verifyAdminPassword` rejects stored hashes above the cap (fail-fast guard)
- New `test/admin-pbkdf2.test.ts` — 6 tests (100k round-trip, wrong password, ceiling guard, 10k floor, malformed strings, parseInt(0) edge case)

## Why
Workers' `crypto.subtle.deriveBits` rejects PBKDF2 above 100k with `NotSupportedError`. The 600k script default soft-bricked `/admin/login` twice this engagement — once during the 2026-04-26 cutover, once during today's 2026-04-30 staging smoke test. Both required manual recovery.

## Test plan
- [x] `npm test -- --run` worker — 21/21 green (4 existing + 6 new)
- [x] Existing 100k hashes still verify (cap check is `>`, not `>=`)
- [x] Phase F runbook A.6 ("repeat A.1–A.7 for production worker") now works as written without the 100k workaround

## Phase F implication
Removes one of the three Phase F readiness gaps surfaced by today's smoke test. The other two are tracked separately as #45 (env var stale) and #46 (enroll button no-op).