### PR TITLE
fix(enrollment): allow enrollment when facility cache is empty (#46)

### DIFF
--- a/deliverables/F2/PWA/app/src/App.tsx
+++ b/deliverables/F2/PWA/app/src/App.tsx
@@ -139,7 +139,10 @@ function AppShell() {
         ? {
             hcw_id: enrollment.hcw_id,
             facility_id: enrollment.facility_id,
-            facility_type: enrollment.facility_type,
+            // facility_type is optional on EnrollmentRow (Issue #46); only
+            // include the field if populated so exactOptionalPropertyTypes
+            // is happy.
+            ...(enrollment.facility_type ? { facility_type: enrollment.facility_type } : {}),
           }
         : null,
     [enrollment],

--- a/deliverables/F2/PWA/app/src/lib/db.ts
+++ b/deliverables/F2/PWA/app/src/lib/db.ts
@@ -58,7 +58,13 @@ export interface EnrollmentRow {
   id: 'singleton';
   hcw_id: string;
   facility_id: string;
-  facility_type: string;
+  /**
+   * Optional. Populated from the local facilities cache at enroll time when
+   * available. On a fresh tablet whose facility cache is empty (Issue #46),
+   * enrollment still completes; `facility_type` is filled later when the
+   * facilities sync runs (consumers fall back to '' or look it up live).
+   */
+  facility_type?: string;
   enrolled_at: number;
   /**
    * Per-tablet JWT issued by the Cloudflare Worker (spec §5).

--- a/deliverables/F2/PWA/app/src/lib/draft.ts
+++ b/deliverables/F2/PWA/app/src/lib/draft.ts
@@ -6,7 +6,13 @@ export const LOCAL_SPEC_VERSION = '2026-04-17-m1';
 export interface EnrollmentInfo {
   hcw_id: string;
   facility_id: string;
-  facility_type: string;
+  /**
+   * Optional — see EnrollmentRow comment in db.ts. Submissions made before
+   * the facilities cache populates carry an empty `facility_type`; backend
+   * tolerates this and the value can be backfilled from facility_id at
+   * analysis time.
+   */
+  facility_type?: string;
 }
 
 export function getOrCreateDraftId(): string {
@@ -43,7 +49,7 @@ export async function submitDraft(id: string, enrollment: EnrollmentInfo): Promi
     const valuesWithFacility = {
       ...draft.values,
       facility_id: enrollment.facility_id,
-      facility_type: enrollment.facility_type,
+      facility_type: enrollment.facility_type ?? '',
     };
 
     const submission: SubmissionRow = {

--- a/deliverables/F2/PWA/app/src/lib/enrollment.test.ts
+++ b/deliverables/F2/PWA/app/src/lib/enrollment.test.ts
@@ -44,10 +44,36 @@ describe('enrollment store', () => {
     expect(reloaded).toEqual(row);
   });
 
-  it('setEnrollment throws if the facility_id is unknown to the cache', async () => {
-    await expect(
-      setEnrollment({ hcw_id: 'HCW-1', facility_id: 'F-XXX', device_token: FAKE_TOKEN }),
-    ).rejects.toThrow(/facility F-XXX/i);
+  // Issue #46: enrollment must succeed on a fresh tablet whose facilities
+  // cache is empty. The cache populates from /facilities (authenticated)
+  // after enrollment completes, so requiring it pre-enroll deadlocks first
+  // use. The verified JWT (already server-checked by /verify-token before
+  // setEnrollment is called) is the authoritative facility_id source; the
+  // local cache lookup was a soft check, not a security boundary.
+  it('setEnrollment succeeds when the facility is not in the local cache (fresh-tablet path)', async () => {
+    const row = await setEnrollment({
+      hcw_id: 'HCW-1',
+      facility_id: 'F-XXX',
+      device_token: FAKE_TOKEN,
+    });
+    expect(row).toMatchObject({
+      id: 'singleton',
+      hcw_id: 'HCW-1',
+      facility_id: 'F-XXX',
+      device_token: FAKE_TOKEN,
+    });
+    // facility_type is omitted entirely when the facility isn't cached.
+    expect('facility_type' in row && row.facility_type !== undefined).toBe(false);
+  });
+
+  it('setEnrollment populates facility_type when the facility IS cached', async () => {
+    // F-001 is in the cache via beforeEach.
+    const row = await setEnrollment({
+      hcw_id: 'HCW-2',
+      facility_id: 'F-001',
+      device_token: FAKE_TOKEN,
+    });
+    expect(row.facility_type).toBe('Hospital');
   });
 
   it('setEnrollment throws on empty hcw_id', async () => {

--- a/deliverables/F2/PWA/app/src/lib/enrollment.ts
+++ b/deliverables/F2/PWA/app/src/lib/enrollment.ts
@@ -21,17 +21,23 @@ export async function setEnrollment(input: SetEnrollmentInput): Promise<Enrollme
   if (trimmedToken.length === 0) {
     throw new Error('device_token is required');
   }
+  // Issue #46: a fresh tablet's local facilities cache is empty until the
+  // first authenticated /facilities sync (which itself needs the device
+  // token from a completed enrollment — chicken-and-egg). Don't gate
+  // enrollment on the cache lookup; populate facility_type when the
+  // facility happens to be cached, otherwise leave it undefined and let
+  // the post-enrollment sync backfill it. The verified JWT (already
+  // server-checked by /verify-token before this call) is the authoritative
+  // source of facility_id, so the local cache check was a soft check, not
+  // a security boundary.
   const facility = await db.facilities.get(input.facility_id);
-  if (!facility) {
-    throw new Error(`Unknown facility ${input.facility_id}`);
-  }
   const row: EnrollmentRow = {
     id: 'singleton',
     hcw_id: trimmedHcw,
-    facility_id: facility.facility_id,
-    facility_type: facility.facility_type,
+    facility_id: facility?.facility_id ?? input.facility_id,
     enrolled_at: Date.now(),
     device_token: trimmedToken,
+    ...(facility?.facility_type ? { facility_type: facility.facility_type } : {}),
   };
   await db.enrollment.put(row);
   return row;


### PR DESCRIPTION
Closes #46.

## Summary
- \`db.ts:EnrollmentRow.facility_type\` made optional.
- \`enrollment.ts:setEnrollment\` no longer throws when the facility isn't cached. It populates \`facility_type\` if the lookup succeeds; otherwise omits the field. The verified JWT remains the authoritative \`facility_id\` source — the cache lookup was a soft check, not a security boundary.
- \`draft.ts:EnrollmentInfo.facility_type\` matched: optional, with \`''\` fallback in submissions.
- \`App.tsx\` uses conditional spread to satisfy \`exactOptionalPropertyTypes\`.
- \`enrollment.test.ts\`: replaced the "throws on unknown facility" test with two new ones — fresh-tablet path succeeds with \`facility_type\` omitted, cached-facility path still populates it.

## Why
Today's smoke test against \`f2-pwa-staging.pages.dev\` (deploy SHA \`0f65defc\`) found that the Enroll button on Step 2 of enrollment did nothing visible — under the hood, \`setEnrollment\` was throwing \`Unknown facility F-001\` because the local Dexie cache was empty. Chicken-and-egg: cache populates only from authenticated \`/facilities\`, which needs a device_token that only comes from a completed enrollment. Phase F production cutover would face this on every fresh tablet.

## Test plan
- [x] \`npm test\` — 313/313 green
- [x] \`npm run typecheck\` — clean
- [ ] After merge: redeploy staging, repeat the manual smoke test (verify token → fill HCW ID → click Enroll → confirm advance to Section A WITHOUT the IDB-write workaround used during today's smoke).

## Phase F implication
Closes the third (and last) Phase F gate from today's smoke test. Combined with #47 (PBKDF2 cap) and #48 (env var build guard), all three readiness gaps surfaced today are addressed in code. Soak window can restart once these merge.