### PR TITLE
docs(uat): R3 guides refresh — bump v2.0.0 → v2.0.2 + reflect post-#280 fixes

### DIFF
--- a/docs/F2-PWA-UAT-Round-3-Admin-Portal-Tester-Guide-2026-05-13.md
+++ b/docs/F2-PWA-UAT-Round-3-Admin-Portal-Tester-Guide-2026-05-13.md
@@ -7,7 +7,7 @@
 **Coordinator:** Carl Patrick L. Reyes (Data Programmer)
 **Window:** Opens Wed 2026-05-13 AM · Closes Fri 2026-05-15 PM (sprint close)
 
-> **Project context.** The F2 Admin Portal is the operations console ASPSI ops users run from. It mirrors the **CSWeb** dashboard model — same shape, 5 dashboards × 5 roles × per-instrument flags. An ops user enrolls HCWs (mints tablet tokens), monitors submissions, triages dead-letter-queue entries, manages files (training plans, rosters), schedules CSV break-out exports, audits actions, and onboards other ops users. Round 3's job is twofold: **(a) regression-check** that the 33 admin-side R2 fixes (closed 2026-05-09) plus the v2.0.1 patch bundle (PR #136 — 9 E4-APRT-04x patches) still hold on current prod (v2.0.0+v2.0.1), and **(b) stress-test** what Round 2 didn't cover — concurrent multi-admin actions, RBAC edge cases, cross-tab session, kill-switch/spec-drift admin response, audit log completeness, FX-017 deferred touch-targets, large-data scenarios.
+> **Project context.** The F2 Admin Portal is the operations console ASPSI ops users run from. It mirrors the **CSWeb** dashboard model — same shape, 5 dashboards × 5 roles × per-instrument flags. An ops user enrolls HCWs (mints tablet tokens), monitors submissions, triages dead-letter-queue entries, manages files (training plans, rosters), schedules CSV break-out exports, audits actions, and onboards other ops users. Round 3's job is twofold: **(a) regression-check** that the 33 admin-side R2 fixes (closed 2026-05-09) plus the v2.0.1 patch bundle (PR #136 — 9 E4-APRT-04x patches) still hold on current prod (v2.0.2 — covers v2.0.0 base + v2.0.1 patches + 2026-05-12 polish slate), and **(b) stress-test** what Round 2 didn't cover — concurrent multi-admin actions, RBAC edge cases, cross-tab session, kill-switch/spec-drift admin response, audit log completeness, FX-017 deferred touch-targets, large-data scenarios.
 
 > **Why this round exists.** Round 2 closed cleanly with 33 admin-side issues fixed; v2.0.1 patches (Create-HCW UI, RBAC cache fix, JWT pwc enforce, design 5-fix sweep, concurrency, last_login_at, orphan-admin guards, user-self password rotation) shipped AFTER R2 closed and never had explicit tester walks. R3 is the first cycle to (a) confirm R2 + v2.0.1 fixes haven't regressed and (b) explore admin-specific scenario classes R2's nominal-flow walk didn't touch.
 
@@ -22,13 +22,13 @@
 | **Production Admin Portal** | https://f2-pwa.pages.dev/admin/login |
 | **Help (no-auth)** | https://f2-pwa.pages.dev/admin/help |
 | **Worker (curl smoke)** | https://f2-pwa-worker.hcw.workers.dev |
-| **Current prod version** | v2.0.0 base + v2.0.1 patch bundle (PR #136 merged 2026-05-09) |
+| **Current prod version** | v2.0.2 (header `v2.0.2 · spec 2026-04-17-m1`) — covers v2.0.0 base + v2.0.1 patch bundle (PR #136) + 2026-05-12 polish slate (PRs #274/#276/#279/#281/#283/#285/#288/#291) |
 | **Spec — full Admin Portal design** | `docs/superpowers/specs/2026-05-01-f2-admin-portal-design.md` |
 | **Concept overview** | `wiki/concepts/F2 Admin Portal.md` |
 | **Bug repo** | https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues |
 | **Bug-filing label** | `from-uat-round-3-2026-05` |
 | **Slack channel (blockers + daily check-in)** | `#f2-pwa-uat` on `aspsi-doh-uhc-survey2.slack.com` |
-| **Release notes** | https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/releases/tag/v2.0.0 |
+| **Release notes** | https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/releases/tag/v2.0.2 (latest) · [v2.0.1](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/releases/tag/v2.0.1) · [v2.0.0](https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/releases/tag/v2.0.0) |
 | **R3 sprint card** | https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/issues/271 |
 
 ---
@@ -58,9 +58,9 @@
 
 1. **Open `https://f2-pwa.pages.dev/admin/login`** in Chrome. Page loads with the Verde paper background and login form.
 2. **Login with your dedicated credential** (your R2-reset password). Land on Data dashboard.
-3. **Confirm version.** Apps & Settings → Versioning should read **PWA: 2.0.0** + **Worker: 2.0.0+** (with v2.0.1 patches in Worker hash).
-4. **Sidebar shows your username + role badge** ("Administrator") at the bottom-left. Version footer below should read **`v2.0.0`** (NOT `v0.1.0-staging` — that was a hardcoded literal regression fixed 2026-05-12 in PR #279). If you still see `v0.1.0-staging`, hard-refresh the page to pull the new bundle.
-5. **Open `https://f2-pwa.pages.dev/admin/help` in incognito** (no auth). Help page renders **and the URL bar stays at `/admin/help`** (NOT racing to `/admin/login` — that was a useEffect race fixed 2026-05-12 in PR #279). The full operator sidebar is still visible to unauthenticated users by current design — that broader UX gap is tracked separately as #278 for v2.0.2.
+3. **Confirm version.** Apps & Settings → Versioning should read **PWA: 2.0.2** + **Worker: 2.0.0+** (Worker version pinned via wrangler.toml; package.json bump to 2.0.2 is PWA-side only).
+4. **Sidebar shows your username + role badge** ("Administrator") at the bottom-left. Version footer below should read **`v2.0.2`** (NOT `v0.1.0-staging` — that was a hardcoded literal regression fixed 2026-05-12 in PR #279; not `v2.0.0` or `v2.0.1` either — bumped in PR #291). If you still see an older value, hard-refresh the page to pull the new bundle.
+5. **Open `https://f2-pwa.pages.dev/admin/help` in incognito** (no auth). Help page renders, the URL bar stays at `/admin/help`, **and the sidebar shows ONLY the Help link + a "Sign in" CTA** (the full operator nav is hidden for unauthenticated users — fixed in PR #281). If you see the full nav with all 7 dashboard links + a "Sign out" button while not signed in, hard-refresh.
 6. **Confirm seed data exists** — Data → HCWs sub-tab → 12 `DEMO-HCW-*` rows visible.
 7. **DevTools open** (F12) — Network + Console tabs visible. Capture screenshots of these for any bug.
 

--- a/docs/F2-PWA-UAT-Round-3-HCW-Survey-Tester-Guide-2026-05-13.md
+++ b/docs/F2-PWA-UAT-Round-3-HCW-Survey-Tester-Guide-2026-05-13.md
@@ -7,11 +7,11 @@
 **Coordinator:** Carl Patrick L. Reyes (Data Programmer)
 **Window:** Opens Wed 2026-05-13 AM · Closes Fri 2026-05-15 PM (sprint close)
 
-> **Project context.** This is the **DOH UHC Survey Year 2 — Healthcare Worker Survey**. Field rollout uses tablets handed to HCWs (nurses, midwives, physicians, etc.) at sampled health facilities. Round 3's job is twofold: **(a)** **regression-check** that the 14 HCW-survey-side R2 fixes (closed 2026-05-08 / 2026-05-09) still hold on current prod (v2.0.0), and **(b)** **stress-test** what Round 2 didn't cover — offline behavior, real device matrix, edge data, resume after force-quit, and token edge cases.
+> **Project context.** This is the **DOH UHC Survey Year 2 — Healthcare Worker Survey**. Field rollout uses tablets handed to HCWs (nurses, midwives, physicians, etc.) at sampled health facilities. Round 3's job is twofold: **(a)** **regression-check** that the 14 HCW-survey-side R2 fixes (closed 2026-05-08 / 2026-05-09) still hold on current prod (v2.0.2 — includes the v2.0.1 R2 patch wave + 2026-05-12 polish slate), and **(b)** **stress-test** what Round 2 didn't cover — offline behavior, real device matrix, edge data, resume after force-quit, and token edge cases.
 
 > **Why this round exists.** Round 2 closed cleanly with 47 issues fixed (14 HCW-survey side + 33 Admin Portal). R3 is the first cycle on the post-R2 build to (a) confirm those fixes haven't regressed under continued development and (b) explore scenario classes R2's full-form happy/alt/error pass didn't touch.
 
-> **Scope of this guide.** PWA-side only — what an HCW sees on the tablet. No Admin Portal testing this round (Admin Portal stays at v2.0.1 from PR #136; no R3 cycle for it).
+> **Scope of this guide.** PWA-side only — what an HCW sees on the tablet. Admin Portal testing has its own companion guide (link above); both Shan + Kidd walk both sides.
 
 ---
 
@@ -20,7 +20,7 @@
 | Item | Value |
 |---|---|
 | **Production PWA URL** | https://f2-pwa.pages.dev |
-| **Current prod version** | v2.0.0 (header: `v2.0.0 · spec 2026-04-17-m1`) |
+| **Current prod version** | v2.0.2 (header: `v2.0.2 · spec 2026-04-17-m1`) — includes v2.0.0 + v2.0.1 patches + 2026-05-12 polish slate |
 | **Spec — verbatim question text + validation rules** | `deliverables/F2/F2-Spec.md` |
 | **Skip logic + branching** | `deliverables/F2/F2-Skip-Logic.md` |
 | **Cross-field validation** | `deliverables/F2/F2-Cross-Field.md` |
@@ -68,7 +68,7 @@ Same as Round 2 — see `docs/F2-PWA-UAT-Round-2-HCW-Survey-Tester-Guide-2026-05
 
 ## 4. Pre-Flight Checks (do these before testing)
 
-1. **Confirm prod version.** Open `https://f2-pwa.pages.dev` on your test device. Header should read `v2.0.0 · spec 2026-04-17-m1`. If it says `v1.x.x`, hard-refresh (Ctrl+Shift+R or pull-down refresh on tablet) — service worker may need to update.
+1. **Confirm prod version.** Open `https://f2-pwa.pages.dev` on your test device. Header should read `v2.0.2 · spec 2026-04-17-m1`. If it says `v1.x.x` or `v2.0.0` / `v2.0.1`, hard-refresh (Ctrl+Shift+R or pull-down refresh on tablet) — service worker may need to update.
 2. **Open DevTools** (F12 on desktop, or Chrome remote debugging from a paired desktop for tablets). Network + Console tabs visible.
 3. **Read these reference docs once before testing:**
    - `deliverables/F2/F2-Spec.md` — full questionnaire structure


### PR DESCRIPTION
## Summary

Per Carl's check: "is the UAT R3 guide updated and ready to be used?"

Honest answer pre-this-PR: **no, not fully.** Guides were updated this AM in PR #280 (right after PR #279) but 4 more user-visible PRs landed since then. Pre-flight checks pointed at `v2.0.0` while prod now serves `v2.0.2`; the `/admin/help` pre-flight check still flagged the unauth-Layout gap as "tracked for v2.0.2" while PR #281 actually shipped the fix.

This PR brings the guides current.

## What changed

### HCW guide
- Project context: `current prod (v2.0.0)` → `v2.0.2`
- Scope-of-this-guide: dropped stale "no R3 cycle for Admin Portal" line — there IS a companion guide
- Quick Reference: prod version v2.0.0 → v2.0.2
- Pre-Flight #1: header expectation v2.0.0 → v2.0.2 + add v2.0.0/v2.0.1 to hard-refresh trigger list

### Admin Portal guide
- Project context: `current prod (v2.0.0+v2.0.1)` → `v2.0.2`
- Quick Reference: prod version updated + Release notes link to v2.0.2 (latest) + v2.0.1 + v2.0.0
- Pre-Flight #3: Versioning panel expectation PWA: 2.0.0 → 2.0.2
- Pre-Flight #4: footer expectation v2.0.0 → v2.0.2 with hard-refresh hint
- Pre-Flight #5: **rewritten** — slim no-auth Layout (PR #281) shipped, so testers now see ONLY the Help link + Sign-in CTA when unauthenticated. Stale "broader UX gap tracked separately as #278" note dropped.

## What didn't change

- All scenario content in 5A (R2 regression) + 5B (new scenarios) — none of today's PRs invalidated any test scenario
- Tester roster + tokens + credentials — unchanged
- Bug-filing template + label — unchanged
- Triage cadence — unchanged

## Test plan

- [x] All scenario sections preserved
- [x] All version refs match current prod (v2.0.2 / `v2.0.2 · spec 2026-04-17-m1`)
- [x] All previously-deferred-to-v2.0.2 follow-up notes either updated to "shipped in PR #N" or dropped
- [ ] **Reviewer:** spot-check that the Pre-Flight #5 rewrite for /admin/help correctly describes what testers will see (slim no-auth Layout)

## Risk

Pure documentation. Zero deployment impact. No code touched.