### PR TITLE
fix(ci): branch-aware VITE_F2_PROXY_URL for CF Pages deploy (#282)

### DIFF
--- a/.github/workflows/cf-pages-deploy.yml
+++ b/.github/workflows/cf-pages-deploy.yml
@@ -72,9 +72,20 @@ jobs:
         working-directory: deliverables/F2/PWA/app
         # VITE_F2_PROXY_URL is the post-auth-rearch worker origin (Issue #45).
         # vite.config.ts fails the build fast if it's missing or REPLACE_ME.
+        #
+        # Branch-aware (closes #282 — E4-PWA-012): main builds use the prod
+        # worker URL; staging builds use the staging worker URL when the
+        # VITE_F2_PROXY_URL_STAGING repo secret is set, else fall back to
+        # prod URL (preserves pre-fix behavior so staging doesn't suddenly
+        # fail to build before the staging secret lands). Add the staging
+        # secret in repo Settings → Secrets, value:
+        #   https://f2-pwa-worker-staging.hcw.workers.dev
         env:
-          VITE_F2_PROXY_URL: ${{ secrets.VITE_F2_PROXY_URL }}
-        run: npm run build
+          VITE_F2_PROXY_URL: ${{ github.event.workflow_run.head_branch == 'main' && secrets.VITE_F2_PROXY_URL || secrets.VITE_F2_PROXY_URL_STAGING || secrets.VITE_F2_PROXY_URL }}
+        run: |
+          echo "Branch: ${{ github.event.workflow_run.head_branch }}"
+          echo "Worker URL configured: $(echo $VITE_F2_PROXY_URL | sed 's|https://||' | cut -d. -f1)"
+          npm run build
 
       - if: steps.secrets.outputs.ready == 'true'
         name: Resolve project name from branch


### PR DESCRIPTION
## Summary

Closes [#282](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/282) (E4-PWA-012). Surfaced this PM while attempting authenticated dogfood on staging — the staging Pages site was calling the PROD Worker URL, breaking environment isolation.

## What changed

`.github/workflows/cf-pages-deploy.yml` Build step now branches `VITE_F2_PROXY_URL` by `head_branch`:

```yaml
VITE_F2_PROXY_URL: ${{ github.event.workflow_run.head_branch == 'main' && secrets.VITE_F2_PROXY_URL || secrets.VITE_F2_PROXY_URL_STAGING || secrets.VITE_F2_PROXY_URL }}
```

- **`main` builds** → `secrets.VITE_F2_PROXY_URL` (prod URL — unchanged behavior)
- **`staging` builds** → `secrets.VITE_F2_PROXY_URL_STAGING` (new staging URL)
- **Fallback** → if staging secret isn't set yet, falls back to prod URL so this workflow change doesn't break staging builds before the new secret lands

Also added an echo line at the end of the Build step that logs the resolved worker subdomain (e.g., `f2-pwa-worker` vs `f2-pwa-worker-staging`) so future deploys are auditable from Actions logs.

## Carl-side handoff

Add the new repo secret to fully close #282:

| Setting | Value |
|---|---|
| **Path** | Settings → Secrets and variables → Actions → New repository secret |
| **Name** | `VITE_F2_PROXY_URL_STAGING` |
| **Value** | `https://f2-pwa-worker-staging.hcw.workers.dev` |

Once added, the next push to the `staging` branch will deploy a build that correctly points at the staging worker.

## Verification

**Pre-secret-add (after this PR merges):**
```sh
curl -s https://f2-pwa.pages.dev/ | grep -oE '/assets/index-*\.js' | head -1 \
  | xargs -I{} curl -s "https://f2-pwa.pages.dev{}" \
  | grep -oE '"https://f2-pwa-worker[a-z-]*\.hcw\.workers\.dev"'
# → expect: "https://f2-pwa-worker.hcw.workers.dev"   (unchanged — main uses prod)
```

**Post-secret-add (after Carl adds VITE_F2_PROXY_URL_STAGING and pushes to staging):**
```sh
curl -s https://f2-pwa-staging.pages.dev/ | grep -oE '/assets/index-*\.js' | head -1 \
  | xargs -I{} curl -s "https://f2-pwa-staging.pages.dev{}" \
  | grep -oE '"https://f2-pwa-worker[a-z-]*\.hcw\.workers\.dev"'
# → expect: "https://f2-pwa-worker-staging.hcw.workers.dev"   ← FIXED
```

## Risk

- **Workflow-only change.** No app code modified. CI app+worker tests should pass on the same code as PR #281 just merged.
- **Backwards-compatible.** Falls back to prod URL if the new staging secret isn't set yet, so this PR doesn't break staging deploys before Carl's handoff.