### PR TITLE
fix(F2): EnrollmentScreen Refresh uses verified token, not pre-enrollment deviceToken (#52)

### DIFF
--- a/deliverables/F2/PWA/app/src/App.tsx
+++ b/deliverables/F2/PWA/app/src/App.tsx
@@ -279,7 +279,7 @@ function AppShell() {
       {authStatus === 'loading' ? (
         <p className="p-6 text-sm text-muted-foreground">{t('chrome.loading')}</p>
       ) : authStatus === 'unenrolled' ? (
-        <EnrollmentScreen onRefresh={refresh} />
+        <EnrollmentScreen />
       ) : view === 'sync' ? (
         <Suspense
           fallback={<p className="p-6 text-sm text-muted-foreground">{t('chrome.loading')}</p>}

--- a/deliverables/F2/PWA/app/src/a11y.test.tsx
+++ b/deliverables/F2/PWA/app/src/a11y.test.tsx
@@ -48,7 +48,7 @@ describe('a11y pages', () => {
 
   it('enrollment screen has no violations', async () => {
     const { container } = render(
-      wrap(<EnrollmentScreen onRefresh={async () => ({ ok: true, count: 0 })} />),
+      wrap(<EnrollmentScreen />),
     );
     expect(await axe(container, AXE_COMPONENT_CONFIG)).toHaveNoViolations();
   });

--- a/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.test.tsx
+++ b/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.test.tsx
@@ -14,6 +14,7 @@ import { LocaleProvider } from '@/i18n/locale-context';
 import { db } from '@/lib/db';
 import { EnrollmentScreen } from './EnrollmentScreen';
 import * as verifyClient from '@/lib/verify-token-client';
+import * as facilitiesClient from '@/lib/facilities-client';
 
 const FAKE_TOKEN = 'eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJ0In0.fake-sig';
 
@@ -28,14 +29,28 @@ function mockVerifyOk(facilityId = 'F-001') {
   });
 }
 
-function setup(props: Partial<React.ComponentProps<typeof EnrollmentScreen>> = {}) {
+function mockGetFacilitiesOk(facilities = [
+  {
+    facility_id: 'F-NEW',
+    facility_name: 'Newly Fetched',
+    facility_type: 'RHU',
+    region: 'NCR',
+    province: 'Metro Manila',
+    city_mun: 'Quezon City',
+    barangay: 'Test',
+  },
+]) {
+  return vi.spyOn(facilitiesClient, 'getFacilities').mockResolvedValue({
+    ok: true,
+    facilities,
+  });
+}
+
+function setup() {
   return render(
     <LocaleProvider>
       <AuthProvider>
-        <EnrollmentScreen
-          onRefresh={vi.fn().mockResolvedValue({ ok: true, count: 1 })}
-          {...props}
-        />
+        <EnrollmentScreen />
       </AuthProvider>
     </LocaleProvider>,
   );
@@ -160,15 +175,29 @@ describe('<EnrollmentScreen>', () => {
     });
   });
 
-  it('calls onRefresh when the refresh button is clicked (after token verify)', async () => {
+  it('refreshes facilities via the verified token when Refresh is clicked', async () => {
     mockVerifyOk('F-001');
-    const onRefresh = vi.fn().mockResolvedValue({ ok: true, count: 2 });
+    const getFacilitiesSpy = mockGetFacilitiesOk();
     const user = userEvent.setup();
-    setup({ onRefresh });
+    setup();
     await user.type(screen.getByTestId('enrollment-token-input'), FAKE_TOKEN);
     await user.click(screen.getByRole('button', { name: /verify token/i }));
     await waitFor(() => screen.getByLabelText(/HCW ID/i));
+    // The verify path auto-seeds the cache, so call count is 1 after verify.
+    // Clicking Refresh again should bump to 2 and pass the verified token.
     await user.click(screen.getByRole('button', { name: /refresh/i }));
-    expect(onRefresh).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(getFacilitiesSpy).toHaveBeenCalledTimes(2));
+    expect(getFacilitiesSpy.mock.calls[1]?.[0]?.deviceToken).toBe(FAKE_TOKEN);
+  });
+
+  it('auto-seeds the facility cache on token verify (no manual Refresh needed)', async () => {
+    mockVerifyOk('F-001');
+    const getFacilitiesSpy = mockGetFacilitiesOk();
+    const user = userEvent.setup();
+    setup();
+    await user.type(screen.getByTestId('enrollment-token-input'), FAKE_TOKEN);
+    await user.click(screen.getByRole('button', { name: /verify token/i }));
+    await waitFor(() => expect(getFacilitiesSpy).toHaveBeenCalledTimes(1));
+    expect(getFacilitiesSpy.mock.calls[0]?.[0]?.deviceToken).toBe(FAKE_TOKEN);
   });
 });

--- a/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.tsx
+++ b/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.tsx
@@ -2,22 +2,22 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/lib/auth-context';
-import { listFacilities, type RefreshResult } from '@/lib/facilities-cache';
+import { listFacilities, refreshFacilities } from '@/lib/facilities-cache';
 import type { FacilityRow } from '@/lib/db';
 import { getSyncEnv } from '@/lib/env';
+import { getFacilities } from '@/lib/facilities-client';
 import { verifyDeviceToken } from '@/lib/verify-token-client';
-
-interface EnrollmentScreenProps {
-  onRefresh: () => Promise<RefreshResult>;
-}
 
 /**
  * Two-step enrollment after the auth re-arch (spec §4.2):
  *   Step 1: paste tablet token, verify against Worker, store claims locally.
  *   Step 2: pick yourself from the facility's roster (facility is pre-locked
  *           by the token's `facility_id` claim — only the HCW ID picker is shown).
+ *
+ * Refresh uses the just-verified token directly — pre-enrollment there's no
+ * deviceToken in auth-context yet, so we can't rely on App.tsx's refresh.
  */
-export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
+export function EnrollmentScreen() {
   const { t } = useTranslation();
   const { enroll } = useAuth();
 
@@ -62,6 +62,25 @@ export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
       }
       setVerifiedToken(token);
       setTokenFacilityId(result.claims.facility_id);
+      // Auto-seed the facility cache so the user can enroll without an extra
+      // Refresh click. Pre-cutover, the bundle had its own HMAC and refresh
+      // worked at any time; post-cutover the only cred we have is this just-
+      // verified token.
+      try {
+        const refreshResult = await refreshFacilities({
+          fetcher: () =>
+            getFacilities({
+              proxyUrl: env.proxyUrl,
+              deviceToken: token,
+              fetchImpl: fetch.bind(globalThis),
+            }),
+        });
+        if (refreshResult.ok) {
+          setFacilities(await listFacilities());
+        }
+      } catch {
+        // Non-fatal — user can click Refresh manually if auto-seed fails.
+      }
     } catch (err) {
       setError((err as Error).message);
     } finally {
@@ -70,10 +89,19 @@ export function EnrollmentScreen({ onRefresh }: EnrollmentScreenProps) {
   };
 
   const handleRefresh = async () => {
+    if (!verifiedToken) return;
     setRefreshing(true);
     setError(null);
     try {
-      const result = await onRefresh();
+      const env = getSyncEnv();
+      const result = await refreshFacilities({
+        fetcher: () =>
+          getFacilities({
+            proxyUrl: env.proxyUrl,
+            deviceToken: verifiedToken,
+            fetchImpl: fetch.bind(globalThis),
+          }),
+      });
       if (!result.ok) {
         setError(result.error.message);
       }

--- a/deliverables/F2/PWA/app/src/keyboard-nav.test.tsx
+++ b/deliverables/F2/PWA/app/src/keyboard-nav.test.tsx
@@ -12,7 +12,7 @@ describe('keyboard nav', () => {
     render(
       <I18nextProvider i18n={i18n}>
         <AuthProvider>
-          <EnrollmentScreen onRefresh={async () => ({ ok: true, count: 0 })} />
+          <EnrollmentScreen />
         </AuthProvider>
       </I18nextProvider>,
     );


### PR DESCRIPTION
## Summary

Closes #52. Resurrects the fix from stale PR #32 (closed earlier today as superseded), cleaned up to drop the unrelated 2366-line planning doc that came along on the original branch.

### Bug

During two-step enrollment, after Step 1 (token verify) succeeds, clicking **Refresh facility list** calls \`EnrollmentScreen\`'s \`onRefresh\` prop. \`App.tsx:282\` binds it to a callback that uses \`useAuth().enrollment?.device_token\` — which is empty pre-enrollment. Refresh always returned \`{ ok: false, error: 'No device token' }\`.

### Fix

Move refresh into \`EnrollmentScreen\` and source the token from Step 1's verified state (\`verifiedToken\`). Removes the \`onRefresh\` prop entirely.

### Diff

5 files / +76/-19:
- \`src/App.tsx\` — drop \`onRefresh={refresh}\` prop
- \`src/components/enrollment/EnrollmentScreen.tsx\` — internal refresh using verifiedToken
- \`src/components/enrollment/EnrollmentScreen.test.tsx\` — drop fixture, mock facilitiesClient.getFacilities
- \`src/a11y.test.tsx\` + \`src/keyboard-nav.test.tsx\` — drop the prop

### Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 314/314 (one new test for the refresh path)
- [ ] After staging deploy: enroll a fresh tablet, click Refresh after token verify, confirm facility list populates without error.