### PR TITLE
fix(F2): v1.3.0 high+medium severity batch (#20 #21 #23 #24)

### DIFF
--- a/deliverables/F2/PWA/app/src/App.tsx
+++ b/deliverables/F2/PWA/app/src/App.tsx
@@ -247,11 +247,11 @@ function AppShell() {
   };
 
   return (
-    <main className="mx-auto flex min-h-screen-dvh w-full max-w-screen-2xl flex-col">
+    <main className="mx-auto flex min-h-screen-dvh w-full max-w-screen-xl flex-col">
       <BroadcastBanner message={runtimeConfig.broadcast_message} />
       <header className="flex items-center justify-between border-b px-6 py-3">
         <div className="flex flex-col">
-          <h1 className="font-serif text-2xl font-medium tracking-tight">{t('chrome.appTitle')}</h1>
+          <h1 className="font-serif text-3xl font-medium tracking-tight">{t('chrome.appTitle')}</h1>
           <span className="font-mono text-xs leading-none text-muted-foreground">
             v{APP_VERSION} · spec {LOCAL_SPEC_VERSION}
           </span>

--- a/deliverables/F2/PWA/app/src/components/ui/button.tsx
+++ b/deliverables/F2/PWA/app/src/components/ui/button.tsx
@@ -4,8 +4,12 @@ import { cn } from '@/lib/utils';
 
 // Verde Manual: buttons are flat. Solid color (primary, destructive) carries
 // prominence; outline uses the hairline border. No shadows on chrome — see DESIGN.md.
+//
+// Default size is 44px (h-11) — Apple HIG / WCAG minimum touch target for
+// gloved tablet use in the field. The `sm` 32px size is reserved for desktop
+// chrome (header utilities) where mouse-precision is the input model.
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground disabled:hover:bg-muted',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground disabled:hover:bg-muted',
   {
     variants: {
       variant: {
@@ -17,10 +21,10 @@ const buttonVariants = cva(
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-9 px-4 py-2',
+        default: 'h-11 px-4 py-2',
         sm: 'h-8 rounded-md px-3 text-xs',
-        lg: 'h-10 rounded-md px-8',
-        icon: 'h-9 w-9',
+        lg: 'h-12 rounded-md px-8',
+        icon: 'h-11 w-11',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary

Round 4 ASPSI UAT readiness — batch fix for the 4 high-severity + 2 medium-severity v1.3.0 internal-QA issues.

| Issue | Severity | Fix |
|-------|----------|-----|
| #20 | HIGH visual | Page \`<h1>\` bumped from \`text-2xl\` (24px) to \`text-3xl\` (28px) so the page title is consistently larger than every \`<h2>\`. |
| #21 | HIGH visual | \`<main>\` capped at \`max-w-screen-xl\` (1280px) instead of \`max-w-screen-2xl\` (1536px). Form now centers symmetrically on 1920px+ viewports. Matches DESIGN.md "Frame max width 1280px". |
| #23 | MEDIUM ux/a11y | Default Button height \`h-9\` (36px) → \`h-11\` (44px). Meets WCAG / Apple HIG 44×44 minimum tap target for gloved tablet use. \`lg\` and \`icon\` sizes bumped proportionally. \`sm\` kept at \`h-8\` (32px) as explicit compact variant for desktop chrome. |
| #24 | MEDIUM a11y | \`focus-visible\` ring upgraded from \`ring-1\` (no offset) to \`ring-2 ring-offset-2 ring-offset-background\` (2px ring + 2px offset). Matches DESIGN.md a11y rule. |

## Already-fixed (verified, not closed by this PR but documented)

- **#19** Q4/Q9/Q10/Q11 — raw Zod \`Expected number, received nan\`. Already fixed by \`src/lib/zod-error-map.ts\` (added in PR #31, imported via \`src/main.tsx:5\`). The 2026-04-25 QA report predated PR #31 (merged 2026-04-26).
- **#22** Disabled buttons fail WCAG AA contrast. Already fixed by Verde Manual polish (PR #41, merged 2026-04-26): \`disabled:bg-muted disabled:text-muted-foreground\` replaces the prior \`opacity:0.5\`. Computed contrast on Verde tokens passes AA (~5:1).

Both will be closed separately with verification notes after this PR lands.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 313/313 passing
- [x] \`VITE_F2_PROXY_URL=... npm run build\` — green, bundle-secrets check OK
- [ ] Smoke on staging after merge: H1 reads larger than H2 in header; layout centers on 1920×1080; Tab through enrollment shows visible 2px focus ring; tap-target on Refresh / Enroll buttons feels right on tablet.

Closes #20
Closes #21
Closes #23
Closes #24