### PR TITLE
fix(build): assert VITE_F2_PROXY_URL on production build (#45)

### DIFF
--- a/.github/workflows/cf-pages-deploy.yml
+++ b/.github/workflows/cf-pages-deploy.yml
@@ -42,6 +42,10 @@ jobs:
 
       - name: Build
         working-directory: deliverables/F2/PWA/app
+        # VITE_F2_PROXY_URL is the post-auth-rearch worker origin (Issue #45).
+        # vite.config.ts fails the build fast if it's missing or REPLACE_ME.
+        env:
+          VITE_F2_PROXY_URL: ${{ secrets.VITE_F2_PROXY_URL }}
         run: npm run build
 
       - name: Resolve project name from branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
         run: npm test
 
       - name: Build (includes bundle-secrets check)
+        # vite.config.ts now requires VITE_F2_PROXY_URL on production builds
+        # (Issue #45). The staging Worker URL is public — fine to hardcode
+        # for CI build verification. Real deploys (cf-pages-deploy.yml)
+        # read from the repo secret.
+        env:
+          VITE_F2_PROXY_URL: https://f2-pwa-worker.hcw.workers.dev
         run: npm run build
 
   worker:

--- a/deliverables/F2/PWA/app/.env.example
+++ b/deliverables/F2/PWA/app/.env.example
@@ -3,6 +3,10 @@
 # Cloudflare Worker origin. Per-tablet device tokens are stored in IndexedDB,
 # not in the build environment, and are issued by ASPSI ops via the Worker's
 # /admin/ UI.
+#
+# REQUIRED for production builds. `npm run build` fails fast if
+# VITE_F2_PROXY_URL is unset or still the REPLACE_ME placeholder (Issue #45).
+# Vitest / dev mode are unaffected.
 
 # Cloudflare Worker origin. No trailing slash.
 VITE_F2_PROXY_URL=https://f2-pwa-worker.REPLACE_ME.workers.dev

--- a/deliverables/F2/PWA/app/vite.config.ts
+++ b/deliverables/F2/PWA/app/vite.config.ts
@@ -1,11 +1,30 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 import { visualizer } from 'rollup-plugin-visualizer';
 import path from 'node:path';
 import pkg from './package.json' with { type: 'json' };
 
-export default defineConfig({
+// Build-time guard for required env vars (Issue #45). Production builds without
+// VITE_F2_PROXY_URL silently embed an unset value and the deployed PWA renders
+// a "VITE_F2_PROXY_URL is not set" error at the enrollment screen — broken for
+// every user. Caught at build now so it can't slip through to deploy.
+function assertRequiredEnv(mode: string): void {
+  if (mode !== 'production') return;
+  const env = loadEnv(mode, __dirname, '');
+  if (!env.VITE_F2_PROXY_URL || env.VITE_F2_PROXY_URL.includes('REPLACE_ME')) {
+    throw new Error(
+      'VITE_F2_PROXY_URL is required for production builds and is unset (or still ' +
+        "the .env.example placeholder). Set it in .env.local OR pass inline:\n\n" +
+        '  VITE_F2_PROXY_URL=https://f2-pwa-worker.<account>.workers.dev npm run build\n\n' +
+        'See .env.example for the canonical worker-origin shape.',
+    );
+  }
+}
+
+export default defineConfig(({ mode }) => {
+  assertRequiredEnv(mode);
+  return {
   plugins: [
     react(),
     process.env.BUNDLE_VISUALIZE === '1'
@@ -74,4 +93,5 @@ export default defineConfig({
   resolve: {
     alias: { '@': path.resolve(__dirname, './src') },
   },
+  };
 });

--- a/deliverables/comms/_weekly-status-template.md
+++ b/deliverables/comms/_weekly-status-template.md
@@ -1,0 +1,68 @@
+---
+type: deliverable
+kind: weekly-status-template
+audience: internal (Carl + project record)
+sender: Carl Patrick L. Reyes
+related_task: E0-010
+tags: [weekly-status, internal, e0-010, e0-011]
+---
+
+# Weekly Status — Template (Internal)
+
+> Reusable format for the weekly internal status snapshot, owned by Carl (Data Programmer). **Internal-only** — not sent to ASPSI Mgmt Committee or DOH. Cadence: one snapshot per ASPSI Sprint week, written EOD Friday at sprint close. Each instance is saved as `weekly-status-YYYY-MM-DD.md` in this same folder (gitignored).
+>
+> **Purpose:** consolidate the week into a single artifact that survives between standups and the next sprint plan. Useful inputs: future retro Q&A, periodic ad-hoc updates if Mgmt asks, narrative continuity if Carl needs to brief someone fast. Not a comms send.
+
+## Conventions
+
+- **Internal voice:** plain, direct, declarative. No "po" / "Ma'am" / "Sir" — this is a self-facing artifact. Code-level detail (PR numbers, SHAs, bug IDs) is fine and sometimes useful for the future-Carl reader; abstraction lives at the layer that's actually informative.
+- **Length target:** ≤1 screen of body (~250–500 words). The artifact's value is being scannable a month later, not exhaustive.
+- **Anchor on quality and deliverables, not payment deadlines** — surface tranche / deadline exposure as a *risk*, not as the framing. (Memory: `feedback_quality_over_deadline`.)
+- **Stay in Carl's lane:** describe ASPSI-side actions and Carl's own work. Do NOT frame items as DOH-facing routing tasks; that's a different lane. (Memory: `feedback_comms_lane_discipline`.)
+- **Open items section captures decisions still owed** — to Carl, to ASPSI, to DOH. Lists who-owes-what so future-Carl can pick the thread up cold.
+
+---
+
+## Snapshot scaffold
+
+**Week of:** Mon YYYY-MM-DD → Fri YYYY-MM-DD (Sprint NNN)
+**Author:** Carl Patrick L. Reyes
+**Status:** internal artifact, not sent
+
+### Headline
+
+*[1–2 sentences on the most consequential thing this week. Anchor on deliverable progress or a decision that landed. If a critical risk shifted, lead with that instead.]*
+
+### Closed this week
+
+- *[Deliverable-level bullet — what's now done that wasn't last week. Cite the workstream epic / instrument / PR when useful.]*
+- *[…]*
+
+### In flight (next week)
+
+- *[Top 3–5 active items, each with the responsible role and a target close. Carry-forwards from this sprint + planned next-sprint commits.]*
+- *[…]*
+
+### Open items / decisions owed
+
+- *[Decisions that haven't landed and the owner. E.g., "Tablet procurement tier — owner: ASPSI Mgmt; ask sent 2026-04-29." OR "F2 burnout reduction-vs-removal confirmation — owner: ASPSI internal review." OR "Tranche 2 official revised deadline — owner: DOH-PMSMD, surfaced via ASPSI."]*
+- *[If none: "No open decisions blocking next sprint."]*
+
+### Risks on the watchlist
+
+- *[1–3 material risks. One-sentence mitigation status each. Cull anything that's already absorbed or stale.]*
+- *[…]*
+
+### Tranche / deliverable position
+
+*[1–2 sentences on where we stand against contracted milestones (D1–D6, Tranches 1–4). Framing: "what's submission-ready on our side" + "what's pending external".]*
+
+---
+
+## Drafter notes
+
+- Pull source material from `scrum/sprint-current.md` (committed items + status), `scrum/product-backlog.md` § Status at a Glance, and the Friday standup. The standup's "Yesterday (Done)" + sprint board snapshot is usually 80% of "Closed this week".
+- For "In flight", reuse the next sprint's likely shape (carry-forwards from this sprint + planned next-sprint commits). If next sprint isn't planned yet, lead with the carry-forwards.
+- For "Open items", scan epic files for items still tagged blocked or with external owners. Don't manufacture entries.
+- For "Risks", default to the existing watchlist in `product-backlog.md` (Risks & Watchlist section).
+- If the snapshot turns into a Mgmt-facing send later (template was originally drafted for that), the conversion is mechanical — add a `To:` block, soften the voice, drop code-level detail. The information itself transfers cleanly.

--- a/deliverables/comms/email-juvy-tablet-specs.md
+++ b/deliverables/comms/email-juvy-tablet-specs.md
@@ -1,0 +1,100 @@
+---
+type: deliverable
+kind: email-draft
+audience: Juvy (ASPSI procurement)
+sender: Carl Patrick L. Reyes
+date_drafted: 2026-04-29
+date_sent: 2026-04-29
+status: sent
+related_task: E5-CAPI-001
+tags: [capi, tablet, procurement, e5, field-distribution]
+---
+
+# Draft Email — CAPI Tablet Specifications for Procurement
+
+**To:** Ma'am Juvy
+**From:** Carl Patrick L. Reyes <clreyes6@up.edu.ph>
+**Subject:** CAPI Tablet Specifications — ASPSI | DOH UHC Survey 2
+
+---
+
+Ma'am Juvy,
+
+Good morning po. Below are the tablet specifications for the CAPI fieldwork. These tablets will run the CSEntry Android app for F1 (Facility Head), F3 (Patient Exit), and F4 (Community), with offline data capture, GPS auto-tagging, and one verification photo per case. The same tablet should also be capable of running the F2 HCW PWA via Chrome in case interviewer-administered fallback is needed.
+
+## Minimum specifications (per unit)
+
+- **Form factor:** Android tablet, 10-inch screen (8" acceptable but not preferred — F1/F3/F4 forms are dense)
+- **OS:** Android 12 or higher (with active security updates)
+- **RAM:** 4 GB minimum (6 GB or higher recommended)
+- **Storage:** 64 GB internal minimum
+- **Battery:** 6,000 mAh minimum — a full survey day is ~8 hours of active use
+- **Connectivity:** Wi-Fi required; LTE/4G with SIM slot recommended for sync away from facility Wi-Fi
+- **GPS:** Built-in GNSS (required for auto-coordinate capture per case)
+- **Camera:** Rear camera, 5 MP or higher (required for verification photo per case)
+- **Browser:** Latest Chrome with Service Worker + IndexedDB support (required for F2 PWA)
+- **Touch:** Capacitive, 10-point multi-touch
+
+## Suggested models with indicative price range
+
+Good price-performance for PH field surveys — for reference, not exhaustive. Prices are SRP estimates as of Q2 2026; please confirm against current vendor quotes:
+
+### Recommended tier (best balance of reliability + form factor)
+
+- Samsung Galaxy Tab A9+ (11", 4/64 GB, LTE) — **₱14,000 – ₱17,000**
+- Samsung Galaxy Tab A8 (10.5", 4/64 GB) — **₱11,000 – ₱14,000**
+- Lenovo Tab M10 Plus, 3rd Gen (10.6", 4/64 GB) — **₱12,000 – ₱15,000**
+- Honor Pad X9 (11.5", 4/128 GB) — **₱11,000 – ₱13,000**
+
+### More affordable alternatives (~₱8,000 – ₱11,000)
+
+These still meet the minimum spec, but please confirm **GPS is included** with the seller before ordering — some Wi-Fi-only budget SKUs drop the GNSS chip, and we need GPS for per-case auto-coordinate capture:
+
+- Lenovo Tab M9, 3rd Gen (9", 4/64 GB) — **₱7,500 – ₱9,500**
+- Honor Pad X8a (11.5", 4/128 GB, LTE variant for GPS) — **₱9,000 – ₱11,000**
+- Xiaomi Redmi Pad SE 8.7" LTE (8.7", 4/128 GB, Android 14) — **₱8,500 – ₱10,500** (GPS on the LTE version only)
+- Refurbished Samsung Galaxy Tab A8 (10.5", 4/64 GB) — **₱8,000 – ₱10,000** (require warranty + battery health check from vendor)
+
+### Modest tier — cheapest with decent specs (~₱5,500 – ₱8,500)
+
+Bare-minimum-but-functional units. Trade-offs are real, so consider these only if the budget is tight enough that the recommended/affordable tiers would mean cutting headcount or spares:
+
+- Samsung Galaxy Tab A7 Lite **LTE** (8.7", 3/32 GB, Android 11→12) — **₱6,500 – ₱8,000**
+- Lenovo Tab M8, 4th Gen **LTE** (8", 3/32 or 4/64 GB, Android 12) — **₱5,500 – ₱7,500**
+- Realme Pad Mini **LTE** (8.7", 3/32 or 4/64 GB) — **₱6,500 – ₱8,500**
+
+**Trade-off notes for this tier:**
+
+- 8" screen makes F1/F3/F4 dense item grids harder to tap accurately — train enumerators to default to landscape orientation.
+- 3 GB RAM is OK for CSEntry alone but will be sluggish if the F2 PWA fallback is needed on the same device.
+- 32 GB storage requires regular sync-and-purge discipline so case data + photos don't fill up the device mid-fieldwork.
+- Confirm Android security updates are available through the engagement window (~12–18 months); some budget SKUs go end-of-life sooner.
+- Always specify the **LTE variant** to ensure the GNSS chip is included.
+
+> Going below ~₱5,500 per unit usually means dropping below the minimum spec — older Android, no GPS, or no security updates. Please avoid no-name brands (Teclast, Blackview, Doogee, etc.); build quality and security update support are not viable for a multi-month engagement, and field replacement costs offset the upfront savings.
+
+## Required accessories per tablet (with indicative price range)
+
+- Rugged carrying case with hand strap — **₱500 – ₱1,500**
+- Tempered-glass screen protector — **₱200 – ₱500**
+- 20W or higher fast charger + USB-C cable — **₱500 – ₱1,000** (often bundled; spec a spare set per unit)
+- 64 GB microSD card, optional buffer for photo overflow — **₱400 – ₱700**
+
+**Indicative total per unit (tablet + accessories):**
+
+- Recommended tier: ~₱13,000 – ₱20,000 per unit
+- Affordable tier: ~₱9,500 – ₱14,000 per unit
+- Modest tier: ~₱7,000 – ₱12,000 per unit
+
+Add ~10–15% on top of total quantity for the spare-ratio units.
+
+## Procurement notes
+
+- Please include a ~10–15% spare ratio over the enumerator headcount for field replacements and damaged-unit quarantine.
+- Units should ship with default Google Play Services. We will install CSEntry, the F1/F3/F4 dictionaries, and security baseline during imaging (covered under E5-CAPI-003).
+- If LTE-capable, no SIMs are needed at procurement — we can provision those separately.
+
+Happy to vet a vendor short-list before purchase, or clarify any line item.
+
+Thank you po,
+Carl

--- a/deliverables/comms/weekly-status-2026-05-01.md
+++ b/deliverables/comms/weekly-status-2026-05-01.md
@@ -1,0 +1,65 @@
+---
+type: deliverable
+kind: weekly-status
+audience: internal (Carl + project record)
+sender: Carl Patrick L. Reyes
+date_drafted: 2026-04-30
+status: internal-snapshot
+related_task: E0-010 / E0-011
+sprint: 003
+sprint_window: 2026-04-27 to 2026-05-01
+tags: [weekly-status, internal, sprint-003, e0-010, e0-011]
+---
+
+# Weekly Status — Week of 2026-04-27 (Sprint 003)
+
+**Author:** Carl Patrick L. Reyes
+**Status:** internal artifact, not sent to ASPSI Mgmt or DOH
+**Snapshot taken:** 2026-04-30 (Sprint 003 Day 4 EOD; Friday close happens after this is written)
+
+### Headline
+
+Two long-running F2 HCW PWA blockers cleared this week — both production cutover prerequisites resolved (Issues #33 + #34 closed via PRs #43 + #44, merged + manually deployed to staging). 24-hour soak now running; production cutover go/no-go decision lands EOD Friday based on soak results. F1 Designer sign-off (E2-F1-010, two-sprint carry) still owed before sprint close.
+
+### Closed this week
+
+- **F2 PWA — Round 3 internal-QA blockers cleared.** Issue #33 (multi-select state pollution in Sections F/G — RHF checkbox-group DOM-read clobbering the array on cross-question onChange) and Issue #34 (CF Pages auto-deploy not firing) both shipped to staging. Fix: drop `name={reg.name}` from multi-select checkboxes; replace native CF Pages auto-deploy with `.github/workflows/cf-pages-deploy.yml` triggered on `workflow_run`. PRs #43 and #44 merged 2026-04-30, manual `wrangler pages deploy` of SHA `0f65defc` live on staging. 24-hour soak in progress.
+- **CAPI tablet specifications submitted (E5-CAPI-001).** Email to Juvy 2026-04-29 with three pricing tiers (recommended ~₱13–20K, affordable ~₱9.5–14K, modest ~₱7–12K), recommended models, accessory list, 10–15% spare-ratio recommendation. Awaiting procurement steer.
+- **Survey Manual — CSPro CAPI section + 2 appendices drafted (E7-DOC-001).** Drafts at `deliverables/Survey-Manual/CSPro-Section-Draft_2026-04-29.md` ready for Kidd. SPEED 2023 legacy cleaned out of the rewrite. Open questions tracked: questionnaire-numbering scheme, F2 manual scope, PAPI fallback policy.
+- **F1 Designer dictionary walkthrough preparation complete.** Bug list (5 closed-in-code, 1 PARTIAL pending ASPSI Q166, 2 deferred-with-rationale per spec §5) and case-control block disposition finalized. Designer-side sign-off pass queued — work bounded, just needs Carl in CSPro Designer.
+- **DOH/ADB/EXECOM matrix feedback triaged (E0-032a).** All 23 Annex G remarks routed against current build state: 14 DONE in build, 5 DEFERRED-WITH-RATIONALE (analysis-layer / sampling-frame, flagged for Epic 11 + IR), 3 VERIFY pending ASPSI spot-check, 1 OPEN sub-question (F2 burnout/satisfaction reduction-vs-removal — current build is *more conservative* than Annex G commitment). No new CAPI-schema work falls out. Triage at `wiki/analyses/Analysis - DOH-PMSMD Matrix Feedback Triage.md`.
+- **Weekly status format defined (E0-010).** Template + this first instance. Internal snapshot, not Mgmt-facing.
+
+### In flight (next week — Sprint 004 carry-forwards)
+
+- **E2-F1-010 — F1 Facility Head Designer sign-off.** Two-sprint carry; if it doesn't close Friday it becomes three-sprint. Owner: Carl. Bounded ~4h.
+- **E3-F1-001 — F1 Form file Section A layout in Designer.** Generator skeleton in place; Designer pass unblocks on F1 sign-off. Owner: Carl. Bounded ~4h.
+- **E4-PWA-013 — F2 PWA Phase F production cutover** (gated on soak staying clean through Friday afternoon). Owner: Carl, executes per `docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md`.
+- **E7-DOC-001 — Survey Manual review iteration with Kidd.** Owner: Kidd; Carl on standby for clarifications.
+- **E0-032a follow-up — F2 burnout reduction-vs-removal confirmation.** Owner: ASPSI internal review (Esmeralda / Kidd). Default if no response by mid-Sprint-004: full removal stands and the triage closes.
+
+### Open items / decisions owed
+
+- **Tablet procurement tier go/no-go** — owner: ASPSI Mgmt. Ask sent 2026-04-29; no response yet.
+- **Survey Manual reviewer assignment** — owner: ASPSI internal (Kidd default). Confirming Kidd is sufficient vs. needing additional eyes.
+- **F2 HCW burnout/satisfaction reduction-vs-removal** — owner: ASPSI internal review. Default = full removal stands.
+- **CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID repo secrets** — owner: Carl. Needed before the new cf-pages-deploy workflow does anything; manual `wrangler pages deploy` is the working fallback in the meantime.
+
+### Risks on the watchlist
+
+- **F1 Designer sign-off slipping to three-sprint carry.** If E2-F1-010 doesn't close Friday, momentum cost on the carry-forward grows. Mitigation: prioritize the Designer pass on Friday, ahead of the cutover decision.
+- **F2 PWA cutover soak tight.** 24-hour window ends ~16:40 PHT Friday, right at sprint close. Anomaly during soak → cutover defers cleanly to Sprint 004 (production stays on the path-B Verde Manual port; HMAC-in-bundle CSO finding still applies to prod-only until then).
+
+### Deliverable production state (informational)
+
+F1 / F3 / F4 instruments + supporting CAPI artifacts: F3/F4 build-ready since 2026-04-21, F1 closes on Designer sign-off this sprint. F2 PWA in production at v1.1.1 with Verde Manual visual identity. Survey Manual CSPro section drafted for review. From a Data Programmer perspective the production-side deliverables under D1–D6 are tracking; downstream tranche acceptance and submission timing are in ASPSI ops / PI lane (out-of-scope for this snapshot per `feedback_tranche_tracking_out_of_scope`).
+
+---
+
+## Drafter notes
+
+- Headline framing pivots Friday based on the soak outcome:
+  - **Soak clean:** keep current framing; add a "Closed this week" bullet noting Phase F cutover executed.
+  - **Soak shows a regression:** rewrite headline to flag deferral; move the cutover to "In flight" with new gate criteria; add the soak-failure detail to "Open items / decisions owed".
+- This snapshot is the source of truth for what Sprint 003 produced. If a Mgmt-facing brief is needed later, the conversion is mechanical (add `To:` block, soften voice, drop code-level detail like PR / SHA / RHF specifics). The information transfers cleanly.
+- Source material: `scrum/sprint-current.md`, `scrum/product-backlog.md` § Status at a Glance, this week's standups, `log.md` tail.

--- a/scrum/epics/epic-00-project-management.md
+++ b/scrum/epics/epic-00-project-management.md
@@ -48,18 +48,24 @@ Continuous workstream spanning the full engagement. Governs sprint cadence, stak
 - [ ] **E0-013** Prepare monthly stakeholder brief `status::todo` `priority::medium` `estimate::recurring`
 - [ ] **E0-014** Define ad-hoc client escalation protocol (what triggers escalation, who owns the call) `status::todo` `priority::medium` `estimate::2h`
 
-### Ethics Coordination
+### Ethics Coordination *(ASPSI/PI lane — NOT Data Programmer scope)*
 
-- [ ] **E0-020** SJREB application status check (via ASPSI) — ongoing tracking until clearance received `status::in-progress` `priority::critical` `estimate::ongoing`
-  - Notes: long-pole blocker for Epic 6 (Testing and Pilot) pretest phase
+> **Scope:** Ethics coordination is owned by ASPSI ops / PI (Dr Claro, Dr Paunlagui, Juvy as PMO) per the signed CSA D1–D6 (TOR + Personnel Schedule). Items below are tracked here for project-level visibility; do not pull into Carl's sprint backlog. See `feedback_sjreb_out_of_scope.md` and `feedback_data_programmer_scope.md`.
+
+- [ ] **E0-020** SJREB application status check (via ASPSI) — ongoing tracking until clearance received `status::in-progress` `priority::critical` `estimate::ongoing` `out_of_scope::data_programmer` `owner::aspsi-pi`
+  - Notes: long-pole blocker for Epic 6 (Testing and Pilot) pretest phase. Project-level dependency, not Carl-actionable.
 - [x] **E0-021** PSA sampling endorsement captured in approved Inception Report `status::done` `priority::critical`
 
 ### Risk & Change Management
 
-- [ ] **E0-030** Maintain risk register in Product Backlog §5 `status::ongoing` `priority::high` `estimate::recurring`
-- [ ] **E0-031** Define change request protocol for mid-engagement questionnaire revisions (intake form, impact assessment, backlog refresh) `status::todo` `priority::high` `estimate::4h`
-- [ ] **E0-032** Track timeline vs deliverable deadlines (D2, D3, D4, D5, D6) weekly `status::ongoing` `priority::high` `estimate::recurring`
-- [ ] **E0-033** Set up late delivery penalty tracker (1% of total per calendar day per CSA §5) — calculates exposure if deadlines slip `status::todo` `priority::medium` `estimate::2h`
+- [ ] **E0-030** Maintain risk register in Product Backlog §5 `status::ongoing` `priority::high` `estimate::recurring` *(informational consumption only — active risk-register stewardship is PM/PI work)*
+- [ ] **E0-031** Define change request protocol for mid-engagement questionnaire revisions (intake form, impact assessment, backlog refresh) `status::todo` `priority::high` `estimate::4h` *(protocol-design is PM lane; CAPI-side revisions arising from CRs land under E2/E3 instrument tasks)*
+- [ ] **E0-032** Track timeline vs deliverable deadlines (D2, D3, D4, D5, D6) weekly `status::ongoing` `priority::high` `estimate::recurring` `out_of_scope::data_programmer` `owner::aspsi-pi-pmo`
+  - Tranche / deadline tracking owned by ASPSI ops / PI / PMO. Carl is responsible for *production* of the deliverables (D1–D6), not the schedule on which they are accepted and paid. Project-level dependency only; surface in PIB / risk register, not in Carl's sprint backlog. See `feedback_tranche_tracking_out_of_scope.md`.
+- [ ] **E0-032a** DOH-PMSMD matrix feedback triage — route requested revisions through the appropriate workstream `status::ongoing` `priority::high` `estimate::recurring` `out_of_scope::data_programmer` `owner::aspsi-pi-pmo`
+  - Coordination overhead (matrix dispositioning, DOH-side comms) is ASPSI/PI lane. CAPI-technical fallout (specific F1/F2/F3/F4 revisions) folds into the relevant E2/E3 instrument task — not tracked under E0-032a. See `feedback_e0_032a_out_of_scope.md`.
+- [ ] **E0-033** Set up late delivery penalty tracker (1% of total per calendar day per CSA §5) — calculates exposure if deadlines slip `status::todo` `priority::medium` `estimate::2h` `out_of_scope::data_programmer` `owner::aspsi-pi-pmo`
+  - Financial / penalty exposure tracking is PM/PI/PMO lane. See `feedback_data_programmer_scope.md`.
 
 ### Project Governance (already done — baseline)
 
@@ -77,5 +83,6 @@ Continuous workstream spanning the full engagement. Governs sprint cadence, stak
 
 ## Notes
 
-- This epic has a high proportion of `recurring` and `ongoing` tasks because it's a continuous workstream. Sprint planning should pull in the **active recurring ceremonies** plus any open one-time items relevant to the sprint period.
-- Tasks E0-020 and E0-032 should appear in every sprint until resolved.
+- This epic has a high proportion of `recurring` and `ongoing` tasks because it's a continuous workstream. **Most are NOT Data Programmer scope** — they're tracked here for project-level visibility but should not auto-pull into Carl's sprints. Sprint planning should pull in the **active recurring ceremonies that are explicitly in Data Programmer scope** (currently: E0-001 sprint planning, E0-002 retros, E0-006 PB upkeep, E0-007 epic upkeep) plus any open one-time items.
+- **Out-of-scope guard:** Items annotated `out_of_scope::data_programmer` (currently E0-020, E0-032, E0-032a, E0-033, plus the close-out items E0-050 / E0-051) must NOT be added to `sprint-current.md` as Carl-owned tasks. They live in ASPSI ops / PI / PMO lane (Juvy / Dr Claro / Dr Paunlagui). See `feedback_data_programmer_scope.md` umbrella for the full IN/OUT-of-scope reference.
+- Sprint 003 (2026-04-27 → 2026-05-01) leaked E0-020, E0-032, and E0-032a back into the sprint board despite the umbrella memory rule; cleanup performed at sprint close 2026-05-01. Audit-on-detection discipline added to the relevant memory files so this doesn't slip again.

--- a/scrum/epics/epic-00-project-management.md
+++ b/scrum/epics/epic-00-project-management.md
@@ -3,7 +3,7 @@ epic: 0
 title: CAPI Project Management & Stakeholder Engagement
 phase: continuous
 status: active-ongoing
-last_updated: 2026-04-13
+last_updated: 2026-05-01
 ---
 
 # Epic 0 — CAPI Project Management & Stakeholder Engagement
@@ -42,11 +42,17 @@ Continuous workstream spanning the full engagement. Governs sprint cadence, stak
 
 ### Stakeholder Communication
 
-- [ ] **E0-010** Define weekly status update format (to ASPSI Management Committee) `status::todo` `priority::high` `estimate::2h`
-- [ ] **E0-011** Send weekly status updates to ASPSI `status::todo` `priority::high` `estimate::recurring`
-- [ ] **E0-012** Define monthly stakeholder brief format (DOH / ADB touchpoint) `status::todo` `priority::medium` `estimate::2h`
-- [ ] **E0-013** Prepare monthly stakeholder brief `status::todo` `priority::medium` `estimate::recurring`
-- [ ] **E0-014** Define ad-hoc client escalation protocol (what triggers escalation, who owns the call) `status::todo` `priority::medium` `estimate::2h`
+> **Scope split:** Carl owns the *internal* status format (E0-010) for his own tracking + project record per `feedback_weekly_status_internal_only.md`. Recurring stakeholder-facing sends, brief preparation, and escalation-protocol design are PM/PI/PMO lane (Juvy / Dr Claro / Dr Paunlagui) per `feedback_data_programmer_scope.md` and `feedback_comms_lane_discipline.md`.
+
+- [ ] **E0-010** Define weekly status update format — *internal-only* (Carl's tracking + project record, not for ASPSI Mgmt or DOH send) `status::todo` `priority::high` `estimate::2h`
+- [ ] **E0-011** Send weekly status updates to ASPSI `status::todo` `priority::high` `estimate::recurring` `out_of_scope::data_programmer` `owner::aspsi-pi-pmo`
+  - Recurring stakeholder-facing send. Per `feedback_weekly_status_internal_only.md`, no recurring send happens from Carl; the internal artifact (E0-010) stays internal. If/when ASPSI wants a stakeholder-facing weekly, ASPSI/PMO authors and ships it.
+- [ ] **E0-012** Define monthly stakeholder brief format (DOH / ADB touchpoint) `status::todo` `priority::medium` `estimate::2h` `out_of_scope::data_programmer` `owner::aspsi-pi-pmo`
+  - Stakeholder-facing brief format design. PM/PI lane.
+- [ ] **E0-013** Prepare monthly stakeholder brief `status::todo` `priority::medium` `estimate::recurring` `out_of_scope::data_programmer` `owner::aspsi-pi-pmo`
+  - Recurring stakeholder-facing send to DOH / ADB. Out per `feedback_comms_lane_discipline.md`.
+- [ ] **E0-014** Define ad-hoc client escalation protocol (what triggers escalation, who owns the call) `status::todo` `priority::medium` `estimate::2h` `out_of_scope::data_programmer` `owner::aspsi-pi-pmo`
+  - Escalation-protocol design = PM/PI lane per `feedback_data_programmer_scope.md`.
 
 ### Ethics Coordination *(ASPSI/PI lane — NOT Data Programmer scope)*
 
@@ -76,13 +82,16 @@ Continuous workstream spanning the full engagement. Governs sprint cadence, stak
 - [x] **E0-044** 13-epic service lifecycle derived from workflow and captured in Product Backlog `status::done`
 - [x] **E0-045** Service Offerings area scaffolded at `2_Areas/Service-Offerings/CAPI-Development/` `status::done`
 
-### Handoff Preparation *(activates near project close)*
+### Handoff Preparation *(activates near project close — ASPSI/PI/PMO lane)*
 
-- [ ] **E0-050** Stakeholder-facing close-out brief template `status::todo` `priority::low` `estimate::3h`
-- [ ] **E0-051** Final acceptance letter checklist (what must the client sign off on) `status::todo` `priority::low` `estimate::2h`
+> **Scope:** Stakeholder-facing close-out artifacts are PM/PI/PMO lane per `feedback_data_programmer_scope.md`. Carl's close-out work lives in Epic 12 (system handover package, technical runbook, knowledge-transfer sessions, NDU file disposition, retrospective writeback) — *not* the stakeholder-facing brief or acceptance-letter checklist.
+
+- [ ] **E0-050** Stakeholder-facing close-out brief template `status::todo` `priority::low` `estimate::3h` `out_of_scope::data_programmer` `owner::aspsi-pi-pmo`
+- [ ] **E0-051** Final acceptance letter checklist (what must the client sign off on) `status::todo` `priority::low` `estimate::2h` `out_of_scope::data_programmer` `owner::aspsi-pi-pmo`
 
 ## Notes
 
 - This epic has a high proportion of `recurring` and `ongoing` tasks because it's a continuous workstream. **Most are NOT Data Programmer scope** — they're tracked here for project-level visibility but should not auto-pull into Carl's sprints. Sprint planning should pull in the **active recurring ceremonies that are explicitly in Data Programmer scope** (currently: E0-001 sprint planning, E0-002 retros, E0-006 PB upkeep, E0-007 epic upkeep) plus any open one-time items.
-- **Out-of-scope guard:** Items annotated `out_of_scope::data_programmer` (currently E0-020, E0-032, E0-032a, E0-033, plus the close-out items E0-050 / E0-051) must NOT be added to `sprint-current.md` as Carl-owned tasks. They live in ASPSI ops / PI / PMO lane (Juvy / Dr Claro / Dr Paunlagui). See `feedback_data_programmer_scope.md` umbrella for the full IN/OUT-of-scope reference.
+- **Out-of-scope guard:** Items annotated `out_of_scope::data_programmer` (currently E0-011, E0-012, E0-013, E0-014, E0-020, E0-032, E0-032a, E0-033, E0-050, E0-051) must NOT be added to `sprint-current.md` as Carl-owned tasks. They live in ASPSI ops / PI / PMO lane (Juvy / Dr Claro / Dr Paunlagui). See `feedback_data_programmer_scope.md` umbrella for the full IN/OUT-of-scope reference.
+- **In-scope E0 items** (the ones that should pull into sprints): E0-001, E0-002, E0-003, E0-006, E0-007, E0-008, E0-010 (define internal format only). E0-030 (risk register) is informational consumption only. E0-031 (change-request protocol) is borderline — protocol design is PM lane, but CAPI-side CR handling fold into E2/E3.
 - Sprint 003 (2026-04-27 → 2026-05-01) leaked E0-020, E0-032, and E0-032a back into the sprint board despite the umbrella memory rule; cleanup performed at sprint close 2026-05-01. Audit-on-detection discipline added to the relevant memory files so this doesn't slip again.

--- a/scrum/product-backlog.md
+++ b/scrum/product-backlog.md
@@ -6,7 +6,7 @@ data_programmer: Carl Patrick L. Reyes
 qa_tester: Shan (ASPSI, RA)
 contract: CSA signed 2025-12-15, effective 2025-11-14
 engagement_window: November 2025 – August 2026
-last_updated: 2026-04-27
+last_updated: 2026-05-01
 ---
 
 # Product Backlog — UHC Survey Year 2 CAPI Development
@@ -23,7 +23,9 @@ last_updated: 2026-04-27
 
 ### Headline (this week)
 
-**Sprint 003, Day 1 — Mon 2026-04-27. Scrum artifact alignment pass + new commitments.** Sprint 003 dates corrected to 2026-04-27 → 2026-05-01 (Mon-Fri, parity with Sprint 002 cadence — earlier `sprint-current.md` had off-by-one `04-28 → 05-02`). Two new Sprint 003 items added: **E4-PWA-013** (F2 PWA auth re-arch Phase F production cutover decision — gated on Issue #33 + #34 resolution + ≥24h clean staging soak; earliest window ~17:35 PHT today; *critical*) and **E0-008** (auto-standup retro-injection tooling — closes the recurring ritual gap where retro Q4 action items get captured in `sprint-current.md` Daily Notes but not in the Day 1 daily standup; *stretch*). Sprint 002 backfilled with an Inter-Sprint Activity section (Sat 2026-04-25 + Sun 2026-04-26) and a reconstructed Apr 24 Fri standup; all four Sprint 002 standups (Apr 20–23) patched for sprint-status / project-name / goal-banner consistency. Sprint goal anchor unchanged: **close E2-F1-010 (F1 Designer sign-off — two-sprint carry-forward)**.
+**Sprint 003 close — Fri 2026-05-01. Scope-discipline cleanup: E0-020 / E0-032 / E0-032a removed from sprint board as out-of-Data-Programmer-scope per CSA D1–D6.** Three Epic 0 items had leaked back into Sprint 003 (E0-020 SJREB tracking + E0-032 Tranche/deadline tracking as Recurring; E0-032a DOH-PMSMD matrix triage as Carry-forward critical) despite the umbrella scope memory. Cleaned up at sprint close: dropped from `sprint-current.md` Committed/Recurring; annotated in `epic-00-project-management.md` with `out_of_scope::data_programmer` `owner::aspsi-pi-pmo`; reframed in this Backlog's Epic 0 In-flight section as ASPSI/PI/PMO-lane informational. Audit-on-detection discipline added to the SJREB + Tranche memories so this doesn't slip again. Honest Sprint 003 board after cleanup: 4 committed (E2-F1-010, E0-010 internal-only, E3-F1-001, E4-PWA-013) + 3 stretch (E2-F3-010, E2-F4-010, E0-008); none closed at sprint end — F1 Designer sign-off carries to Sprint 004 as a three-sprint carry.
+
+**Sprint 003, Day 1 — Mon 2026-04-27. Scrum artifact alignment pass + new commitments.** Sprint 003 dates corrected to 2026-04-27 → 2026-05-01 (Mon-Fri, parity with Sprint 002 cadence — earlier `sprint-current.md` had off-by-one `04-28 → 05-02`). Two new Sprint 003 items added: **E4-PWA-013** (F2 PWA auth re-arch Phase F production cutover decision — gated on Issue #33 + #34 resolution + ≥24h clean staging soak; *critical*) and **E0-008** (auto-standup retro-injection tooling — closes the recurring ritual gap where retro Q4 action items get captured in `sprint-current.md` Daily Notes but not in the Day 1 daily standup; *stretch*). Sprint 002 backfilled with an Inter-Sprint Activity section (Sat 2026-04-25 + Sun 2026-04-26) and a reconstructed Apr 24 Fri standup; all four Sprint 002 standups (Apr 20–23) patched for sprint-status / project-name / goal-banner consistency. Sprint goal anchor unchanged: **close E2-F1-010 (F1 Designer sign-off — two-sprint carry-forward)**.
 
 **Inter-sprint, Sun 2026-04-26 (latest) — F2 PWA Verde Manual LIVE on production via path B; CF Pages auto-deploy confirmed broken on main too.** Cherry-picked the 5 Verde Manual commits (#37 tokens / #38 fonts / #39 layout & components / #40 DESIGN-006 sweep / #41 polish — staging SHAs `47e1553` / `c1a97bb` / `4fd2d92` / `1458f29` / `7bfc28a`) onto `main` via PR [#42](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/pull/42) (`a1c4a3e`), resolving conflicts in `App.tsx` (h1 styling) and `EnrollmentScreen.tsx` (kept main's pre-auth-rearch single-step logic + applied Verde styling intent). Auth re-arch (PR #31) intentionally NOT in this port — stays on staging awaiting Phase F gate. **Production deploy:** GitHub auto-deploy didn't fire on the merge to main (confirms Issue #34 affects main pushes too, not just staging). Manually deployed via `wrangler pages deploy dist --project-name=f2-pwa --branch=main --commit-hash=a1c4a3ea` after `npm install -g wrangler` (deployment `4f61356a-51fb-4ea2-aeb0-647edc678be0`). Canonical `f2-pwa.pages.dev` now serves Verde Manual: pale verde paper `#F2F5EE`, DOH emerald `#006B3F`, Newsreader serif h1/h2, Public Sans body, JetBrains Mono on version subtitle + eyebrows. Existing F2 PWA installs with the old service worker get an "Update available" prompt on next launch (per `vite.config.ts` `registerType: 'prompt'`). DESIGN-006 also closed today (PR #40) — `--warning` token added, alpha-aware HSL slot syntax migration, raw Tailwind colors swept. Polish PR (#41) flattened buttons, hairline-edged modals.
 
@@ -146,13 +148,17 @@ Each epic below is a long-running workstream that spans its portion of the engag
 - **Comms infrastructure live:** ASPSI project mailbox (`aspsi.doh.uhc.survey2.data@gmail.com`) for artifacts and decisions of record; CAPI Viber group for real-time coordination
 - **Team structure clarified:** Carl as Data Programmer; Shan (ASPSI RA) as QA Tester for the CAPI build
 
-**In flight:**
-- SJREB ethics clearance coordination (via ASPSI)
-- Ongoing risk tracking and stakeholder communication
+**In flight (Data Programmer scope):**
 - Product Backlog maintenance (this document)
-- Authoring the weekly status update format for ASPSI Management Committee — Carl-controlled narrative, not a coordination ask
+- Defining the internal weekly status format (E0-010) — Carl-controlled internal tracking, *not* a recurring send to ASPSI Mgmt or DOH (per `feedback_weekly_status_internal_only.md`)
+- Sprint cadence + scrum artifact upkeep (Sprint 003 closing 2026-05-01)
 
-**Next milestone:** First weekly status update shipped to ASPSI Management Committee.
+**ASPSI / PI / PMO lane — informational only (NOT Data Programmer scope per CSA D1–D6):**
+- SJREB ethics clearance coordination (E0-020) — owned by ASPSI ops / PI; long-pole dependency for Epic 6 pretest
+- D2 / D3 / Tranche 2 timeline + deadline tracking (E0-032) — owned by ASPSI ops / PI / PMO; Carl produces the deliverables, ASPSI manages submission timing
+- DOH-PMSMD matrix feedback coordination (E0-032a) — owned by ASPSI ops / PI; CAPI-side revisions fold into the relevant E2/E3 instrument task
+
+**Next milestone:** Internal weekly status format defined (E0-010), used for Carl's tracking and the project record.
 
 **Ties to:** Cross-cutting across all other epics. Anchors D1 (ongoing governance).
 

--- a/scrum/sprint-current.md
+++ b/scrum/sprint-current.md
@@ -11,7 +11,7 @@ deliverable_anchor: E2-F1-010 / Tranche 2 (deadline TBC from DOH)
 
 ## Sprint Goal
 
-> **Close E2-F1-010 (F1 Designer sign-off) — two-sprint carry, must not leave this week.** Once F1 sign-off lands, open the FMF build in CSPro Designer for F1 (E3-F1-001 — generator skeleton is ready). Submit Tranche 2 the moment DOH issues the official revised deadline. E0-010 (weekly status format for ASPSI Mgmt Committee) closes this sprint with no further deferral.
+> **Close E2-F1-010 (F1 Designer sign-off) — two-sprint carry, must not leave this week.** Once F1 sign-off lands, open the FMF build in CSPro Designer for F1 (E3-F1-001 — generator skeleton is ready). E0-010 (define internal weekly status format) closes this sprint with no further deferral. Tranche 2 submission timing is ASPSI/PI lane, not a Sprint 003 deliverable for Carl.
 
 ## Committed Items
 
@@ -19,12 +19,10 @@ deliverable_anchor: E2-F1-010 / Tranche 2 (deadline TBC from DOH)
 
 - [ ] **E2-F1-010** F1 DCF opened in CSPro Designer, full validation walkthrough (including new case-control block: `SURVEY_CODE`, `INTERVIEWER_ID`, `DATE_STARTED`, `TIME_STARTED`, `AAPOR_DISPOSITION`, `FACILITY_NAME`, `FACILITY_ADDRESS`), bug list closed or explicitly deferred, sign-off note recorded `status::todo` `priority::critical` `estimate::4h`
 - [ ] **E0-010** Define weekly status update format for ASPSI Management Committee (Carl → Juvy / Dr Claro / Dr Paunlagui) `status::todo` `priority::high` `estimate::2h`
-- [ ] **E0-032a** DOH-PMSMD matrix feedback triage — route any requested revisions into F1/F2 build state or explicitly defer with rationale `status::todo` `priority::critical` `estimate::TBD`
 
-### Recurring (every sprint)
+### ASPSI / PI / PMO lane — informational only (NOT Data Programmer scope)
 
-- [ ] **E0-020** SJREB application status check via ASPSI `status::todo` `priority::critical`
-- [ ] **E0-032** Track D2/D3/Tranche 2 deadline exposure this week — confirm official revised deadline from DOH; submit package immediately on confirmation `status::todo` `priority::high`
+> Scope discipline: **E0-020** (SJREB status), **E0-032** (D2/D3/Tranche deadline tracking), **E0-032a** (DOH-PMSMD matrix coordination triage) are explicitly **not** Carl-owned per the signed CSA D1–D6 (Data Programmer scope = production of CAPI deliverables). They live in ASPSI ops / PI / PMO lane (Juvy / Dr Claro / Dr Paunlagui). Surface as project-level dependencies in `product-backlog.md` and the risk register, not as sprint-board commitments. CAPI-side fallout from the DOH matrix (specific F1/F2/F3/F4 revisions) is folded into the relevant E2/E3 instrument task — not tracked under E0-032a. (Memory: `feedback_data_programmer_scope.md`, `feedback_sjreb_out_of_scope.md`, `feedback_tranche_tracking_out_of_scope.md`, `feedback_e0_032a_out_of_scope.md`.)
 
 ### New for Sprint 003
 
@@ -41,24 +39,27 @@ deliverable_anchor: E2-F1-010 / Tranche 2 (deadline TBC from DOH)
 
 | Class | Items | Estimate |
 |---|---|---|
-| **Committed (must-finish)** | E2-F1-010, E0-010, E0-032a, E0-020, E0-032, E3-F1-001, E4-PWA-013 | ~14–15h + E0-032a unbounded |
+| **Committed (must-finish)** | E2-F1-010, E0-010, E3-F1-001, E4-PWA-013 | ~12–13h |
 | **Stretch** | E2-F3-010, E2-F4-010, E0-008 | ~7h |
 
-> Capacity: ~25h solo-dev week. Hard commits are ~14–15h (including E4-PWA-013 Phase F decision today) leaving room for E0-032a if it arrives heavy, or pulling stretch Designer validations (E2-F3-010 / E2-F4-010) into the week.
+> Capacity: ~25h solo-dev week. Hard commits are ~12–13h (including E4-PWA-013 Phase F decision Mon 2026-04-27) leaving room to pull stretch Designer validations (E2-F3-010 / E2-F4-010) into the week. Sprint board re-scoped 2026-05-01 (sprint close): E0-020 / E0-032 / E0-032a removed as out-of-Data-Programmer-scope; see "ASPSI / PI / PMO lane" section above.
 
 ## Daily Notes
 
 ### 2026-04-27 (Mon) — Sprint 003 kickoff
 
 - **Carry-forward from Sprint 002 retro Q4:** Day 1 ritual — before writing the Today-plan table, grep deliverables/ for files modified since last standup to catch artifact drift. Prevents standup generator from narrating "pending" on already-done work. (Two occurrences Sprint 001 + Sprint 002.)
-- **Tranche 2 status:** Extension in effect; official revised deadline not yet received from DOH as of 2026-04-25. Monitor and submit immediately on confirmation.
+- **Tranche 2 status (informational only):** Extension in effect; official revised deadline pending from DOH as of 2026-04-25. Tracking + submission timing is ASPSI/PI lane (not Carl's). Surfaced here so Carl has awareness of where his deliverables sit vs. contracted milestones.
+
+### 2026-05-01 (Fri) — Sprint 003 close, scope-discipline cleanup
+
+- Out-of-scope items removed from sprint board: **E0-020** (SJREB tracking), **E0-032** (Tranche/deadline tracking), **E0-032a** (DOH-PMSMD matrix triage). All three are ASPSI/PI/PMO lane per CSA D1–D6 Data Programmer scope. They had leaked back into Sprint 003 despite the umbrella memory rule (`feedback_data_programmer_scope.md`); audit-on-detection discipline added to the SJREB + Tranche memories so this doesn't slip again.
+- Net Sprint 003 commit drops from 6 → 4 (E2-F1-010, E0-010, E3-F1-001, E4-PWA-013) + 3 stretch (E2-F3-010, E2-F4-010, E0-008). Honest sprint board: 0/4 committed done at sprint close — F1 Designer sign-off carries to Sprint 004 as a three-sprint carry.
 
 ## Definition of Done — Sprint 003
 
 - [ ] **E2-F1-010** closed: F1 DCF walkthrough complete in CSPro Designer (including case-control block), bug list closed or deferred with rationale, sign-off note appended to `log.md`.
 - [ ] **E3-F1-001** closed: F1 FMF Designer pass complete; `FacilityHeadSurvey.fmf` saved and reviewed.
-- [ ] **E0-010** closed: weekly status update format defined and first draft sent to ASPSI Mgmt Committee.
-- [ ] **E0-032a** closed or explicitly deferred: DOH-PMSMD matrix feedback dispositioned.
+- [ ] **E0-010** closed: weekly status update format defined for Carl's internal tracking (per `feedback_weekly_status_internal_only.md`).
 - [ ] **E4-PWA-013** closed: F2 PWA Phase F cutover decision recorded in `log.md` — either Worker JWT proxy promoted to production, OR deferral with reason + re-gate criteria documented.
-- [ ] **Tranche 2** submitted if official revised deadline is issued this week.
 - [ ] **Sprint 003 retrospective** (4 questions) filled in `sprint-current.md` by EOD Fri 2026-05-01; sprint archived to `scrum/sprints/sprint-003.md`; `sprint-current.md` reset for Sprint 004.

--- a/scrum/standups/2026-05-01.md
+++ b/scrum/standups/2026-05-01.md
@@ -1,0 +1,151 @@
+---
+date: 2026-05-01
+project: UHC Survey Year 2 — CAPI Development
+sprint: 003
+sprint_day: 5 of 5
+---
+
+# Daily Standup — 2026-05-01, Friday
+
+**Project:** UHC Survey Year 2 — CAPI Development
+**Sprint:** 003 — **Close E2-F1-010 (F1 Designer sign-off) — two-sprint carry, must not leave this week.** Once F1 sign-off lands, open the FMF build in CSPro Designer for F1 (E3-F1-001 — generator skeleton is ready). Submit Tranche 2 the moment DOH issues the official revised deadline. E0-010 (weekly status format for ASPSI Mgmt Committee) closes this sprint with no further deferral.
+**Sprint Day:** 5 of 5
+
+---
+
+## Stakeholder Context *(from Product Backlog)*
+
+### Headline (this week)
+
+**Sprint 003, Day 1 — Mon 2026-04-27. Scrum artifact alignment pass + new commitments.** Sprint 003 dates corrected to 2026-04-27 → 2026-05-01 (Mon-Fri, parity with Sprint 002 cadence — earlier `sprint-current.md` had off-by-one `04-28 → 05-02`). Two new Sprint 003 items added: **E4-PWA-013** (F2 PWA auth re-arch Phase F production cutover decision — gated on Issue #33 + #34 resolution + ≥24h clean staging soak; earliest window ~17:35 PHT today; *critical*) and **E0-008** (auto-standup retro-injection tooling — closes the recurring ritual gap where retro Q4 action items get captured in `sprint-current.md` Daily Notes but not in the Day 1 daily standup; *stretch*). Sprint 002 backfilled with an Inter-Sprint Activity section (Sat 2026-04-25 + Sun 2026-04-26) and a reconstructed Apr 24 Fri standup; all four Sprint 002 standups (Apr 20–23) patched for sprint-status / project-name / goal-banner consistency. Sprint goal anchor unchanged: **close E2-F1-010 (F1 Designer sign-off — two-sprint carry-forward)**.
+
+**Inter-sprint, Sun 2026-04-26 (latest) — F2 PWA Verde Manual LIVE on production via path B; CF Pages auto-deploy confirmed broken on main too.** Cherry-picked the 5 Verde Manual commits (#37 tokens / #38 fonts / #39 layout & components / #40 DESIGN-006 sweep / #41 polish — staging SHAs `47e1553` / `c1a97bb` / `4fd2d92` / `1458f29` / `7bfc28a`) onto `main` via PR [#42](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/pull/42) (`a1c4a3e`), resolving conflicts in `App.tsx` (h1 styling) and `EnrollmentScreen.tsx` (kept main's pre-auth-rearch single-step logic + applied Verde styling intent). Auth re-arch (PR #31) intentionally NOT in this port — stays on staging awaiting Phase F gate. **Production deploy:** GitHub auto-deploy didn't fire on the merge to main (confirms Issue #34 affects main pushes too, not just staging). Manually deployed via `wrangler pages deploy dist --project-name=f2-pwa --branch=main --commit-hash=a1c4a3ea` after `npm install -g wrangler` (deployment `4f61356a-51fb-4ea2-aeb0-647edc678be0`). Canonical `f2-pwa.pages.dev` now serves Verde Manual: pale verde paper `#F2F5EE`, DOH emerald `#006B3F`, Newsreader serif h1/h2, Public Sans body, JetBrains Mono on version subtitle + eyebrows. Existing F2 PWA installs with the old service worker get an "Update available" prompt on next launch (per `vite.config.ts` `registerType: 'prompt'`). DESIGN-006 also closed today (PR #40) — `--warning` token added, alpha-aware HSL slot syntax migration, raw Tailwind colors swept. Polish PR (#41) flattened buttons, hairline-edged modals.
+
+**Inter-sprint, Sun 2026-04-26 (earlier) — F2 PWA design system codified; staging migration shipped.** `/gstack-design-consultation` produced [`deliverables/F2/PWA/app/DESIGN.md`](../deliverables/F2/PWA/app/DESIGN.md) — visual source of truth anchored on *"This is real software, not a government form."* Direction: **Verde Manual** — clinical stationery + utility on DOH "Verde Vision / Berde para sa bayan" institutional palette. End-to-end staging migration delivered in 5 focused PRs (#37/#38/#39/#40/#41), all merged. App-level CLAUDE.md added at `deliverables/F2/PWA/app/CLAUDE.md` to scope gstack to the F2 PWA workstream. **Two design follow-ups still open:** `E3-F2-PWA-DESIGN-004` (self-host fonts, gated on `pyftsubset`), `E3-F2-PWA-DESIGN-005` (refine hex from official DOH brand-book PDF, blocked-external on ASPSI). DESIGN-006 closed.
+
+**Inter-sprint, Sun 2026-04-26 — F2 PWA auth re-arch cut over to staging.** PR #31 (Cloudflare Worker JWT proxy replacing HMAC-in-bundle) merged to `staging` and live on `f2-pwa-staging.pages.dev`. Mitigates the **CRITICAL** finding from the 2026-04-25 `/gstack-cso` audit (HMAC was inlined into the Vite bundle, exposing it to anyone who downloaded the staging build). Worker URL: `https://f2-pwa-worker.hcw.workers.dev`. Disruption window ~18 min (longer than runbook's 4–6 min — see Issue #34). Three Round 3 issues filed during the cutover smoke test: **#33** Section F/G multi-select state pollution (Phase F blocker), **#34** CF Pages auto-deploy not firing on staging push (Phase F blocker or runbook rewrite), **#35** Worker PBKDF2 600k iters exceeds Workers' 100k cap (operational gotcha, fixed at runtime). PR #32 hot-fix opened for the EnrollmentScreen pre-refresh regression (deployed manually). **Phase F (production cutover) gated on ≥24 hours of clean staging soak + #33/#34 resolution; earliest window ~17:35 PHT 2026-04-27.**
+
+**Inter-sprint, Sat 2026-04-25 — F2 PWA Rounds 1 + 2 closed; Sprint 003 starts Mon 2026-04-27.** Tranche 2 (40%) was due 2026-04-24; ASPSI confirmed extension in effect, official revised deadline pending from DOH. Sprint 002 closed 2026-04-24 with F3 + F4 specs Build-ready and F1 DCF Designer-ready. Heavy lift on the 25th was the F2 PWA UAT closure (see F2 PWA section below).
+
+**F3 and F4 skip-logic + validation specs both landed 2026-04-21 (Sprint 002 Day 2 overdelivery).** F3 spec reviewed at 1133 lines — all 12 sections A–L, 14 sanity findings, 15 CSPro PROC templates, 6 open questions dispositioned (1 routed to Juvy: Q31 IP_GROUP; 5 spec-decisions with override clause). F4 spec drafted at 904 lines — all 17 sections A–Q, 13 sanity findings (findings #1/#2 CLOSED-BY-VERIFICATION 2026-04-21: `C_HOUSEHOLD_ROSTER` already repeating at `max_occurs=20`, `J_HEALTH_SEEKING` intentionally respondent-level per Apr 20 source), 11 CSPro PROC templates, 8 open questions dispositioned (3 routed to ASPSI, 5 spec-decisions). Both F3 and F4 are **Build-ready**. Deliverables at `deliverables/CSPro/F3/` and `deliverables/CSPro/F4/`.
+
+**F1 skip-logic + validation spec aligned with F3/F4 on 2026-04-21.** F1 spec rewrite added GPS capture via `REC_FACILITY_CAPTURE` (uses `ReadGPSReading()` helper) + verification-photo capture (filename-reference pattern, `TakeVerificationPhoto()` helper) + PSGC cascade (`onfocus` + `loadcase()` + `setvalueset()` via `PSGC-Cascade.apc`). F1 DCF now at **12 records / 671 items**. Shared `.apc` fragments live under `deliverables/CSPro/Capture-Helpers.apc` and `deliverables/CSPro/PSGC-Cascade.apc` — F3/F4 will consume the same helpers. Designer round 2 / sign-off (E2-F1-010) remains the carry-forward from Sprint 001. PSGC value sets still blocked on ASPSI.
+
+**F2 PWA — Production at v1.1.1 codebase, Verde Manual visual identity since 2026-04-26.** Both UAT rounds closed:
+
+- **v1.1.0 — UAT Round 1** (closed 2026-04-25): 7 issues fixed including the auto-advance bug, mid-section skip logic, Section G role-hide, max-value enforcement on age + tenure fields. Round opened 2026-04-23 by Shan (ASPSI), closed with "Pass with comments" 2026-04-24, all comments addressed and verified 2026-04-25.
+- **v1.1.1 — UAT Round 2** (closed 2026-04-25): 6 issues fixed including the gate-question navigation regression (Q12=No / Q31=No couldn't proceed), specialty filter by role (Dentists no longer see medical specialties), real-time validation tooltips, language switcher visibility, and the silent submit-failure fix.
+
+Production: https://f2-pwa.pages.dev. App header shows `v1.1.1 · spec 2026-04-17-m1`. Release notes at GitHub Releases [v1.1.0](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/releases/tag/v1.1.0) and [v1.1.1](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/releases/tag/v1.1.1); CHANGELOG.md auto-maintained. Verde Manual visual identity ported via PR #42 (path B, 2026-04-26) — auth re-arch stays on staging awaiting Phase F.
+
+**Round 3 (v1.2.0) backlog queued** — 3 enhancement issues on the [project board](https://github.com/users/cplreyes/projects/7): exclusive "I don't know" multi-select, "All of the above" auto-select, and matrix view for scale-style questions. ASPSI translation delivery (Filipino + others queued on their side) is the gating dependency for full localisation; switcher architecture is in place to drop them in without code changes.
+
+**Visual-identity migration (Verde Manual) — LIVE in production 2026-04-26.** All five migration PRs merged on staging (#37 tokens, #38 fonts, #39 layout & components, #40 DESIGN-006 sweep, #41 polish), then ported to main via path-B PR #42 and manually deployed via `wrangler pages deploy` (CF Pages auto-deploy is broken — see #34). See `deliverables/F2/PWA/app/DESIGN.md` for the full system. Two follow-ups still open: `E3-F2-PWA-DESIGN-004` (self-host fonts, gated on `pyftsubset`), `E3-F2-PWA-DESIGN-005` (refine hex from official DOH brand-book PDF, blocked-external on ASPSI).
+
+**Automation in place** (all on `main` since 2026-04-25): GitHub Actions `uat-slack-events.yml` (real-time issue/milestone events to `#f2-pwa-uat`), `uat-slack-digest.yml` (09:00 MNL daily snapshot when a round is active), `uat-release-notes.yml` (milestone-closed → CHANGELOG + GitHub Release + Slack post + auto-bump `package.json`).
+
+**F2 Epic 3 build is complete.** CSPro-encoder and Google Forms fallback tracks are retired and remain least priority — do not reopen unless deployment context changes fundamentally.
+
+Comms infrastructure fully provisioned (project mailbox + Viber group both live, Shan onboarded as QA tester, Juvy confirmed as DOH-routing gate per the Apr 13 Team Communication Protocol).
+
+### By Workstream Epic
+
+| # | Epic | Current State | Next Milestone |
+|---|---|---|---|
+| **0** | CAPI Project Management & Stakeholder Engagement | **Active / Ongoing** (Sprint 003 committed: E0-010 weekly status format; stretch: E0-008 auto-standup retro-injection tooling) | E0-010 weekly status update format drafted + first send to ASPSI Mgmt Committee; E0-008 lands in `.claude/scripts/generate_standup.py` |
+| **1** | Inception & Engagement Setup | **Done** | — (historical, closed Dec 2025) |
+| **2** | Survey Questionnaire Design & Dictionary | **In Progress** (F1 Design — Designer round 2 / sign-off next; **F3 Build-ready, F4 Build-ready** — specs complete 2026-04-21; F2 data model lives inside the PWA spec; PLF Source Captured) | F1 sign-off (E2-F1-010); F3/F4 Designer validation (E2-F3-010, E2-F4-010) |
+| **3** | CAPI Application Development | **In Progress** (F2 **PWA in production at v1.1.1 with Verde Manual visual identity since 2026-04-26**, Rounds 1+2 closed, Round 3 v1.2.0 UX backlog queued; F1 CSPro build pending Designer sign-off; F3/F4 Build-ready) | F1 `FacilityHeadSurvey.fmf` Section A layout (Sprint 003); F3/F4 build slots TBD; F2 Round 3 UX features (#16/#17/#18) when slot opens |
+| **4** | Backend & Sync Infrastructure (CSWeb for CAPI; Apps Script + Cloudflare Pages + Worker for PWA) | **In Progress** (PWA staging on auth re-arch v1.2.0 via Worker JWT proxy; production on v1.1.1 + Verde Manual visual port via #42, auth re-arch awaiting Phase F cutover; CF Pages auto-deploy confirmed broken on both branches via #34, manual `wrangler pages deploy` is current workaround; CSWeb track Not Started) | **E4-PWA-013** Phase F production cutover decision (≥24 hr staging soak + #33/#34 resolved; Sprint 003 committed *critical*; decision window ~17:35 PHT 2026-04-27); CSWeb provisioning + integration ETL spec drafted |
+| **5** | Field Distribution & Device Management (tablets for CAPI; URL distribution + PWA install + reminder ops for F2) | **In Progress** (PWA distribution model proven via UAT; CAPI tablet spec drafted 2026-04-29 — E5-CAPI-001 in-progress, awaiting procurement confirmation from ASPSI ops) | Tablet provisioning SOP drafted; F2 distribution-list SOP drafted |
+| **6** | Testing and Pilot | **Mode-aware:** PWA test stack live (vitest + Playwright + cross-platform QA; UAT Rounds 1+2 closed). CAPI track Not Started. | F1 desk test (follows Epic 3); QA Tester (Shan) handoff workflow extended to CAPI |
+| **7** | Training and Documentation | **In Progress** (Survey Manual CAPI section + 2 appendices drafted 2026-04-29 for Kidd's review; training decks Not Started) | Kidd's review on E7-DOC-001 draft; resolve open questions (questionnaire-number scheme, F2 manual scope, PAPI fallback); CAPI training deck E7-TRAIN-001 |
+| **8** | Fieldwork Monitoring and Quality Control | Not Started (activates at fieldwork) | Cross-track BI dashboard scaffolded (CSWeb + F2 backend in one view) |
+| **9** | Data Management and Security | **Governance Active** (NDU + privacy compliance ongoing) | Secure sync + backup strategy defined for both tracks |
+| **10** | Data Cleaning and Processing | Not Started | Shared codebook + harmonization ETL spec drafted alongside instrument design |
+| **11** | Analysis Support & Deliverables | Not Started | Interim tabulation template prepared ahead of D4; CSV + Stata export pipeline defined for both tracks |
+| **12** | Handover, Closeout & Retrospective | Not Started | NDU-compliant file disposition plan |
+
+### By Survey Instrument
+
+| Instrument | Mode | Pages | Current State |
+|---|---|---|---|
+| **F1 — Facility Head** | Interviewer-administered (CSPro CAPI) | 34 | **Design — closing** — DCF at 12 records / 671 items (post Apr 21 GPS+photo+PSGC-cascade pass); E2-F1-009b closed 2026-04-17; skip-logic spec aligned with F3/F4 on 2026-04-21; PSGC value sets still blocked on ASPSI; Designer round 2 / sign-off (E2-F1-010) is the next milestone |
+| **F2 — Healthcare Worker** | **Self-admin — PWA (primary). Google Forms + CSPro-encoder fallbacks retired 2026-04-17. CSPro F2 track: least priority — do not reopen.** | 14 | **Production live at v1.1.1 (2026-04-25).** UAT Rounds 1 + 2 both closed (13 issues fixed). PWA at `deliverables/F2/PWA/app/`; production https://f2-pwa.pages.dev; staging https://b1e46a55.f2-pwa-staging.pages.dev. UAT automation live (Slack events + daily digest + release-notes pipeline). Round 3 (v1.2.0) backlog queued: 3 enhancement items + Verde Manual visual-identity migration (DESIGN.md committed 2026-04-26, PRs #37 tokens + #38 fonts open, PR 3 layout deferred). |
+| **F3 — Patient** | Interviewer-administered (CSPro CAPI) | 23 | **Design — Build-ready 2026-04-21** (18 records / 840 items, sections A–L). Skip-logic + validation spec reviewed at `deliverables/CSPro/F3/F3-Skip-Logic-and-Validations.md`; 1 question to Juvy (Q31 IP_GROUP). |
+| **F4 — Household** | Interviewer-administered (roster-heavy, new for Year 2; CSPro CAPI) | 26 | **Design — Build-ready 2026-04-21** (22 records / 623 items, sections A–Q; skip-logic + validation spec at `deliverables/CSPro/F4/F4-Skip-Logic-and-Validations.md`; `C_HOUSEHOLD_ROSTER` already repeating at `max_occurs=20`, `J_HEALTH_SEEKING` intentionally respondent-level — assumed schema patch closed by verification). |
+| **PLF — Patient Listing Form** | Recruitment form | 1 | Source Captured |
+
+---
+
+**Top-level risks on the watchlist (Likelihood High OR Impact High):**
+
+- **SJREB ethics clearance delay** — Likelihood Medium, Impact High — blocks all pretesting and fieldwork
+- **Timeline pressure on D2 / D3 extended window / Tranche 2** — Likelihood High (Tranche 2 due Fri 2026-04-24), Impact High — late delivery penalty applies (1% of total per calendar day if no further extension)
+- **F2 questionnaire cover blocks authored interviewer-style** — Likelihood High (confirmed), Impact Low — PWA renders its own cover blocks from spec; print-mode / paper fallback still gated on ASPSI review of the rewrite draft
+- **PII breach or data loss** — Likelihood Low, Impact High — regulatory and reputational
+
+---
+
+## Sprint Board
+
+| To Do | In Progress | Review | Blocked | Done |
+|-------|-------------|--------|---------|------|
+| 9 | 0 | 0 | 0 | 0 / 9 |
+
+## Yesterday — since 2026-04-30
+
+**(root)/**
+- `index.md`
+
+**deliverables/**
+- `deliverables/F2/PWA/app/src/App.tsx`
+- `deliverables/F2/PWA/app/src/components/survey/Question.tsx`
+- `deliverables/F2/PWA/app/src/components/survey/Section.cross-question.test.tsx`
+- `deliverables/F2/PWA/app/src/lib/db.ts`
+- `deliverables/F2/PWA/app/src/lib/draft.ts`
+- `deliverables/F2/PWA/app/src/lib/enrollment.test.ts`
+- `deliverables/F2/PWA/app/src/lib/enrollment.ts`
+- `deliverables/F2/PWA/app/vite.config.ts`
+- `deliverables/F2/PWA/worker/src/admin.ts`
+- `deliverables/comms/_weekly-status-template.md`
+- `deliverables/comms/weekly-status-2026-05-01.md`
+
+**docs/**
+- `docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md`
+
+**scrum/**
+- `scrum/epics/epic-00-project-management.md`
+- `scrum/sprint-current.md`
+
+**wiki/**
+- `wiki/analyses/Analysis - DOH-PMSMD Matrix Feedback Triage.md`
+
+## Today (Plan)
+
+| # | ID | Item | Status | Priority | Estimate |
+|---|----|------|--------|----------|----------|
+| 1 | **E2-F1-010** | F1 DCF opened in CSPro Designer, full validation walkthrough (including new case-control block: `SURVEY_CODE`, `INTERVIEWER_ID`, `DATE_STARTED`, `TIME_STARTED`, `AAPOR_DISPOSITION`, `FACILITY_NAME`, `FACILITY_ADDRESS`), bug list closed or explicitly deferred, sign-off note recorded | todo | critical | 4h |
+| 2 | **E0-010** | Define weekly status update format for ASPSI Management Committee (Carl → Juvy / Dr Claro / Dr Paunlagui) | todo | high | 2h |
+| 3 | **E0-020** | SJREB application status check via ASPSI | todo | critical | — |
+| 4 | **E0-032** | Track D2/D3/Tranche 2 deadline exposure this week — confirm official revised deadline from DOH; submit package immediately on confirmation | todo | high | — |
+| 5 | **E3-F1-001** | F1 FMF Section A layout in CSPro Designer — generator skeleton (`FacilityHeadSurvey.generated.fmf`) is ready; Designer opens the file, applies form-layout-plan splits (per-subsection forms, no scrolling, roster-scrolls-alone), visual polish. Output: Designer-reviewed FMF saved as `FacilityHeadSurvey.fmf`. | todo | high | 4h |
+| 6 | **E4-PWA-013** | F2 PWA auth re-arch Phase F production cutover decision — by ~17:35 PHT today, assess Issue #33 (Section F/G multi-select state pollution) + #34 (CF Pages auto-deploy broken on both branches) status; if both resolved AND ≥24h clean staging soak holds, execute production cutover of Worker JWT proxy to `f2-pwa.pages.dev` per `docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md`; if either still open, document deferral with reason and re-gate criteria in `log.md`. | todo | critical | 2h decide + 1h cut OR 0h defer |
+| 7 | **E2-F3-010** | F3 DCF Designer validation pass — verify case-control block in FIELD_CONTROL, full item walkthrough; sign-off note recorded | todo | medium | 3h |
+| 8 | **E2-F4-010** | F4 DCF Designer validation pass — same scope as F3 | todo | medium | 3h |
+| 9 | **E0-008** | Auto-standup retro-injection — extend `.claude/scripts/generate_standup.py` to read the prior sprint's `## Retrospective` Q4 ("One thing to change in Sprint N+1") and surface it as a Day 1 banner in the next sprint's first standup. Closes the ritual gap (Sprint 001→002 and Sprint 002→003 both had retro Q4 captured in `sprint-current.md` Daily Notes but not surfaced in the Day 1 daily standup). | todo | medium | 1h |
+
+## Blockers & Impediments
+
+- **At risk:** **E2-F1-010** F1 DCF opened in CSPro Designer, full validation walkthrough (including new case-control block: `SURVEY_CODE`, `INTERVIEWER_ID`, `DATE_STARTED`, `TIME_STARTED`, `AAPOR_DISPOSITION`, `FACILITY_NAME`, `FACILITY_ADDRESS`), bug list closed or explicitly deferred, sign-off note recorded — still `todo` past sprint midpoint
+- **At risk:** **E0-010** Define weekly status update format for ASPSI Management Committee (Carl → Juvy / Dr Claro / Dr Paunlagui) — still `todo` past sprint midpoint
+- **At risk:** **E0-020** SJREB application status check via ASPSI — still `todo` past sprint midpoint
+- **At risk:** **E0-032** Track D2/D3/Tranche 2 deadline exposure this week — confirm official revised deadline from DOH; submit package immediately on confirmation — still `todo` past sprint midpoint
+- **At risk:** **E3-F1-001** F1 FMF Section A layout in CSPro Designer — generator skeleton (`FacilityHeadSurvey.generated.fmf`) is ready; Designer opens the file, applies form-layout-plan splits (per-subsection forms, no scrolling, roster-scrolls-alone), visual polish. Output: Designer-reviewed FMF saved as `FacilityHeadSurvey.fmf`. — still `todo` past sprint midpoint
+- **At risk:** **E4-PWA-013** F2 PWA auth re-arch Phase F production cutover decision — by ~17:35 PHT today, assess Issue #33 (Section F/G multi-select state pollution) + #34 (CF Pages auto-deploy broken on both branches) status; if both resolved AND ≥24h clean staging soak holds, execute production cutover of Worker JWT proxy to `f2-pwa.pages.dev` per `docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md`; if either still open, document deferral with reason and re-gate criteria in `log.md`. — still `todo` past sprint midpoint
+
+---
+
+## Notes
+
+_Auto-generated by `.claude/scripts/generate_standup.py` on 2026-05-01T00:07+08:00. Edit freely._

--- a/scrum/standups/2026-05-01.md
+++ b/scrum/standups/2026-05-01.md
@@ -91,7 +91,9 @@ Comms infrastructure fully provisioned (project mailbox + Viber group both live,
 
 | To Do | In Progress | Review | Blocked | Done |
 |-------|-------------|--------|---------|------|
-| 9 | 0 | 0 | 0 | 0 / 9 |
+| 7 | 0 | 0 | 0 | 0 / 7 |
+
+> Sprint-close scope audit (2026-05-01): **E0-020** (SJREB tracking), **E0-032** (Tranche/deadline tracking), **E0-032a** (DOH-PMSMD matrix triage) removed from the board — out of Data Programmer scope per CSA D1–D6. ASPSI/PI/PMO lane. See `feedback_data_programmer_scope.md` umbrella + `feedback_e0_032a_out_of_scope.md`. Original 9-item count included these three leaks.
 
 ## Yesterday — since 2026-04-30
 
@@ -126,26 +128,30 @@ Comms infrastructure fully provisioned (project mailbox + Viber group both live,
 | # | ID | Item | Status | Priority | Estimate |
 |---|----|------|--------|----------|----------|
 | 1 | **E2-F1-010** | F1 DCF opened in CSPro Designer, full validation walkthrough (including new case-control block: `SURVEY_CODE`, `INTERVIEWER_ID`, `DATE_STARTED`, `TIME_STARTED`, `AAPOR_DISPOSITION`, `FACILITY_NAME`, `FACILITY_ADDRESS`), bug list closed or explicitly deferred, sign-off note recorded | todo | critical | 4h |
-| 2 | **E0-010** | Define weekly status update format for ASPSI Management Committee (Carl → Juvy / Dr Claro / Dr Paunlagui) | todo | high | 2h |
-| 3 | **E0-020** | SJREB application status check via ASPSI | todo | critical | — |
-| 4 | **E0-032** | Track D2/D3/Tranche 2 deadline exposure this week — confirm official revised deadline from DOH; submit package immediately on confirmation | todo | high | — |
-| 5 | **E3-F1-001** | F1 FMF Section A layout in CSPro Designer — generator skeleton (`FacilityHeadSurvey.generated.fmf`) is ready; Designer opens the file, applies form-layout-plan splits (per-subsection forms, no scrolling, roster-scrolls-alone), visual polish. Output: Designer-reviewed FMF saved as `FacilityHeadSurvey.fmf`. | todo | high | 4h |
-| 6 | **E4-PWA-013** | F2 PWA auth re-arch Phase F production cutover decision — by ~17:35 PHT today, assess Issue #33 (Section F/G multi-select state pollution) + #34 (CF Pages auto-deploy broken on both branches) status; if both resolved AND ≥24h clean staging soak holds, execute production cutover of Worker JWT proxy to `f2-pwa.pages.dev` per `docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md`; if either still open, document deferral with reason and re-gate criteria in `log.md`. | todo | critical | 2h decide + 1h cut OR 0h defer |
-| 7 | **E2-F3-010** | F3 DCF Designer validation pass — verify case-control block in FIELD_CONTROL, full item walkthrough; sign-off note recorded | todo | medium | 3h |
-| 8 | **E2-F4-010** | F4 DCF Designer validation pass — same scope as F3 | todo | medium | 3h |
-| 9 | **E0-008** | Auto-standup retro-injection — extend `.claude/scripts/generate_standup.py` to read the prior sprint's `## Retrospective` Q4 ("One thing to change in Sprint N+1") and surface it as a Day 1 banner in the next sprint's first standup. Closes the ritual gap (Sprint 001→002 and Sprint 002→003 both had retro Q4 captured in `sprint-current.md` Daily Notes but not surfaced in the Day 1 daily standup). | todo | medium | 1h |
+| 2 | **E0-010** | Define weekly status update format (internal-only — Carl's tracking, not for ASPSI Mgmt send per `feedback_weekly_status_internal_only.md`) | todo | high | 2h |
+| 3 | **E3-F1-001** | F1 FMF Section A layout in CSPro Designer — generator skeleton (`FacilityHeadSurvey.generated.fmf`) is ready; Designer opens the file, applies form-layout-plan splits (per-subsection forms, no scrolling, roster-scrolls-alone), visual polish. Output: Designer-reviewed FMF saved as `FacilityHeadSurvey.fmf`. | todo | high | 4h |
+| 4 | **E4-PWA-013** | F2 PWA auth re-arch Phase F production cutover decision — assess Issue #33 (Section F/G multi-select state pollution) + #34 (CF Pages auto-deploy broken on both branches) status; if both resolved AND ≥24h clean staging soak holds, execute production cutover of Worker JWT proxy to `f2-pwa.pages.dev` per `docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md`; if either still open, document deferral with reason and re-gate criteria in `log.md`. | todo | critical | 2h decide + 1h cut OR 0h defer |
+| 5 | **E2-F3-010** | F3 DCF Designer validation pass — verify case-control block in FIELD_CONTROL, full item walkthrough; sign-off note recorded | todo | medium | 3h |
+| 6 | **E2-F4-010** | F4 DCF Designer validation pass — same scope as F3 | todo | medium | 3h |
+| 7 | **E0-008** | Auto-standup retro-injection — extend `.claude/scripts/generate_standup.py` to read the prior sprint's `## Retrospective` Q4 ("One thing to change in Sprint N+1") and surface it as a Day 1 banner in the next sprint's first standup. Closes the ritual gap (Sprint 001→002 and Sprint 002→003 both had retro Q4 captured in `sprint-current.md` Daily Notes but not surfaced in the Day 1 daily standup). | todo | medium | 1h |
 
 ## Blockers & Impediments
 
-- **At risk:** **E2-F1-010** F1 DCF opened in CSPro Designer, full validation walkthrough (including new case-control block: `SURVEY_CODE`, `INTERVIEWER_ID`, `DATE_STARTED`, `TIME_STARTED`, `AAPOR_DISPOSITION`, `FACILITY_NAME`, `FACILITY_ADDRESS`), bug list closed or explicitly deferred, sign-off note recorded — still `todo` past sprint midpoint
-- **At risk:** **E0-010** Define weekly status update format for ASPSI Management Committee (Carl → Juvy / Dr Claro / Dr Paunlagui) — still `todo` past sprint midpoint
-- **At risk:** **E0-020** SJREB application status check via ASPSI — still `todo` past sprint midpoint
-- **At risk:** **E0-032** Track D2/D3/Tranche 2 deadline exposure this week — confirm official revised deadline from DOH; submit package immediately on confirmation — still `todo` past sprint midpoint
-- **At risk:** **E3-F1-001** F1 FMF Section A layout in CSPro Designer — generator skeleton (`FacilityHeadSurvey.generated.fmf`) is ready; Designer opens the file, applies form-layout-plan splits (per-subsection forms, no scrolling, roster-scrolls-alone), visual polish. Output: Designer-reviewed FMF saved as `FacilityHeadSurvey.fmf`. — still `todo` past sprint midpoint
-- **At risk:** **E4-PWA-013** F2 PWA auth re-arch Phase F production cutover decision — by ~17:35 PHT today, assess Issue #33 (Section F/G multi-select state pollution) + #34 (CF Pages auto-deploy broken on both branches) status; if both resolved AND ≥24h clean staging soak holds, execute production cutover of Worker JWT proxy to `f2-pwa.pages.dev` per `docs/superpowers/runbooks/2026-04-26-f2-auth-cutover.md`; if either still open, document deferral with reason and re-gate criteria in `log.md`. — still `todo` past sprint midpoint
+- **At risk:** **E2-F1-010** F1 DCF Designer sign-off — still `todo` at sprint close; carrying to Sprint 004 as a three-sprint carry
+- **At risk:** **E0-010** Define internal weekly status format — still `todo` at sprint close
+- **At risk:** **E3-F1-001** F1 FMF Section A layout — still `todo` at sprint close (gated on E2-F1-010 anyway)
+- **At risk:** **E4-PWA-013** F2 PWA Phase F cutover decision — still `todo` at sprint close; soak gate likely re-set by post-merge deploy of #45/#47/#48/#49 PRs
+
+## Out of Data Programmer scope (informational — ASPSI/PI/PMO lane)
+
+- **E0-020** SJREB application status — owned by ASPSI ops / PI (Dr Claro, Dr Paunlagui, Juvy as PMO). Project-level dependency for Epic 6 (pretest), not a Carl line item.
+- **E0-032** D2/D3/Tranche 2 deadline tracking — owned by ASPSI/PI; Carl's deliverables (F1 DCF + sign-off, F2 PWA in production) are the *production* side of D2/D3, but submission timing is ASPSI's call.
+- **E0-032a** DOH-PMSMD matrix feedback triage — coordination overhead is ASPSI/PI lane. Any specific F1/F2/F3/F4 revisions arising from matrix feedback fold into the relevant E2/E3 instrument task, not into a Carl-owned E0 item.
 
 ---
 
 ## Notes
 
 _Auto-generated by `.claude/scripts/generate_standup.py` on 2026-05-01T00:07+08:00. Edit freely._
+
+_Edited 2026-05-01 sprint-close: removed E0-020 / E0-032 / E0-032a from Today (Plan) + Blockers — out of Data Programmer scope per CSA D1–D6. See sprint-current.md Daily Notes 2026-05-01 entry and `feedback_e0_032a_out_of_scope.md`._


### PR DESCRIPTION
Closes #45.

## Summary
- `vite.config.ts` — switch to function form; new `assertRequiredEnv(mode)` throws on production build if `VITE_F2_PROXY_URL` is unset or still the .env.example REPLACE_ME placeholder. Vitest / dev unaffected (mode-gated).
- `.env.example` — explicit "REQUIRED for production builds" callout cross-referencing this issue.
- `.github/workflows/cf-pages-deploy.yml` — passes \`VITE_F2_PROXY_URL\` from a repo secret to the build step. Without this the CI workflow itself would now fail with the new guard.

## Why
Production builds without `VITE_F2_PROXY_URL` silently bake an unset value and the deployed PWA renders a "VITE_F2_PROXY_URL is not set" error at the enrollment screen — broken for every user. Hit twice this engagement: once during the 2026-04-26 cutover, once when the SHA \`0f65defc\` smoke-test deploy went out today at 16:40 PHT and the 24h soak window was effectively dead until I caught it during the smoke walk-through.

## Test plan
- [x] Empty env → \`npm run build\` fails fast with the helpful message
- [x] Set env → build succeeds, bundle works (smoke-tested live on \`be427992.f2-pwa-staging.pages.dev\`)
- [x] Vitest run — 312/312 green (mode='test' skips the guard)

## Required repo secret before merge

Add \`VITE_F2_PROXY_URL\` to repo Settings → Secrets and variables → Actions:
- Value: \`https://f2-pwa-worker.hcw.workers.dev\` (no trailing slash)
- Same place as \`CLOUDFLARE_API_TOKEN\` + \`CLOUDFLARE_ACCOUNT_ID\` from PR #44

Without this secret, the CF Pages deploy workflow will fail on the build step (which is the point — fail-fast on misconfigured deploys).

## Phase F implication
Closes one of the three Phase F readiness gaps from today's smoke test. The PBKDF2 cap fix is in PR #47 (#35); the enroll-button no-op is filed as #46 and needs deeper investigation.