### PR TITLE
R3 prep slate 2: perf baseline + backup runbook + secrets rotation (#192 #173 #172)

### DIFF
--- a/deliverables/F2/PWA/app/PERFORMANCE.md
+++ b/deliverables/F2/PWA/app/PERFORMANCE.md
@@ -1,0 +1,83 @@
+# F2 PWA — Performance Baseline & Budget
+
+Reference baseline for the F2 PWA (HCW survey + Admin Portal) measured on production. Use this to detect regressions in future releases.
+
+**First measurement:** 2026-05-12 (PR #274 + slate 2 — closes [#192](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/192) E6-PWA-010)
+**Method:** Lighthouse 11.7.1, headless Chromium, mobile profile (default), single sample, run from operator workstation against `https://f2-pwa.pages.dev/`.
+
+> Single-sample Lighthouse numbers fluctuate ±5% run-to-run. Treat ±10pt swings on any individual metric as noise; persistent shifts of >10pt or any score dropping below the **AA budget** below as a regression.
+
+## Baseline (2026-05-12)
+
+### HCW survey root (`/`)
+
+| Metric | Value | LH score | Budget |
+|---|---|---|---|
+| **Performance** | — | **0.91** | ≥ 0.85 |
+| First Contentful Paint | 2.5 s | 0.68 | ≤ 3.0 s |
+| Largest Contentful Paint | 2.8 s | 0.83 | ≤ 4.0 s |
+| Cumulative Layout Shift | 0 | 1.0 | ≤ 0.1 |
+| Total Blocking Time | 10 ms | 1.0 | ≤ 200 ms |
+| Speed Index | 3.5 s | 0.88 | ≤ 5.8 s |
+| Time to Interactive | 2.6 s | 0.98 | ≤ 5.0 s |
+
+### Admin Portal login (`/admin/login`)
+
+| Metric | Value | LH score | Budget |
+|---|---|---|---|
+| **Performance** | — | **0.93** | ≥ 0.85 |
+| First Contentful Paint | 2.3 s | 0.75 | ≤ 3.0 s |
+| Largest Contentful Paint | 2.3 s | 0.93 | ≤ 4.0 s |
+| Cumulative Layout Shift | 0 | 1.0 | ≤ 0.1 |
+| Total Blocking Time | 190 ms | 0.91 | ≤ 200 ms |
+| Speed Index | 2.3 s | 0.99 | ≤ 5.8 s |
+| Time to Interactive | 2.6 s | 0.98 | ≤ 5.0 s |
+
+## Resource Composition
+
+HCW root first-paint network footprint (cold cache):
+
+| Resource | Requests | Transfer (gzipped) |
+|---|---|---|
+| Total | 12 | 394 KB |
+| Script (`index-*.js`) | 2 | 250 KB |
+| Font (`/fonts/*.woff2`) | 4 of 22 | 76 KB |
+| Stylesheet (`index-*.css`) | 2 | 13 KB |
+| Other (icons, vite.svg, fonts.css, sw.js) | 4 | 55 KB |
+
+Notes:
+- The font runtime cache is doing what it should — only 4 woff2 (Newsreader 500, JBMono 400, Public Sans 400+500) get fetched at first paint, not all 22. The remaining 18 weights are pulled lazily as the user encounters surfaces that use them, then cached for offline use.
+- The `index-*.js` bundle is currently 930 KB raw / 250 KB gzipped. Vite emits a chunk-size warning at the 500 KB raw threshold ([build log](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/275)) — this is a known suboptimal that doesn't currently trip the perf budget but is worth route-splitting at v2.0.2.
+
+## Budget
+
+| Surface | Perf score floor | LCP floor | TBT ceiling | CLS ceiling |
+|---|---|---|---|---|
+| HCW survey | 0.85 | ≤ 4.0 s | ≤ 200 ms | ≤ 0.1 |
+| Admin Portal | 0.85 | ≤ 4.0 s | ≤ 200 ms | ≤ 0.1 |
+| Bundle size (gzipped, single chunk) | — | — | ≤ 350 KB | — |
+
+Floor values are intentionally below current baseline — they're regression triggers, not aspirational targets. If a future release drops below any floor, a perf-regression issue gets filed automatically (TODO: wire to CI in #275 follow-up).
+
+## Re-measurement
+
+To re-run the baseline:
+
+```sh
+cd deliverables/F2/PWA/app
+npx lighthouse https://f2-pwa.pages.dev --only-categories=performance \
+  --chrome-flags="--headless=new --no-sandbox" \
+  --output=json --output-path=./lh-perf-hcw.json --quiet
+
+npx lighthouse https://f2-pwa.pages.dev/admin/login --only-categories=performance \
+  --chrome-flags="--headless=new --no-sandbox" \
+  --output=json --output-path=./lh-perf-admin.json --quiet
+```
+
+Run 3 times and average; single samples are noisy.
+
+## Known regressions / follow-ups
+
+- **Bundle splitting** ([#275](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/275) — to file): the `index-*.js` chunk is 930 KB raw. Route-level code-splitting on `/admin/*` would let the HCW survey ship with a smaller initial JS payload (most HCWs never load admin code).
+- **CI perf gate** (deferred): no automated regression detection today. Adding a Lighthouse CI step against staging on every PR would catch perf drops at the PR level instead of post-deploy.
+- **Authenticated-state perf** (deferred): same as the a11y audit limitation — Lighthouse against post-login dashboards needs cookie-injection setup. Tracked alongside [#273](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/273) (E6-PWA-009b).

--- a/docs/superpowers/runbooks/2026-05-12-f2-pwa-backup-restore.md
+++ b/docs/superpowers/runbooks/2026-05-12-f2-pwa-backup-restore.md
@@ -1,0 +1,142 @@
+# Runbook — F2 PWA backup + restore
+
+**Created:** 2026-05-12
+**Closes:** #173 (E4-PWA-011 — backup + restore runbook for FacilityMasterList + submissions sheets)
+**Owner:** Carl (hands-on Google account access — can't be delegated unless ops team has equivalent permissions on `aspsi.doh.uhc.survey2.data@gmail.com`)
+**Cadence:** Weekly Friday + before any major migration or destructive admin action
+
+---
+
+## Context
+
+The F2 backend lives in three storage layers:
+
+1. **Google Sheet** (`F2-PWA-Backend` spreadsheet on the project Gmail account) — primary durable store. 9 sheets: `F2_Responses`, `F2_Audit`, `F2_Users`, `F2_Roles`, `F2_HCWs`, `F2_FileMeta`, `F2_DataSettings`, `FacilityMasterList`, plus the original Google Forms intake sheet (legacy, retained as historical reference).
+2. **Cloudflare R2** — file uploads (training plans, rosters) + scheduled break-out CSV exports. Buckets: `f2-admin` (prod), `f2-admin-staging`. Object lifecycle: keep indefinitely (no TTL) until manual cleanup.
+3. **Cloudflare KV** (`F2_AUTH` namespace) — JWT revocation list. Ephemeral; reconstructible from `F2_HCWs.token_revoked_at` if lost.
+
+Risk profile:
+
+| Layer | Loss = | Recovery without backup |
+|---|---|---|
+| Sheet | All survey responses + audit + admin state | None — submission data is irrecoverable |
+| R2 | Operator-uploaded files + historical CSV exports | Files: irrecoverable. CSVs: re-runnable from sheet |
+| KV | Revocation list | Reconstruct from F2_HCWs in ~5 min |
+
+**Sheet is the only single-point-of-failure that can't be reconstructed from another layer.** This runbook prioritizes it.
+
+---
+
+## Backup procedure
+
+### 1. Sheet snapshot (weekly Friday)
+
+Google Sheets keeps revision history forever, but a snapshot copy gives a clean restore target if the live sheet becomes corrupted by a bad migration or accidental deletion.
+
+```
+File → Make a copy
+Name: "F2-PWA-Backend — snapshot YYYY-MM-DD"
+Folder: "Drive / ASPSI-DOH / F2 backups/"
+```
+
+Notes:
+- Copy includes all sheets, including the legacy Google Forms intake sheet.
+- Apps Script projects bound to the original sheet are NOT copied; the snapshot is a data copy only.
+- Add a note in the copy's first cell: `SNAPSHOT — DO NOT EDIT. Source: F2-PWA-Backend, taken YYYY-MM-DD HH:MM PHT by <name>.`
+
+### 2. Apps Script source export (monthly)
+
+Apps Script auto-saves every keystroke and keeps version history, but a tarball offline gives an off-platform copy.
+
+```
+clasp pull --rootDir ./backups/apps-script-YYYY-MM-DD
+```
+
+Or manually: open the AS editor → File → Download `.js` files individually. Slower but no clasp install needed.
+
+### 3. R2 bucket sync (weekly Friday)
+
+Pull all R2 objects to a local backup folder via wrangler:
+
+```
+wrangler r2 object get --recursive f2-admin --output-dir ./backups/r2/YYYY-MM-DD/
+```
+
+Sizes: typically <100 MB if file uploads are kept lean per the 100 MB-per-file ceiling.
+
+### 4. KV snapshot (optional — reconstructible)
+
+Skip unless you've recently mass-revoked tokens and want a point-in-time record:
+
+```
+wrangler kv:bulk get F2_AUTH --output ./backups/kv/F2_AUTH-YYYY-MM-DD.json
+```
+
+---
+
+## Restore procedure
+
+### Sheet — full restore from snapshot
+
+1. **Stop writes.** Apps Script editor → click the active deployment → Pause cron triggers (or set `OPS_DISABLE_WRITES=true` script property if implemented).
+2. Open the snapshot copy. Verify it's the right vintage (check the first-cell note).
+3. **Decide:** rename-and-replace OR per-sheet copy.
+   - **Rename-and-replace** (cleaner if all sheets are corrupted): rename `F2-PWA-Backend` to `F2-PWA-Backend — corrupt YYYY-MM-DD`, rename the snapshot to `F2-PWA-Backend`. Update Apps Script project to bind to the new sheet (Project Settings → Script Properties → SHEET_ID).
+   - **Per-sheet copy** (cleaner if only one sheet is corrupted): copy the affected sheet from the snapshot into the live spreadsheet (Tab → Copy to → existing spreadsheet → F2-PWA-Backend). Delete the corrupted tab.
+4. **Re-enable writes.** Resume cron triggers.
+5. **Smoke-verify:** open Admin Portal → Data → Responses; confirm the table renders. Run a test enrollment from `/admin/users` → `Add user`.
+
+### R2 — restore individual file
+
+1. Find the affected `file_id` from the `F2_FileMeta` sheet.
+2. Locate the corresponding object in `./backups/r2/<date>/`.
+3. Push back: `wrangler r2 object put f2-admin/<file_id> --file <local-path> --content-type <mime>`.
+4. Verify via Admin Portal → Apps & Settings → Files → click row → Download.
+
+### KV — full revocation-list rebuild
+
+```javascript
+// Run from AS editor or local Node script with Cloudflare API token:
+// 1. Read F2_HCWs sheet, filter where token_revoked_at IS NOT NULL
+// 2. For each, KV.put(F2_AUTH, `revoked:${enrollment_token_jti}`, '1')
+```
+
+---
+
+## Verification (post-restore)
+
+Run all of these before declaring restore complete:
+
+- [ ] Admin Portal `/admin/login` loads and authenticates.
+- [ ] `/admin/data?tab=responses` shows non-empty table for the expected period.
+- [ ] `/admin/data?tab=audit` shows audit rows for the period.
+- [ ] `/admin/apps?tab=files` shows the expected file list.
+- [ ] HCW enrollment flow: open a known `DEMO-HCW-*` enrollment URL → token validates → form loads.
+- [ ] Submit a test response → check it appears in `F2_Responses` within 60 seconds.
+
+---
+
+## Schedule
+
+| Backup | Cadence | Owner | Where |
+|---|---|---|---|
+| Sheet snapshot | Weekly Fri 17:00 PHT | Carl (or ops trainee) | Drive / ASPSI-DOH / F2 backups/ |
+| Apps Script source | Monthly first Friday | Carl | local repo `./backups/apps-script-*` (gitignored) |
+| R2 bucket sync | Weekly Fri 17:00 PHT | Carl | local repo `./backups/r2/*` (gitignored) |
+| KV snapshot | On-demand only | Carl | local repo `./backups/kv/*` (gitignored) |
+
+Pre-fieldwork (when production HCW enrollments begin), upgrade the Sheet cadence to **daily 23:00 PHT** via Apps Script time-driven trigger writing a snapshot copy programmatically. Issue to file when fieldwork start date is set.
+
+---
+
+## Restore drill (annual)
+
+Once a year, exercise the restore on staging:
+
+1. Take a snapshot of the staging sheet.
+2. Make a destructive edit on staging (delete a row, drop a column).
+3. Restore from snapshot per the procedure above.
+4. Confirm verification checklist passes.
+5. Document drill date in this file's footer.
+
+**Drills run:** _(none yet — first scheduled 2027-05-12)_

--- a/docs/superpowers/runbooks/2026-05-12-f2-secrets-rotation.md
+++ b/docs/superpowers/runbooks/2026-05-12-f2-secrets-rotation.md
@@ -1,0 +1,208 @@
+# Runbook — F2 backend secrets rotation policy
+
+**Created:** 2026-05-12
+**Closes:** #172 (E4-PWA-010 — backend secrets rotation policy documented)
+**Owner:** Carl (hands-on Cloudflare + Google Workspace + Gmail credential access — can't be delegated)
+**Cadence:** See per-secret tables below; emergency rotation on any suspected compromise
+
+---
+
+## Context
+
+The F2 PWA backend uses 6 distinct secret-bearing surfaces. This runbook defines what each is, when to rotate, how to rotate, and what breaks if you skip it.
+
+| Secret | Layer | Default cadence | Emergency trigger |
+|---|---|---|---|
+| `JWT_SIGNING_KEY` | Worker (`wrangler secret`) | Annual | Suspected leak, departing operator, post-incident |
+| `APPS_SCRIPT_HMAC` / `PROP_HMAC_SECRET` | Worker secret + AS Script Property | Annual + on AS deploy ID rotation | Same |
+| `APPS_SCRIPT_URL` (deploy ID) | Worker secret + AS deployment | When AS code changes materially | Same |
+| Cloudflare R2 access keys | Account-level (Cloudflare dashboard) | Annual | Same |
+| `aspsi.doh.uhc.survey2.data@gmail.com` password | Google Workspace | Quarterly | Same |
+| Admin user passwords (`F2_Users.password_hash`) | F2 Admin Portal — per-user | Per user, on demand (forced rotation on role change) | Suspected leak, role change, departure |
+
+**Order of operations on a multi-secret rotation:** rotate the password (Gmail) first, then everything downstream that depends on access to the AS / Cloudflare dashboard. JWT + HMAC last because they require coordinated worker + AS deploys.
+
+---
+
+## 1. `JWT_SIGNING_KEY` (Worker)
+
+**What it does:** signs every enrollment-token JWT minted for HCW tablets and every admin session JWT. Rotation invalidates all currently-active sessions and tokens — testers/HCWs need new tokens.
+
+**When to rotate:**
+- Annual (calendar reminder: every May 1)
+- Immediately if leaked (e.g., committed to git, leaked in a screenshot, exposed in a log)
+- After any operator with prod Cloudflare access leaves
+
+**How to rotate:**
+
+1. Generate new key:
+   ```sh
+   openssl rand -base64 32 | tr -d '=' | tr '+/' '-_'
+   ```
+2. Set on Worker (do staging first):
+   ```sh
+   cd deliverables/F2/PWA/worker
+   wrangler secret put JWT_SIGNING_KEY --env staging
+   # paste the new key, hit enter
+   wrangler secret put JWT_SIGNING_KEY
+   # paste the same new key for prod
+   ```
+3. Re-mint all active enrollment tokens. Open Admin Portal → Data → HCWs → for each row with `status='enrolled'`, click **REISSUE**. (For >50 HCWs, file a follow-up to add a bulk-reissue script.)
+4. Force-logout all active admin sessions: open Admin Portal → Users → for each row, click the menu → **Revoke active sessions**. (No bulk button yet.)
+5. Notify Shan + Kidd in `#f2-pwa-uat` that they need to re-login and re-enroll their test devices.
+
+**What breaks if you skip:** key compromise → arbitrary token forgery → unauthorized admin access OR unauthorized survey submission with stolen HCW identity.
+
+---
+
+## 2. `APPS_SCRIPT_HMAC` / `PROP_HMAC_SECRET`
+
+**What it does:** the Worker signs every request to Apps Script with HMAC-SHA256 over the request body using this shared secret. AS verifies the signature before executing. Rotating requires the Worker secret + the AS Script Property to update **simultaneously** — there's no graceful overlap.
+
+**When to rotate:**
+- Annual (calendar reminder: every May 1, paired with `JWT_SIGNING_KEY`)
+- Immediately if leaked
+- Whenever the Apps Script deploy ID rotates (see §3)
+
+**How to rotate (paired update — coordinate timing carefully):**
+
+1. Generate new HMAC secret:
+   ```sh
+   openssl rand -base64 32 | tr -d '=' | tr '+/' '-_'
+   ```
+2. Open the F2-PWA-Backend Apps Script project. Project Settings → Script Properties → set `PROP_HMAC_SECRET` to the new value. **Do NOT save yet.**
+3. In a separate shell, queue the Worker secret update:
+   ```sh
+   cd deliverables/F2/PWA/worker
+   wrangler secret put APPS_SCRIPT_HMAC --env staging
+   # paste new value
+   ```
+4. Click **Save** on the AS Script Property → immediately complete the wrangler `secret put` for staging by hitting enter.
+5. Smoke-test staging: open `https://f2-pwa-worker-staging.hcw.workers.dev/health` → expect 200. Submit a test enrollment via `/admin/login` (staging). If 503 errors with HMAC mismatch in logs, you mistimed the swap — repeat steps 2–4 carefully.
+6. Repeat for prod:
+   ```sh
+   wrangler secret put APPS_SCRIPT_HMAC
+   ```
+   Run AS Script Property update in lockstep on the prod AS project (not the staging one — they're separate AS projects per `2026-05-01-ap0-apps-script-staging-setup.md`).
+7. Smoke prod via Admin Portal → Data → Responses (should load).
+
+**Disruption window:** 1–3 minutes if you do it carefully; up to 10 minutes if you flub the timing and have to repeat. Run it in a low-traffic window (early AM PHT).
+
+**What breaks if you skip:** HMAC compromise → an attacker who knows the secret can call Apps Script directly and bypass Worker auth, manipulating sheet data without going through the Admin Portal.
+
+---
+
+## 3. `APPS_SCRIPT_URL` (deployment ID)
+
+**What it does:** the Worker `fetch`-es Apps Script at this exact URL. Each AS deployment has a unique URL containing the deploy ID. Rotating means re-deploying AS and updating the Worker secret.
+
+**When to rotate:**
+- Whenever you make material AS code changes that need to atomically activate (rare — most AS updates use the existing deployment via `clasp push` which updates the same deploy ID).
+- If the deploy ID is somehow leaked alongside the HMAC (combined leak = full bypass).
+
+**How to rotate:**
+
+1. In the AS editor: **Deploy → New deployment** (NOT "Manage deployments" → edit). Copy the new Web app URL.
+2. Update Worker secret:
+   ```sh
+   cd deliverables/F2/PWA/worker
+   wrangler secret put APPS_SCRIPT_URL --env staging
+   wrangler secret put APPS_SCRIPT_URL
+   ```
+3. Smoke as in §2 step 5.
+4. **Archive the old deployment** in AS (Manage deployments → Archive). Don't delete — keep for audit trail.
+
+**What breaks if you skip:** AS deployment URL stays callable indefinitely after a code change; old code keeps running for any caller who hasn't updated their URL. Mostly an issue if you forgot to update AS Script Properties at the same time and prod is still hitting the old deploy.
+
+---
+
+## 4. Cloudflare R2 access keys
+
+**What they do:** R2 buckets are bound to the Worker via `[[r2_buckets]]` config (binding: `F2_ADMIN_R2`); the Worker uses bucket-binding API, not S3-compatible access keys, so there are no per-Worker R2 access keys to rotate. **However**, if you've created S3-compatible access keys at the account level for `wrangler r2 object get` backup runs (per `2026-05-12-f2-pwa-backup-restore.md`), those need annual rotation.
+
+**When to rotate:**
+- Annual
+- Immediately if the access-key CSV is leaked
+
+**How to rotate:**
+
+1. Cloudflare dashboard → R2 → Manage R2 API tokens → revoke the existing token.
+2. Create a new token with the same scope (read + write on `f2-admin`, `f2-admin-staging`, both `-preview` variants).
+3. Update local credentials file (`~/.cloudflare/r2-credentials` or wherever your backup script reads from).
+4. Re-run a backup smoke (one bucket): `wrangler r2 object list f2-admin` → expect non-error.
+
+**What breaks if you skip:** worst-case, leaked access key lets an attacker enumerate + delete + replace bucket objects. Backup files would be the highest-value target.
+
+---
+
+## 5. Project Gmail password
+
+**What it does:** the project mailbox `aspsi.doh.uhc.survey2.data@gmail.com` is the operator account for everything Cloudflare + Apps Script + Drive (sheet) is bound to. Compromise = full system takeover.
+
+**When to rotate:**
+- Quarterly (calendar reminder: 1st of Feb / May / Aug / Nov)
+- Immediately on any operator transition (Carl handoff, ASPSI ops change)
+- Immediately on any phishing/malware suspicion
+
+**How to rotate:**
+
+1. Sign in via Google Account → Security → Password → change.
+2. Update password manager (1Password / Bitwarden — wherever the credential is stored for cross-operator handoff).
+3. Re-authenticate any active wrangler / clasp sessions:
+   ```sh
+   wrangler logout
+   wrangler login
+   clasp logout
+   clasp login
+   ```
+4. Verify 2FA is still enabled and recovery codes are still trusted.
+
+**What breaks if you skip:** password compromise → attacker logs into Gmail → accesses every connected service → full data exfiltration possible.
+
+---
+
+## 6. Admin user passwords (`F2_Users.password_hash`)
+
+**What they are:** per-user passwords for ASPSI ops staff using the Admin Portal. PBKDF2-hashed (100k iters per `worker/src/admin/auth.ts:18`).
+
+**When to rotate:**
+- On role change (forced by role_version bump — user is bounced to login on next request)
+- On suspected leak
+- Annual recommended (no automatic enforcement yet)
+- On staff departure (delete the user, don't just rotate)
+
+**How to rotate (user-initiated):**
+
+1. User logs into Admin Portal → click their username at sidebar bottom → Change password.
+2. Enter old + new (≥ 8 chars, ≥ 1 number, ≥ 1 letter).
+3. New password takes effect on next request; existing JWT continues to work until session expiry (60 min) — they can keep working.
+
+**How to rotate (admin-forced):**
+
+1. Admin Portal → Users → find user → click menu → **Reset password**.
+2. Modal returns a one-time temporary password. Hand to user out-of-band (Slack DM, in-person — NOT email).
+3. User logs in with temp password → forced password change on next auth (`password_must_change=true`).
+
+**What breaks if you skip:** standard credential-stuffing risk; one stale departed-operator account is one open door.
+
+---
+
+## Annual rotation checklist (run May 1 each year)
+
+- [ ] §1: rotate `JWT_SIGNING_KEY` on staging + prod, re-mint all enrollment tokens, force-logout admin sessions
+- [ ] §2: rotate `APPS_SCRIPT_HMAC` / `PROP_HMAC_SECRET` (paired) on staging + prod
+- [ ] §4: rotate Cloudflare R2 access tokens used by backup tooling
+- [ ] §5 (if not done in last quarter): rotate Gmail password, re-auth wrangler + clasp
+- [ ] §6: send "annual password rotation" Slack reminder to all admin users; track non-compliance after 14 days
+
+Document each rotation in `log.md` with date + ticket reference.
+
+---
+
+## Emergency rotation (any secret leaked)
+
+1. **Stop writes** (if compromise scope is unclear): Apps Script editor → pause cron triggers + open Admin Portal → toggle the kill-switch (Apps & Settings → Kill switch — if implemented; if not, manually set `OPS_KILL_SWITCH=true` script property).
+2. Rotate the leaked secret per the relevant section above.
+3. Audit: open Admin Portal → Data → Audit → filter by suspicious actor / time window. Look for unexpected mutations during the leak window.
+4. **Resume writes** once rotation is verified.
+5. File an incident issue documenting: what leaked, how, scope of audit, mitigation taken.


### PR DESCRIPTION
## Summary

R3-prep slate 2 (Sprint 005, Tue 2026-05-12). Three more GH-pickable items closed before R3 opens Wed AM.

| Issue | Scope | Commit |
|---|---|---|
| **#192** [E6-PWA-010] | Performance baseline + budget | `2106963` — `PERFORMANCE.md` with HCW 0.91 + Admin 0.93 perf scores; filed [#275](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/275) for bundle-split as v2.0.2 follow-up |
| **#173** [E4-PWA-011] | Backup + restore runbook | `88d9815` — `docs/superpowers/runbooks/2026-05-12-f2-pwa-backup-restore.md` covering sheet + R2 + KV layers |
| **#172** [E4-PWA-010] | Backend secrets rotation policy | `b1c7a78` — `docs/superpowers/runbooks/2026-05-12-f2-secrets-rotation.md` covering all 6 secret-bearing surfaces |

## Per-commit detail

### `2106963` — `PERFORMANCE.md` (#192)

Lighthouse perf measured on prod 2026-05-12:

| Surface | Perf | LCP | CLS | TBT |
|---|---|---|---|---|
| HCW root | 0.91 | 2.8s | 0 | 10ms |
| Admin login | 0.93 | 2.3s | 0 | 190ms |

Both above the 0.85 floor. No failing audits. The known 930 KB raw / 250 KB gzipped index chunk doesn't currently trip the perf budget but is filed as [#275](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/275) for v2.0.2 bundle-splitting on the `/admin/*` boundary.

Bundle composition shows the runtime CacheFirst design from #162 is working: only 4 of 22 woff2 files fetched at first paint.

### `88d9815` — backup + restore runbook (#173)

Three layers documented: Google Sheet (9 sub-sheets, weekly Friday snapshot copy), Cloudflare R2 (`f2-admin` + staging, weekly wrangler r2 sync), Cloudflare KV (revocation list, on-demand only — reconstructible from `F2_HCWs.token_revoked_at`).

Full restore procedure for each layer plus a verification checklist (login → dashboards render → enrollment flow → test submission). Annual restore drill scheduled for next year. Pre-fieldwork upgrade to daily sheet snapshots flagged as a follow-up when production HCW enrollments begin.

### `b1c7a78` — secrets rotation policy (#172)

Six secret-bearing surfaces with per-secret cadence, rotation steps, and breakage-on-skip:

1. `JWT_SIGNING_KEY` (Worker) — annual + on operator transition
2. `APPS_SCRIPT_HMAC` / `PROP_HMAC_SECRET` (paired Worker + AS, narrow disruption window) — annual
3. `APPS_SCRIPT_URL` / deployment ID — on material AS code change
4. Cloudflare R2 access tokens (backup tooling) — annual
5. Project Gmail password — quarterly + on operator transition
6. Admin user passwords (`F2_Users`) — on role change + annual recommended

Includes May 1 annual rotation checklist + emergency rotation procedure with kill-switch + audit-log review.

## Test plan

- [x] No code changes — all three are docs (Markdown). No build / typecheck / vitest impact. CI should pass on the worker check (unchanged) + app check (no source changes).
- [ ] **Reviewer:** spot-check that the Performance metrics in `PERFORMANCE.md` match what you see if you re-run Lighthouse against prod yourself.
- [ ] **Reviewer:** runbook accuracy check — the secrets list (§1-§6) matches the actual deployed surface area.

## Risk

Zero production code change. Pure documentation + perf-baseline. Lowest possible deployment risk.