### PR TITLE
R3 prep slate 3: dogfood-found prod fixes (URL token prefill, /admin/help URL race, version footer)

### DIFF
--- a/deliverables/F2/PWA/app/src/admin/App.tsx
+++ b/deliverables/F2/PWA/app/src/admin/App.tsx
@@ -71,8 +71,20 @@ function AdminRoot({ apiBaseUrl, fetchImpl }: AdminAppProps): JSX.Element {
   }, [pathname, isAuthenticated, navigate]);
 
   // Unauthenticated user requesting a protected page → redirect to login.
+  // /admin/help is intentionally exempted (no-auth surface — see render branch
+  // below). Prior to this exemption, navigating directly to /admin/help while
+  // signed out triggered this effect to push history to /admin/login *while*
+  // the render branch below still returned the HelpPage in its Layout, leaving
+  // the URL bar at /admin/login but the visible content as Help — a confusing
+  // mismatch when testers file bugs that quote the URL.
   useEffect(() => {
-    if (!isAuthenticated && pathname !== '/admin/login' && pathname.startsWith('/admin')) {
+    if (
+      !isAuthenticated &&
+      pathname !== '/admin/login' &&
+      pathname !== '/admin/help' &&
+      pathname !== '/admin/help/' &&
+      pathname.startsWith('/admin')
+    ) {
       navigate('/admin/login');
     }
   }, [isAuthenticated, pathname, navigate]);

--- a/deliverables/F2/PWA/app/src/admin/Layout.tsx
+++ b/deliverables/F2/PWA/app/src/admin/Layout.tsx
@@ -186,7 +186,7 @@ export function Layout({ children }: LayoutProps): JSX.Element {
             Sign out
           </Button>
           <p className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground">
-            v0.1.0-staging
+            v{__APP_VERSION__}
           </p>
         </div>
       </aside>

--- a/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.tsx
+++ b/deliverables/F2/PWA/app/src/components/enrollment/EnrollmentScreen.tsx
@@ -38,6 +38,22 @@ export function EnrollmentScreen() {
     void listFacilities().then(setFacilities);
   }, []);
 
+  // Prefill the tablet-token field from the `?token=` URL query string when
+  // the page is opened via an enrollment URL (the format used in tester guides
+  // and ops handouts). Without this, testers/HCWs receiving a URL like
+  // `/enroll?token=eyJhbGc...` see an empty textbox and have to manually copy
+  // the JWT out of the address bar — a regression in the auth re-arch handoff.
+  // Only prefill on first mount; never overwrite a verifying or verified state.
+  useEffect(() => {
+    if (verifiedToken !== null) return;
+    const params = new URLSearchParams(window.location.search);
+    const urlToken = params.get('token');
+    if (urlToken && urlToken.length > 0) {
+      setTokenInput((current) => (current.length === 0 ? urlToken : current));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const facilityFromToken = tokenFacilityId
     ? (facilities.find((f) => f.facility_id === tokenFacilityId) ?? null)
     : null;


### PR DESCRIPTION
## Summary

R3-prep slate 3 (Sprint 005, Tue 2026-05-12). Three real prod bugs caught during a dogfood pass against `f2-pwa.pages.dev` before R3 opens Wed AM. Two HCW-side findings deferred as v2.0.2 follow-ups (#277 a11y, #278 admin-help UX) — neither blocks R3.

| Commit | Bug | Severity |
|---|---|---|
| `b8ff8cc` | URL `?token=...` not prefilled in EnrollmentScreen | HIGH UX |
| `29fa0e8` | `/admin/help` URL racing to `/admin/login` while HelpPage renders | HIGH UX |
| `d7a12d3` | Layout footer hardcoded `"v0.1.0-staging"` on prod | LOW (misleading during triage) |

## Per-bug detail

### `b8ff8cc` — Prefill enrollment token from `?token=` URL

**Repro:** open any URL of the shape `https://f2-pwa.pages.dev/enroll?token=eyJhbGc...` (the format used in tester guides). Pre-fix: empty textbox + disabled "Verify token" button. Tester has to copy the JWT out of the address bar by hand. Post-fix: textbox is prefilled, "Verify token" is immediately enabled.

The plumbing was lost in the auth re-arch handoff. R3 testers will receive these URLs Wed AM — would have been visible in their first 30 seconds.

### `29fa0e8` — Exempt `/admin/help` from auth-redirect race

**Repro:** open `https://f2-pwa.pages.dev/admin/help` in incognito. Pre-fix: HelpPage renders correctly, but the URL bar lands on `/admin/login` due to a useEffect race. Post-fix: URL stays `/admin/help`, content renders as expected.

Per `App.tsx:80-89`, /admin/help is intentionally a no-auth surface ("first-time operators who haven't logged in yet should still be able to read the operator guide"). The protected-route useEffect at line 75 was firing before the render branch could short-circuit. Now exempted alongside /admin/login.

Filed [#278](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/278) separately for the broader UX issue (unauth user sees full operator Layout sidebar with Sign-out button + dashboard links they can't access — a v2.0.2 polish redesign).

### `d7a12d3` — Layout footer reads `__APP_VERSION__`

**Repro:** load any /admin/* page on prod. Pre-fix: sidebar footer reads "v0.1.0-staging" regardless of actual build. Post-fix: reads "v2.0.0" (from `package.json` via Vite's `__APP_VERSION__` define).

Confused incident-triage screenshots ("what version am I on?"). `__APP_VERSION__` was already declared in `vite-env.d.ts` and used at `App.tsx:44`.

## Filed as v2.0.2 follow-ups (NOT shipping today)

- **[#277](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/277)** — Compound-field `<label htmlFor>` points to non-existent IDs (Q1 name, Q9 tenure). Real a11y bug; fix needs `<fieldset><legend>` rewrite for compound questions. ~3h.
- **[#278](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/278)** — Unauthenticated `/admin/help` shows full operator sidebar. UX redesign — slim no-auth shell vs conditional sidebar render. ~2h.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (17 pre-existing warnings, 0 errors)
- [x] `npm test` — 51 files / 422 tests pass (no new tests added; manual verification on prod after merge)
- [ ] **Reviewer:** smoke prod after merge:
  1. Hit any `/enroll?token=eyJhbGc...` URL → token prefilled, Verify button enabled
  2. Hit `/admin/help` in incognito → URL stays `/admin/help`, HelpPage renders
  3. Sidebar footer reads `v2.0.0` (or whatever `package.json` is bumped to)

## Risk

All three are scoped, surgical fixes against well-understood symptoms. No behavior change for authenticated admin paths or the rest of the HCW survey shell.