### PR TITLE
docs(uat): R3 tester guide review pass — reflect today's prod fixes

### DIFF
--- a/docs/F2-PWA-UAT-Round-3-Admin-Portal-Tester-Guide-2026-05-13.md
+++ b/docs/F2-PWA-UAT-Round-3-Admin-Portal-Tester-Guide-2026-05-13.md
@@ -59,8 +59,8 @@
 1. **Open `https://f2-pwa.pages.dev/admin/login`** in Chrome. Page loads with the Verde paper background and login form.
 2. **Login with your dedicated credential** (your R2-reset password). Land on Data dashboard.
 3. **Confirm version.** Apps & Settings → Versioning should read **PWA: 2.0.0** + **Worker: 2.0.0+** (with v2.0.1 patches in Worker hash).
-4. **Sidebar shows your username + role badge** ("Administrator") at the bottom-left.
-5. **Open `https://f2-pwa.pages.dev/admin/help` in incognito** (no auth). Help page renders without redirect to login.
+4. **Sidebar shows your username + role badge** ("Administrator") at the bottom-left. Version footer below should read **`v2.0.0`** (NOT `v0.1.0-staging` — that was a hardcoded literal regression fixed 2026-05-12 in PR #279). If you still see `v0.1.0-staging`, hard-refresh the page to pull the new bundle.
+5. **Open `https://f2-pwa.pages.dev/admin/help` in incognito** (no auth). Help page renders **and the URL bar stays at `/admin/help`** (NOT racing to `/admin/login` — that was a useEffect race fixed 2026-05-12 in PR #279). The full operator sidebar is still visible to unauthenticated users by current design — that broader UX gap is tracked separately as #278 for v2.0.2.
 6. **Confirm seed data exists** — Data → HCWs sub-tab → 12 `DEMO-HCW-*` rows visible.
 7. **DevTools open** (F12) — Network + Console tabs visible. Capture screenshots of these for any bug.
 

--- a/docs/F2-PWA-UAT-Round-3-HCW-Survey-Tester-Guide-2026-05-13.md
+++ b/docs/F2-PWA-UAT-Round-3-HCW-Survey-Tester-Guide-2026-05-13.md
@@ -74,7 +74,7 @@ Same as Round 2 — see `docs/F2-PWA-UAT-Round-2-HCW-Survey-Tester-Guide-2026-05
    - `deliverables/F2/F2-Spec.md` — full questionnaire structure
    - `deliverables/F2/F2-Skip-Logic.md` — all role + facility-type gates
    - Round 2 guide for context on what was previously tested
-4. **Confirm your token works:** open your primary URL above, click Verify token, advance to the role-select / Section A screen.
+4. **Confirm your token works:** open your primary URL above. As of 2026-05-12 the token in the URL **auto-prefills** the textbox — Verify button is enabled immediately. Click Verify, advance to the role-select / Section A screen. (If the textbox is empty after opening the URL, that's a regression — file it as a bug; manual paste from the URL bar still works as a fallback.)
 
 ---
 
@@ -90,7 +90,7 @@ Re-walk the bug paths from Round 2's 14 HCW-survey closures. For each scenario, 
 
 | # | R2 Issue(s) | Section / Q | Original bug summary | Quick regression check |
 |---|---|---|---|---|
-| **5A.1** | [#108](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/108), [#109](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/109) | Token-paste enrollment | Token paste edge cases (whitespace, multi-line, malformed) | Paste your token cleanly → Verify enables → Step 2 loads. Then try pasting with trailing whitespace, with the full URL prefix `https://...?token=`, with characters chopped off — expect graceful handling. |
+| **5A.1** | [#108](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/108), [#109](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/109) | Token-paste enrollment | Token paste edge cases (whitespace, multi-line, malformed) — also URL-prefill regression check | **First, the new auto-prefill path (added 2026-05-12):** open your enrollment URL — expect the token already in the textbox + Verify enabled. Click → Step 2. **Then the manual-paste fallback:** clear the textbox, paste your token cleanly → Verify enables → Step 2 loads. Then try pasting with trailing whitespace, with the full URL prefix `https://...?token=`, with characters chopped off — expect graceful handling. |
 | **5A.2** | [#110](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/110) | Section A, Q9 (year+month) | R2-#110: Q9_2 Month was previously optional, made required 2026-05-09 — blank Months let form proceed despite Q9 being required | Fill Q9 Year(s)=5, leave Month(s) blank, try to advance. Expect: validation error blocking advance until both subfields filled. |
 | **5A.3** | [#111](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/111), [#112](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/112) | Section B, Q25 (UHC Awareness) | Multi-select state pollution / exclusive option behavior | Open Section B Q25. Select Salary + Working hours. Then select "I don't know" — expect previous selections clear. Conversely, with "I don't know" selected, click Salary — expect "I don't know" clears. |
 | **5A.4** | [#114](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/114), [#115](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/115) | Section C, Q31–Q40 (YAKAP/Konsulta) | Role-gated section; Q32 select-all rule | **Physician role only (Kidd):** open Section C. Q32 — click "All of the above" → all 7 services auto-check. Uncheck Mammogram → "All of the above" auto-unchecks. Click "I don't know" → all clear, only "I don't know" remains. **Pharmacist role (Shan):** confirm Section C is HIDDEN in nav. |
@@ -152,9 +152,10 @@ Round 2 walked the happy-path form thoroughly. These scenarios stress-test what 
 
 **What to verify:** Token-paste handles real-world copy-paste mishaps.
 
-- **5B.5.H1 (Clean paste):** Paste your token cleanly into the Step 1 textarea. Expect: Verify button enables; click → Step 2.
+- **5B.5.H1 (URL auto-prefill, NEW 2026-05-12):** Open your enrollment URL fresh (incognito tab + clear storage if you've been testing). Expect: textbox already filled with the token; Verify button enabled; click → Step 2. This is the path real testers + HCWs will use.
+- **5B.5.H2 (Clean manual paste):** Clear the textbox, paste your token cleanly. Expect: Verify enables; click → Step 2.
 - **5B.5.A1 (Trailing whitespace):** Copy your token + 1–2 trailing spaces (common when copy-paste from email). Paste. Expect: Verify still succeeds (whitespace gets trimmed) OR the Verify button greys out with a clear hint.
-- **5B.5.A2 (Multi-line paste):** Copy the entire enrollment URL (including `https://...?token=` prefix) and paste into the token textarea. Expect: app extracts the token portion OR shows a clear error like "Paste only the token, not the full URL."
+- **5B.5.A2 (Multi-line paste — into textbox, NOT browser bar):** Copy the entire enrollment URL (including `https://...?token=` prefix) and paste into the **token textarea** (not the browser address bar — pasting into the address bar uses the auto-prefill path covered in 5B.5.H1). Expect: app extracts the token portion OR shows a clear error like "Paste only the token, not the full URL."
 - **5B.5.E1 (Truncated token):** Paste a token with the last ~20 characters chopped off. Expect: Verify fails with a clear error like "Invalid token signature."
 - **5B.5.E2 (Reused/already-enrolled token):** Use a token that's already been enrolled on a different device. Expect: either accepts and rebinds OR shows a clear "Already enrolled elsewhere" message. Document which.
 - **5B.5.E3 (Expired token):** All current DEMO tokens expire 2026-06-03. Don't worry about this in R3 unless you're testing past that date.


### PR DESCRIPTION
## Summary

Review pass on both R3 tester guides to reflect the three slates that shipped to prod earlier today (PRs #274 + #276 + #279). Companion to the GH #271 body refresh done in parallel.

Doc-only change. No code modified.

## What's updated

### HCW guide — 3 spots updated for the URL-token-prefill behavior (PR #279)

- **Pre-Flight #4** — note the auto-prefill behavior; manual paste from URL bar still works as a fallback if textbox empty (= regression).
- **5A.1** — add the new auto-prefill path as the primary verify, then the manual-paste edge cases as the fallback regression check.
- **5B.5** — split into URL-bar-prefill (5B.5.H1, the path real testers use) / clean manual paste (5B.5.H2) / textbox-paste-of-full-URL (5B.5.A2 — clarified to NOT be the address bar).

### Admin Portal guide — Pre-Flight #4 + #5 extended for PR #279 fixes

- **Pre-Flight #4** — sidebar version footer should read `v2.0.0` (not the hardcoded `v0.1.0-staging` literal that was there before today). Hard-refresh hint if testers see the old value.
- **Pre-Flight #5** — confirm `/admin/help` URL bar stays at `/admin/help` (not racing to `/admin/login`). Note the broader unauth-Layout-leak UX gap is tracked separately as #278 for v2.0.2.

### What didn't need updating

Help copy fixes from PR #274 (#208 — bulk import 100 vs 500, Versioning field list, DataReader/Encoder labels) — the guides reference the correct numbers/labels already in the latest versions; no stale claims to fix.

## Risk

Zero. Two markdown files. No CI failure possible.

Cumulative R3-prep ship today: 3 PRs merged (#274 #276 #279) + this PR + GH #271 body refresh.