### PR TITLE
chore(f2): clear all 17 ESLint warnings — memoize navigate + per-file overrides + dep arrays

### DIFF
--- a/deliverables/F2/PWA/app/eslint.config.js
+++ b/deliverables/F2/PWA/app/eslint.config.js
@@ -23,5 +23,22 @@ export default tseslint.config(
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
   },
+  // Per-file overrides for files that intentionally co-locate components with
+  // their hooks / variant maps / non-component exports. Splitting these into
+  // sibling files would fragment idiomatic React patterns (provider+hook,
+  // shadcn/ui component+cva variants) without meaningful benefit. Fast Refresh
+  // is not the dominant concern in these files — they're stable boilerplate
+  // edited rarely. The exhaustive-deps rule still applies to surface real bugs.
+  {
+    files: [
+      '**/*-context.tsx',
+      '**/admin/lib/pages-router.tsx',
+      '**/components/ui/button.tsx',
+      '**/admin/users/BulkImportModal.tsx',
+    ],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
   eslintConfigPrettier,
 );

--- a/deliverables/F2/PWA/app/src/admin/apps/DataSettings.tsx
+++ b/deliverables/F2/PWA/app/src/admin/apps/DataSettings.tsx
@@ -99,7 +99,7 @@ export function DataSettings({ apiBaseUrl, fetchImpl }: DataSettingsProps): JSX.
     return () => {
       cancelled = true;
     };
-  }, [apiBaseUrl, token, reloadTick]);
+  }, [apiBaseUrl, token, reloadTick, clearAuth, navigate, fetchImpl]);
 
   function authOpts() {
     return {

--- a/deliverables/F2/PWA/app/src/admin/apps/Files.tsx
+++ b/deliverables/F2/PWA/app/src/admin/apps/Files.tsx
@@ -89,7 +89,7 @@ export function Files({ apiBaseUrl, fetchImpl }: FilesProps): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [apiBaseUrl, token, reloadTick]);
+  }, [apiBaseUrl, token, reloadTick, clearAuth, navigate, fetchImpl]);
 
   async function handleUpload(file: File): Promise<void> {
     setUploadError(null);

--- a/deliverables/F2/PWA/app/src/admin/apps/QuotaWidget.tsx
+++ b/deliverables/F2/PWA/app/src/admin/apps/QuotaWidget.tsx
@@ -58,7 +58,7 @@ export function QuotaWidget({ apiBaseUrl, fetchImpl }: QuotaWidgetProps): JSX.El
     return () => {
       cancelled = true;
     };
-  }, [apiBaseUrl, token]);
+  }, [apiBaseUrl, token, clearAuth, navigate, fetchImpl]);
 
   return (
     <section className="flex flex-col gap-2">

--- a/deliverables/F2/PWA/app/src/admin/apps/Versioning.tsx
+++ b/deliverables/F2/PWA/app/src/admin/apps/Versioning.tsx
@@ -67,7 +67,7 @@ export function Versioning({ apiBaseUrl, fetchImpl }: VersioningProps): JSX.Elem
     return () => {
       cancelled = true;
     };
-  }, [apiBaseUrl, token]);
+  }, [apiBaseUrl, token, clearAuth, navigate, fetchImpl]);
 
   return (
     <section className="flex flex-col gap-3">

--- a/deliverables/F2/PWA/app/src/admin/data/AuditTab.tsx
+++ b/deliverables/F2/PWA/app/src/admin/data/AuditTab.tsx
@@ -110,7 +110,7 @@ export function AuditTab({ apiBaseUrl, fetchImpl }: AuditTabProps): JSX.Element 
     return () => {
       cancelled = true;
     };
-  }, [apiQuery, apiBaseUrl, token]);
+  }, [apiQuery, apiBaseUrl, token, clearAuth, navigate, fetchImpl]);
 
   return (
     <div className="flex flex-col gap-4">

--- a/deliverables/F2/PWA/app/src/admin/data/DLQTab.tsx
+++ b/deliverables/F2/PWA/app/src/admin/data/DLQTab.tsx
@@ -104,7 +104,7 @@ export function DLQTab({ apiBaseUrl, fetchImpl }: DLQTabProps): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [apiQuery, apiBaseUrl, token, refreshKey]);
+  }, [apiQuery, apiBaseUrl, token, refreshKey, clearAuth, navigate, fetchImpl]);
 
   // R2-#84: Replay re-attempts the submit through the AS handleSubmit
   // path. If the underlying validation issue has been fixed (e.g., the

--- a/deliverables/F2/PWA/app/src/admin/data/HCWsTab.tsx
+++ b/deliverables/F2/PWA/app/src/admin/data/HCWsTab.tsx
@@ -109,7 +109,7 @@ export function HCWsTab({ apiBaseUrl, fetchImpl }: HCWsTabProps): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [apiQuery, apiBaseUrl, token, reloadTick]);
+  }, [apiQuery, apiBaseUrl, token, reloadTick, clearAuth, navigate, fetchImpl]);
 
   const togglePill = (value: string) => {
     setFilters((prev) => ({ ...prev, status: prev.status === value ? '' : value }));

--- a/deliverables/F2/PWA/app/src/admin/data/ResponseDetail.tsx
+++ b/deliverables/F2/PWA/app/src/admin/data/ResponseDetail.tsx
@@ -95,7 +95,7 @@ function ResponseDetailInner({ apiBaseUrl, submissionId, fetchImpl }: ResponseDe
     return () => {
       cancelled = true;
     };
-  }, [apiBaseUrl, submissionId, token]);
+  }, [apiBaseUrl, submissionId, token, clearAuth, navigate, fetchImpl]);
 
   return (
     <section className="flex flex-col gap-6 py-2">

--- a/deliverables/F2/PWA/app/src/admin/data/ResponsesTab.tsx
+++ b/deliverables/F2/PWA/app/src/admin/data/ResponsesTab.tsx
@@ -151,7 +151,7 @@ export function ResponsesTab({ apiBaseUrl, fetchImpl }: ResponsesTabProps): JSX.
     return () => {
       cancelled = true;
     };
-  }, [apiQuery, apiBaseUrl, token]);
+  }, [apiQuery, apiBaseUrl, token, clearAuth, navigate, fetchImpl]);
 
   const onFilterSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/deliverables/F2/PWA/app/src/admin/lib/pages-router.tsx
+++ b/deliverables/F2/PWA/app/src/admin/lib/pages-router.tsx
@@ -15,8 +15,10 @@
  */
 import React, {
   createContext,
+  useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
   type ReactNode,
   type MouseEvent,
@@ -54,7 +56,10 @@ export function RouterProvider({ children }: { children: ReactNode }): JSX.Eleme
     };
   }, []);
 
-  const navigate = (to: string) => {
+  // Memoize navigate so consumers can put it in useEffect dep arrays without
+  // their effects re-firing on every parent re-render. Empty dep array because
+  // navigate has no closed-over state — it reads window.location each call.
+  const navigate = useCallback((to: string) => {
     // Compare against the full URL (pathname + search) so tab/filter
     // navigations like /admin/data?tab=audit aren't bailed out of just
     // because the pathname matches.
@@ -62,13 +67,14 @@ export function RouterProvider({ children }: { children: ReactNode }): JSX.Eleme
     if (to === current) return;
     window.history.pushState({}, '', to);
     window.dispatchEvent(new Event(PATH_CHANGE_EVENT));
-  };
+  }, []);
 
-  return (
-    <RouterContext.Provider value={{ pathname, search, navigate }}>
-      {children}
-    </RouterContext.Provider>
-  );
+  // Memoize the context value so consumers don't re-render just because
+  // RouterProvider's parent re-rendered (object identity stays stable until
+  // pathname/search actually change).
+  const value = useMemo(() => ({ pathname, search, navigate }), [pathname, search, navigate]);
+
+  return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>;
 }
 
 export function useRouter(): RouterCtx {

--- a/deliverables/F2/PWA/app/src/admin/report/MapReport.tsx
+++ b/deliverables/F2/PWA/app/src/admin/report/MapReport.tsx
@@ -146,7 +146,7 @@ export function MapReport({ apiBaseUrl, fetchImpl }: MapReportProps): JSX.Elemen
     return () => {
       cancelled = true;
     };
-  }, [apiQuery, apiBaseUrl, token]);
+  }, [apiQuery, apiBaseUrl, token, clearAuth, navigate, fetchImpl]);
 
   // Group markers by region (2-char facility prefix) for the sidebar.
   const regionCounts = useMemo(() => {

--- a/deliverables/F2/PWA/app/src/admin/report/SyncReport.tsx
+++ b/deliverables/F2/PWA/app/src/admin/report/SyncReport.tsx
@@ -107,7 +107,7 @@ export function SyncReport({ apiBaseUrl, fetchImpl }: SyncReportProps): JSX.Elem
     return () => {
       cancelled = true;
     };
-  }, [apiQuery, apiBaseUrl, token]);
+  }, [apiQuery, apiBaseUrl, token, clearAuth, navigate, fetchImpl]);
 
   const setLevel = (level: Level) => setFilters({ ...filters, level });
 

--- a/deliverables/F2/PWA/app/src/lib/auth-context.tsx
+++ b/deliverables/F2/PWA/app/src/lib/auth-context.tsx
@@ -74,7 +74,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 // Context+hook pair lives alongside the Provider for cohesion. HMR's
 // "only-export-components" rule is too strict for this React-standard pattern;
 // splitting across files just to satisfy it adds friction without runtime benefit.
-// eslint-disable-next-line react-refresh/only-export-components
+ 
 export function useAuth(): AuthContextValue {
   const ctx = useContext(AuthContext);
   if (!ctx) {


### PR DESCRIPTION
## Summary

Quality cleanup pass. Today's work has been intermittently obscured by 17 accumulated ESLint warnings in `npm run lint` output. This PR clears all 17 — `npm run lint` now exits 0 errors / 0 warnings.

| Bucket | Count | Approach |
|---|---|---|
| `react-hooks/exhaustive-deps` | 11 | Added missing `clearAuth, navigate, fetchImpl` to dep arrays. Safe because all three are stable identities (clearAuth+navigate via useCallback, fetchImpl is a stable prop per-render). |
| `react-refresh/only-export-components` | 6 | Per-file override for files with intentional context+hook colocation (auth-context.tsx, pages-router.tsx, button.tsx, BulkImportModal.tsx). Splitting them would fragment idiomatic React patterns. |

## Per-commit detail

### `73fa6fe` — memoize navigate + per-file react-refresh override

- `pages-router.tsx`: wrap `navigate` in `useCallback` (previously inline; new identity per render). Wrap context value in `useMemo` so RouterProvider re-renders don't cascade.
- `eslint.config.js`: per-file override disabling `react-refresh/only-export-components` for `*-context.tsx` files, `pages-router.tsx`, `button.tsx`, `BulkImportModal.tsx`.

### `14a5386` — close 11 react-hooks/exhaustive-deps warnings

Added `clearAuth, navigate, fetchImpl` to dep arrays in 11 admin data-fetching components:
- `apps/{DataSettings,Files,QuotaWidget,Versioning}.tsx`
- `data/{AuditTab,DLQTab,HCWsTab,ResponseDetail,ResponsesTab}.tsx`
- `report/{MapReport,SyncReport}.tsx`

Plus auto-removal of one stale `// eslint-disable-next-line react-refresh/only-export-components` directive in `src/lib/auth-context.tsx` (no longer needed after the per-file override).

## Out of scope

- **Vite `esbuild` → `oxc` deprecation warnings** — these come from `@vitejs/plugin-react` internals (not our config). Closing them would require migrating to `@vitejs/plugin-react-oxc`. Not a 1.5h-cleanup item.

## Test plan

- [x] `npm run lint` clean (0 errors, **0 warnings** — was 17 warnings)
- [x] `npm run typecheck` clean
- [x] `npm test` — 51 files / 422 tests pass (occasional IndexedDB-race flakes on first run; pass on rerun — pre-existing)
- [x] No behavior change for production: navigate memoization is a strict improvement (fewer unnecessary re-renders); dep array additions don't refire effects in practice (all 3 deps are stable identities)