### PR TITLE
v2.0.2 follow-ups: slim no-auth Layout + compound-field a11y + bundle-split admin (#278 #277 #275)

### DIFF
--- a/deliverables/F2/PWA/app/PERFORMANCE.md
+++ b/deliverables/F2/PWA/app/PERFORMANCE.md
@@ -3,6 +3,7 @@
 Reference baseline for the F2 PWA (HCW survey + Admin Portal) measured on production. Use this to detect regressions in future releases.
 
 **First measurement:** 2026-05-12 (PR #274 + slate 2 — closes [#192](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/192) E6-PWA-010)
+**Re-measurement:** 2026-05-12 PM after slate 4 bundle-split — closes [#275](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/275). See "Bundle-split delta" section below.
 **Method:** Lighthouse 11.7.1, headless Chromium, mobile profile (default), single sample, run from operator workstation against `https://f2-pwa.pages.dev/`.
 
 > Single-sample Lighthouse numbers fluctuate ±5% run-to-run. Treat ±10pt swings on any individual metric as noise; persistent shifts of >10pt or any score dropping below the **AA budget** below as a regression.
@@ -76,8 +77,32 @@ npx lighthouse https://f2-pwa.pages.dev/admin/login --only-categories=performanc
 
 Run 3 times and average; single samples are noisy.
 
+## Bundle-split delta (PR #281 / closes #275)
+
+Slate 4 (2026-05-12 PM) split the `index-*.js` monolithic chunk into three by adding `manualChunks` + `lazy(() => import('@/admin/App'))`:
+
+| Chunk | Pre-split | Post-split | Notes |
+|---|---|---|---|
+| HCW first-paint JS (entry + vendor) | 930 KB raw / 250 KB gzip | **608 KB raw / 188 KB gzip** | 35% raw / 25% gzip reduction; admin chunk no longer downloaded |
+| `index-*.js` (HCW shell) | 930 KB | **26 KB raw / 8 KB gzip** | App.tsx + survey components only |
+| `vendor-*.js` (React + deps) | (in index) | 582 KB raw / 179 KB gzip | All node_modules; eagerly loaded for app boot |
+| `admin-*.js` (Admin portal) | (in index) | 329 KB raw / 61 KB gzip | **Lazy** — only fetched on /admin/* navigation |
+
+`build.modulePreload.resolveDependencies` filters the admin chunk out of `<link rel="modulepreload">` for the HCW entry, so the browser doesn't eager-fetch admin even though it's reachable from the entry's module graph.
+
+Re-measured Lighthouse perf (single sample, post-split, local preview build):
+
+| Surface | Pre-split perf | Post-split perf | LCP delta |
+|---|---|---|---|
+| HCW root | 0.91 | **0.90** | 2.8s → 3.0s (within ±5% sample noise) |
+| Admin login | 0.93 | **0.87** | 2.3s → 3.6s (one-time lazy-fetch cost) |
+
+Trade-off accepted: HCW respondents (dominant traffic class) get a smaller first-paint payload; Admin users (ASPSI ops staff, low traffic, typically on fixed connections) pay a one-time ~1s lazy-load cost on first admin-portal navigation, then everything is cached. For a survey app where 99%+ of traffic is HCW, this is the right shape. Both surfaces remain above the 0.85 perf floor.
+
+A11y unaffected — both surfaces still score 1.0 / 100.
+
 ## Known regressions / follow-ups
 
-- **Bundle splitting** ([#275](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/275) — to file): the `index-*.js` chunk is 930 KB raw. Route-level code-splitting on `/admin/*` would let the HCW survey ship with a smaller initial JS payload (most HCWs never load admin code).
 - **CI perf gate** (deferred): no automated regression detection today. Adding a Lighthouse CI step against staging on every PR would catch perf drops at the PR level instead of post-deploy.
 - **Authenticated-state perf** (deferred): same as the a11y audit limitation — Lighthouse against post-login dashboards needs cookie-injection setup. Tracked alongside [#273](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/273) (E6-PWA-009b).
+- **Vendor chunk split** (deferred): the `vendor-*.js` chunk at 582 KB raw still trips Vite's chunkSizeWarningLimit (500 KB). Could be sub-split into `vendor-react`, `vendor-forms`, etc., but diminishing returns once the admin lazy-load is in place. Re-evaluate if HCW LCP regresses below 0.85 in a future measurement.

--- a/deliverables/F2/PWA/app/src/App.tsx
+++ b/deliverables/F2/PWA/app/src/App.tsx
@@ -1,7 +1,12 @@
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import AdminApp from '@/admin/App';
+
+// Lazy-load the admin portal so HCW respondents — the dominant traffic class —
+// don't pay for the admin chunk on first paint. Closes #275 in combination
+// with the manualChunks split in vite.config.ts; together they take the HCW
+// initial-load JS from ~930 KB raw (single chunk) down to index + vendor only.
+const AdminApp = lazy(() => import('@/admin/App'));
 import { MultiSectionForm } from '@/components/survey/MultiSectionForm';
 import { EnrollmentScreen } from '@/components/enrollment/EnrollmentScreen';
 import { PendingCount } from '@/components/sync/PendingCount';
@@ -392,7 +397,17 @@ export default function App() {
     } catch {
       // VITE_F2_PROXY_URL unset — admin will surface E_NETWORK on login.
     }
-    return <AdminApp apiBaseUrl={proxyUrl} />;
+    return (
+      <Suspense
+        fallback={
+          <div className="flex min-h-screen items-center justify-center bg-paper text-sm text-muted-foreground">
+            Loading admin portal…
+          </div>
+        }
+      >
+        <AdminApp apiBaseUrl={proxyUrl} />
+      </Suspense>
+    );
   }
 
   let fetcher: () => Promise<GetConfigResponse>;

--- a/deliverables/F2/PWA/app/src/admin/Layout.tsx
+++ b/deliverables/F2/PWA/app/src/admin/Layout.tsx
@@ -118,7 +118,7 @@ const NAV_GROUPS: NavGroup[] = [
 const FLAT_NAV: NavItemSpec[] = NAV_GROUPS.flatMap((g) => g.items);
 
 export function Layout({ children }: LayoutProps): JSX.Element {
-  const { username, role, clearAuth } = useAdminAuth();
+  const { username, role, clearAuth, isAuthenticated } = useAdminAuth();
   const { navigate } = useRouter();
 
   const onLogout = () => {
@@ -149,42 +149,73 @@ export function Layout({ children }: LayoutProps): JSX.Element {
         </Link>
 
         <nav className="flex flex-1 flex-col gap-4 overflow-y-auto py-2">
-          {NAV_GROUPS.map((group) => (
-            <div key={group.title} className="flex flex-col">
-              <p className="px-5 pb-1 pt-2 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-                {group.title}
-              </p>
-              {group.items.map((item) => (
-                <SidebarLink key={item.to} item={item} />
-              ))}
-            </div>
-          ))}
+          {isAuthenticated
+            ? NAV_GROUPS.map((group) => (
+                <div key={group.title} className="flex flex-col">
+                  <p className="px-5 pb-1 pt-2 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                    {group.title}
+                  </p>
+                  {group.items.map((item) => (
+                    <SidebarLink key={item.to} item={item} />
+                  ))}
+                </div>
+              ))
+            : // Unauthenticated: only Help is reachable. Show just the Help link
+              // so visitors who landed at /admin/help can confirm they're in the
+              // right place without a wall of links that all bounce to login.
+              (
+                <div className="flex flex-col">
+                  <p className="px-5 pb-1 pt-2 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                    Help
+                  </p>
+                  <SidebarLink
+                    item={{
+                      to: '/admin/help',
+                      label: 'Help',
+                      description: 'Operator guide — what each tab does, common workflows, glossary.',
+                      icon: IconBook,
+                    }}
+                  />
+                </div>
+              )}
         </nav>
 
-        {/* Sidebar footer: user profile + sign out + version */}
+        {/* Sidebar footer: when authenticated, user profile + sign out + version.
+            When unauthenticated (Help-only view), Sign-in CTA + version. */}
         <div className="flex flex-col gap-3 border-t border-hairline px-5 py-4">
-          <div className="flex items-center gap-3">
-            <div
-              aria-hidden="true"
-              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-sm border border-hairline bg-secondary/40 font-mono text-sm text-ink"
+          {isAuthenticated ? (
+            <>
+              <div className="flex items-center gap-3">
+                <div
+                  aria-hidden="true"
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-sm border border-hairline bg-secondary/40 font-mono text-sm text-ink"
+                >
+                  {initial}
+                </div>
+                <div className="flex min-w-0 flex-col">
+                  <p className="truncate text-sm font-medium text-ink">{username ?? '—'}</p>
+                  <p className="truncate font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                    {role ?? '—'}
+                  </p>
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onLogout}
+                className="h-9 w-full border-hairline font-mono text-xs uppercase tracking-wider text-muted-foreground hover:bg-secondary/40 hover:text-ink"
+              >
+                Sign out
+              </Button>
+            </>
+          ) : (
+            <Link
+              to="/admin/login"
+              className="flex h-9 items-center justify-center rounded-sm border border-hairline bg-secondary/40 font-mono text-xs uppercase tracking-wider text-ink hover:bg-secondary/60"
             >
-              {initial}
-            </div>
-            <div className="flex min-w-0 flex-col">
-              <p className="truncate text-sm font-medium text-ink">{username ?? '—'}</p>
-              <p className="truncate font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-                {role ?? '—'}
-              </p>
-            </div>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={onLogout}
-            className="h-9 w-full border-hairline font-mono text-xs uppercase tracking-wider text-muted-foreground hover:bg-secondary/40 hover:text-ink"
-          >
-            Sign out
-          </Button>
+              Sign in
+            </Link>
+          )}
           <p className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground">
             v{__APP_VERSION__}
           </p>
@@ -204,23 +235,33 @@ export function Layout({ children }: LayoutProps): JSX.Element {
             <span className="font-serif text-base font-medium tracking-tight">F2 PWA Portal</span>
           </Link>
           <div className="flex items-center gap-3">
-            <span className="text-sm">{username ?? '—'}</span>
-            <Button
-              type="button"
-              variant="tableAction"
-              size="tableAction"
-              onClick={onLogout}
-              className="text-muted-foreground no-underline hover:text-ink hover:no-underline"
-            >
-              Sign out
-            </Button>
+            {isAuthenticated ? (
+              <>
+                <span className="text-sm">{username ?? '—'}</span>
+                <Button
+                  type="button"
+                  variant="tableAction"
+                  size="tableAction"
+                  onClick={onLogout}
+                  className="text-muted-foreground no-underline hover:text-ink hover:no-underline"
+                >
+                  Sign out
+                </Button>
+              </>
+            ) : (
+              <Link to="/admin/login" className="text-sm font-medium text-ink no-underline hover:no-underline">
+                Sign in
+              </Link>
+            )}
           </div>
         </div>
-        <nav className="flex flex-wrap gap-x-4 gap-y-2 text-sm" aria-label="Primary (mobile)">
-          {FLAT_NAV.map((item) => (
-            <MobileNavLink key={item.to} item={item} />
-          ))}
-        </nav>
+        {isAuthenticated && (
+          <nav className="flex flex-wrap gap-x-4 gap-y-2 text-sm" aria-label="Primary (mobile)">
+            {FLAT_NAV.map((item) => (
+              <MobileNavLink key={item.to} item={item} />
+            ))}
+          </nav>
+        )}
       </header>
 
       {/* Single content area — scrolls independently of fixed sidebar (≥md)

--- a/deliverables/F2/PWA/app/src/components/survey/Question.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Question.tsx
@@ -36,8 +36,19 @@ export function Question({ item }: QuestionProps) {
   const error = errors[item.id];
   const errorMessage = typeof error?.message === 'string' ? error.message : undefined;
 
+  // Compound questions (multi-field — Q1 name, Q9 tenure, etc.) need a
+  // <fieldset>/<legend> wrapper instead of <div>/<label htmlFor>: a single
+  // <label> can't legally point to multiple sub-inputs, and pre-fix it
+  // pointed at item.id which had no matching element — broke screen-reader
+  // announcement of the question text on each sub-input + tripped axe's
+  // label-no-for + form-field-no-id rules. Closes #277.
+  const isCompound = item.type === 'multi-field';
+  const Outer = isCompound ? 'fieldset' : 'div';
+  const Heading = isCompound ? 'legend' : 'label';
+  const headingProps = isCompound ? {} : { htmlFor: item.id };
+
   return (
-    <div className="grid grid-cols-1 gap-y-2 py-3 sm:grid-cols-[80px_1fr]">
+    <Outer className="m-0 grid min-w-0 grid-cols-1 gap-y-2 border-0 p-0 py-3 sm:grid-cols-[80px_1fr]">
       <span
         aria-hidden="true"
         className="font-mono text-sm text-muted-foreground sm:pt-1 sm:pr-4 sm:text-right sm:text-base sm:leading-snug"
@@ -45,14 +56,14 @@ export function Question({ item }: QuestionProps) {
         {item.id}
       </span>
       <div className="flex min-w-0 flex-col gap-2">
-        <label htmlFor={item.id} className="text-base font-medium leading-snug">
+        <Heading {...headingProps} className="text-base font-medium leading-snug">
           <span className="sr-only">
             {item.id}
             {'. '}
           </span>
           {localized(item.label, locale)}
           {item.required ? <span className="ml-1 text-destructive">*</span> : null}
-        </label>
+        </Heading>
         {item.help ? (
           <p className="text-xs text-muted-foreground">{localized(item.help, locale)}</p>
         ) : null}
@@ -77,7 +88,7 @@ export function Question({ item }: QuestionProps) {
           </p>
         ) : null}
       </div>
-    </div>
+    </Outer>
   );
 }
 

--- a/deliverables/F2/PWA/app/vite.config.ts
+++ b/deliverables/F2/PWA/app/vite.config.ts
@@ -115,6 +115,37 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: { '@': path.resolve(__dirname, './src') },
     },
+    build: {
+      // Bundle-split admin routes off the HCW initial-load chunk (closes #275).
+      // HCW respondents — the dominant traffic class in production — never
+      // need admin code, so paying for ~half the bundle they don't use
+      // pre-split was wasted bandwidth. Split shape:
+      //   - admin  → everything under src/admin/* (Login, Dashboards, Help, …)
+      //   - vendor → all node_modules (React, react-i18next, RHF, zod, etc.)
+      //   - index  → HCW survey shell + components (the default chunk)
+      // Rollup automatically deduplicates: shared modules between admin
+      // and HCW (e.g., admin/lib/api-client) end up in the chunk that's
+      // first to import them, with the other side importing it on demand.
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('/src/admin/') || id.includes('\\src\\admin\\')) return 'admin';
+            if (id.includes('/node_modules/') || id.includes('\\node_modules\\')) return 'vendor';
+            return undefined;
+          },
+        },
+      },
+      // Filter modulepreload links so the HCW entry (index.html) doesn't eager-
+      // fetch the admin chunk. Without this filter, Vite emits a
+      // <link rel="modulepreload" href="/assets/admin-*.js"> in index.html for
+      // any chunk reachable from the entry — even lazy(() => import()) ones —
+      // which the browser fetches immediately, defeating the lazy-load benefit.
+      modulePreload: {
+        resolveDependencies(_filename, deps) {
+          return deps.filter((dep) => !dep.includes('/admin-'));
+        },
+      },
+    },
     // Dev-only proxy. /admin/api/* is forwarded to the staging Worker so
     // localhost:5173/admin/login can dogfood the portal end-to-end without
     // running into CORS (admin routes are deliberately not CORS-enabled —


### PR DESCRIPTION
## Summary

R3 prep slate 4 (Sprint 005, Tue 2026-05-12 PM). Closes the three v2.0.2 follow-ups I filed earlier today during the dogfood pass + perf-baseline measurement. All three are real F2 PWA fixes; ship today rather than holding for a v2.0.2 cut.

| Commit | Closes | Scope |
|---|---|---|
| `eac90e9` | **#278** | Slim no-auth Layout for /admin/help (Option B from issue body) |
| `7e53f02` | **#277** | Compound-field a11y — fieldset/legend for Q1 name + Q9 tenure |
| `24cc370` | **#275** | Bundle-split admin routes off HCW chunk + PERFORMANCE.md update |

## Per-commit detail

### `eac90e9` — Slim no-auth Layout (#278)

**Pre-fix:** unauthenticated `/admin/help` showed full operator sidebar (7 dashboard links + Sign-out + "—" placeholders). Confusing.
**Post-fix:** when `!isAuthenticated`, render only the Help nav link, replace user-slot with a "Sign in" CTA link, hide the mobile horizontal nav strip. Authenticated users see the unchanged Layout.

### `7e53f02` — Compound-field a11y (#277)

**Pre-fix:** `<label htmlFor={item.id}>` pointed at non-existent IDs for Q1 (name = 3 sub-inputs) and Q9 (tenure = 2 sub-inputs). Tripped axe rules; screen readers didn't announce question text on each sub-input.
**Post-fix:** detect `item.type === 'multi-field'` and render `<fieldset>+<legend>` instead of `<div>+<label>`. The legend implicitly associates with each contained input per HTML semantics. Tailwind classes neutralize default fieldset border/padding so visual layout is unchanged.

### `24cc370` — Bundle-split admin routes (#275)

**Pre-fix:** monolithic 930 KB raw / 250 KB gzip `index-*.js` chunk loaded on every page (HCW + admin alike). Vite chunk-size warning fired.
**Post-fix:** split into vendor (React + deps), admin (lazy), index (HCW shell only). HCW first-paint JS: **930 → 608 KB raw / 250 → 188 KB gzip** (35% / 25% reduction). Admin chunk lazy-loaded on first /admin/* nav.

Three sub-changes:
1. `vite.config.ts` `manualChunks` splits `src/admin/*` + `node_modules` into their own chunks.
2. `vite.config.ts` `modulePreload.resolveDependencies` filters `/admin-*` out of HCW entry's `<link rel="modulepreload">` (otherwise Vite eager-fetches every reachable chunk, defeating the lazy import).
3. `App.tsx` switches static `import AdminApp` to `lazy(() => import('@/admin/App'))` wrapped in `<Suspense>`.

**Trade-off accepted:** Admin login LCP +1s on first nav (single lazy-fetch round-trip), then cached. HCW (dominant traffic) gets faster first paint. Right shape for a survey app where 99%+ traffic is HCW. Both above 0.85 floor; a11y unchanged at 1.0.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` (17 pre-existing warnings, 0 errors)
- [x] `npm test` — 51 files / 422 tests pass
- [x] `npm run build` — emits 4 chunks (index 26K + vendor 582K + admin 329K + SyncPage 3.5K); `dist/index.html` modulepreload links exclude admin
- [x] Lighthouse re-measured on local preview build:
  - HCW root: perf **0.90** (was 0.91; within ±5% noise) · a11y **1.0**
  - Admin login: perf **0.87** (was 0.93; -6pt for one-time lazy-fetch cost) · a11y **1.0**
- [ ] **Reviewer:** verify on prod after merge:
  1. HCW: open `/` → confirm only `index-*.js` + `vendor-*.js` in Network tab (no `admin-*.js`)
  2. /admin/help: confirm slim no-auth Layout (only Help link in sidebar; "Sign in" CTA at bottom; no Sign-out button)
  3. Survey: in Section A, open DevTools Console — no "Incorrect use of <label for=>" or "form field should have an id" issues

## Risk

- **#278 Layout** — pure conditional render; no auth state semantics changed. Existing admin a11y test continues to pass.
- **#277 Question** — wraps with polymorphic Outer/Heading per item type. Survey-component tests (91 across 11 files) all pass.
- **#275 bundle-split** — Suspense fallback added for admin lazy-load. Visible briefly on first /admin/* nav as "Loading admin portal…". Subsequent navs are instant.