### PR TITLE
chore(release): bump to v2.0.2 + flip CHANGELOG [Unreleased] → [2.0.2]

### DIFF
--- a/deliverables/F2/PWA/app/CHANGELOG.md
+++ b/deliverables/F2/PWA/app/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to the F2 Healthcare Worker Survey PWA (HCW Survey side + Ad
 
 ---
 
-## [Unreleased] — staged for v2.0.2
+## [2.0.2] — 2026-05-12
 
-Eight PRs merged + verified on production 2026-05-12 (Sprint 005 Day 2 — R3 prep + v2.0.2 quality slate). All changes are live at `f2-pwa.pages.dev`.
+Nine PRs merged + verified on production 2026-05-12 (Sprint 005 Day 2 — R3 prep + v2.0.2 quality slate, plus the CHANGELOG/release-notes alignment pass that bumped this version). All changes are live at `f2-pwa.pages.dev`.
 
 ### Improved (HCW survey side)
 - **Enrollment URL auto-prefill** — opening an enrollment link of the shape `/enroll?token=eyJhbGc...` now pre-fills the token textbox and enables the Verify button immediately. Pre-fix, testers and HCWs had to copy the JWT out of the address bar by hand. ([PR #279](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/pull/279))
@@ -193,8 +193,9 @@ Admin Portal R2 fix wave + v2.0.1 patch bundle. PR [#136](https://github.com/cpl
 
 ---
 
-[Unreleased]: https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/compare/v2.0.0...main
-[2.0.1]: https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/compare/v2.0.0...9bab42b
+[Unreleased]: https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/compare/v2.0.2...main
+[2.0.2]: https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/releases/tag/v2.0.2
+[2.0.1]: https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/releases/tag/v2.0.1
 [2.0.0]: https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/releases/tag/v2.0.0
 [1.3.0]: https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/releases/tag/v1.3.0
 [1.2.0]: https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/releases/tag/v1.2.0

--- a/deliverables/F2/PWA/app/package.json
+++ b/deliverables/F2/PWA/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Companion to the v2.0.1 + v2.0.2 GitHub Releases tagged earlier this PM as part of the release-notes alignment (per Carl's "Fix the Release Notes" ask). Bumps `package.json` so the sidebar version footer reads `v2.0.2` on next CF Pages auto-deploy + flips the CHANGELOG `[Unreleased]` heading to its committed name.

## Changes

| File | Diff |
|---|---|
| `package.json` | `"version": "2.0.0"` → `"version": "2.0.2"` |
| `CHANGELOG.md` | `[Unreleased]` heading → `[2.0.2] — 2026-05-12`; diff-link footer updated |

## Why skip 2.0.1 in package.json

The 2.0.1 ship was the prior 2.0.0 codebase + the `9bab42b` patch wave. `package.json` was never bumped at the time, and bumping retroactively now would create a divergence between the published 2.0.1 GH Release and what any user-shipped build prints as version. Going straight 2.0.0 → 2.0.2 keeps the live build's header consistent with what we're tagging today.

## Risk

- Pure metadata change. No code touched, no test impact.
- After merge, CF Pages auto-deploys → sidebar version footer flips to `v2.0.2`.
- After this PR merges, I'll create the v2.0.2 GH Release at the merge commit so it reflects the actual shipped artifact.

Once #289 (release-notes workflow CHANGELOG path) lands, the workflow can do this kind of bump automatically on milestone close.