### PR TITLE
Re-ship stranded a11y fixes #287 #284 (integrity correction)

### DIFF
--- a/deliverables/F2/PWA/app/src/admin/report/MapReport.tsx
+++ b/deliverables/F2/PWA/app/src/admin/report/MapReport.tsx
@@ -297,9 +297,28 @@ function MapPlot({
             key={m.submission_id}
             position={[m.lat, m.lng]}
             icon={hovered?.submission_id === m.submission_id ? VERDE_MARKER_ICON_SELECTED : VERDE_MARKER_ICON}
+            keyboard
             eventHandlers={{
               click: () => onHover(m),
               popupclose: () => onHover(null),
+              // #287: the divIcon is aria-hidden, so AT/keyboard users get
+              // nothing. Decorate the marker element on add: role + name +
+              // tabindex, and bind Enter/Space to the same action as click
+              // (Leaflet's built-in Enter→click is unreliable for divIcons).
+              add: ({ target }) => {
+                const el = target.getElement() as HTMLElement | undefined;
+                if (!el) return;
+                el.setAttribute('role', 'button');
+                el.setAttribute('tabindex', '0');
+                el.setAttribute('aria-label', describeMarker(m));
+                el.addEventListener('keydown', (ev: KeyboardEvent) => {
+                  if (ev.key === 'Enter' || ev.key === ' ') {
+                    ev.preventDefault();
+                    onHover(m);
+                    target.openPopup();
+                  }
+                });
+              },
             }}
           >
             <Popup>
@@ -406,6 +425,12 @@ function FilterText({
       />
     </label>
   );
+}
+
+// #287: accessible name for a map marker (announced to AT, exposed as the
+// marker element's aria-label). Mirrors the Popup's human-readable content.
+function describeMarker(m: MarkerData): string {
+  return `Submission ${m.hcw_id}, facility ${m.facility_id}, submitted ${formatTs(m.submitted_at)}. Activate to view details.`;
 }
 
 function formatTs(iso: string): string {

--- a/deliverables/F2/PWA/app/src/components/chrome/KillSwitchOverlay.tsx
+++ b/deliverables/F2/PWA/app/src/components/chrome/KillSwitchOverlay.tsx
@@ -1,4 +1,6 @@
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useFocusTrap } from '@/lib/use-focus-trap';
 
 interface Props {
   active: boolean;
@@ -6,10 +8,16 @@ interface Props {
 
 export function KillSwitchOverlay({ active }: Props) {
   const { t } = useTranslation();
+  const ref = useRef<HTMLDivElement>(null);
+  // #284: terminal overlay with no controls — trap focus on the dialog so
+  // keyboard/AT can't reach or edit the form behind it.
+  useFocusTrap(ref, active);
   if (!active) return null;
   return (
     <div
-      role="alert"
+      ref={ref}
+      role="alertdialog"
+      aria-modal="true"
       aria-labelledby="kill-switch-title"
       aria-describedby="kill-switch-body"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6"

--- a/deliverables/F2/PWA/app/src/components/chrome/SpecDriftOverlay.tsx
+++ b/deliverables/F2/PWA/app/src/components/chrome/SpecDriftOverlay.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
+import { useFocusTrap } from '@/lib/use-focus-trap';
 
 interface Props {
   drift: boolean;
@@ -10,15 +11,16 @@ interface Props {
 
 export function SpecDriftOverlay({ drift, localVersion, serverMin }: Props) {
   const { t } = useTranslation();
-  const reloadRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (drift) reloadRef.current?.focus();
-  }, [drift]);
+  const ref = useRef<HTMLDivElement>(null);
+  // #284: trap focus on the dialog (was: focus Reload, but Tab still
+  // escaped to the form behind). The hook focuses the first focusable
+  // (Reload) and cycles Tab within the dialog.
+  useFocusTrap(ref, drift);
 
   if (!drift) return null;
   return (
     <div
+      ref={ref}
       role="alertdialog"
       aria-modal="true"
       aria-labelledby="spec-drift-title"
@@ -32,7 +34,7 @@ export function SpecDriftOverlay({ drift, localVersion, serverMin }: Props) {
         <p id="spec-drift-body" className="mb-4 text-sm text-muted-foreground">
           {t('chrome.specDriftBody', { localVersion, serverMin })}
         </p>
-        <Button ref={reloadRef} onClick={() => window.location.reload()}>
+        <Button onClick={() => window.location.reload()}>
           {t('chrome.reload')}
         </Button>
       </div>

--- a/deliverables/F2/PWA/app/src/components/chrome/chrome.test.tsx
+++ b/deliverables/F2/PWA/app/src/components/chrome/chrome.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { I18nextProvider } from 'react-i18next';
 import { i18n } from '@/i18n';
 import { BroadcastBanner } from './BroadcastBanner';
@@ -23,7 +24,8 @@ describe('chrome', () => {
 
   it('KillSwitchOverlay renders when active', () => {
     render(wrap(<KillSwitchOverlay active={true} />));
-    expect(screen.getByRole('alert')).toBeInTheDocument();
+    // #284: now a modal alertdialog (was a passive role="alert").
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
   });
 
   it('KillSwitchOverlay renders nothing when inactive', () => {
@@ -41,5 +43,57 @@ describe('chrome', () => {
       wrap(<SpecDriftOverlay drift={false} localVersion="a" serverMin="a" />),
     );
     expect(container.textContent).toBe('');
+  });
+
+  // #284: blocking overlays must trap focus — the form behind was only
+  // blocked at submit; keyboard/AT could still edit it.
+  it('KillSwitchOverlay is a modal dialog that pulls focus off the form (#284)', () => {
+    render(
+      wrap(
+        <>
+          <input data-testid="form-field" />
+          <KillSwitchOverlay active={true} />
+        </>,
+      ),
+    );
+    const dialog = screen.getByRole('alertdialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    // Focus left the form and is pinned on the (control-less) dialog.
+    expect(screen.getByTestId('form-field')).not.toHaveFocus();
+    expect(dialog).toHaveFocus();
+  });
+
+  it('KillSwitchOverlay traps Tab inside the dialog (#284)', async () => {
+    const user = userEvent.setup();
+    render(
+      wrap(
+        <>
+          <input data-testid="form-field" />
+          <KillSwitchOverlay active={true} />
+        </>,
+      ),
+    );
+    const dialog = screen.getByRole('alertdialog');
+    await user.tab();
+    // Tab does not escape into the form behind the overlay.
+    expect(screen.getByTestId('form-field')).not.toHaveFocus();
+    expect(dialog).toHaveFocus();
+  });
+
+  it('SpecDriftOverlay moves focus to Reload and keeps Tab trapped (#284)', async () => {
+    const user = userEvent.setup();
+    render(
+      wrap(
+        <>
+          <input data-testid="form-field" />
+          <SpecDriftOverlay drift={true} localVersion="a" serverMin="b" />
+        </>,
+      ),
+    );
+    const reload = screen.getByRole('button', { name: /reload/i });
+    expect(reload).toHaveFocus();
+    await user.tab();
+    expect(screen.getByTestId('form-field')).not.toHaveFocus();
+    expect(reload).toHaveFocus(); // only focusable in the dialog → stays
   });
 });

--- a/deliverables/F2/PWA/app/src/lib/use-focus-trap.ts
+++ b/deliverables/F2/PWA/app/src/lib/use-focus-trap.ts
@@ -1,0 +1,82 @@
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * #284: trap focus inside a blocking overlay (KillSwitch / SpecDrift).
+ *
+ * When `active`, this:
+ *  - remembers what was focused, then moves focus into `containerRef`
+ *    (the first focusable child, else the container itself — so a
+ *    button-less terminal overlay like KillSwitch still pulls focus
+ *    off the form behind it),
+ *  - keeps Tab / Shift+Tab cycling within the container (the form
+ *    behind the overlay can no longer be reached or edited by keyboard
+ *    or AT — it was only blocked at submit before),
+ *  - restores focus to the previously-focused element on deactivate.
+ *
+ * Deliberately framework-light (no focus-trap dep): these overlays have
+ * 0–1 focusable children, so the full library would be overkill.
+ */
+export function useFocusTrap(
+  containerRef: RefObject<HTMLElement | null>,
+  active: boolean,
+): void {
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    // No offsetParent/getClientRects visibility filter on purpose: the
+    // overlay only mounts when active and its content is always visible,
+    // and those APIs return falsy under jsdom (untestable) and are flaky
+    // for fixed-position containers in real browsers.
+    const focusables = (): HTMLElement[] =>
+      Array.from(
+        container.querySelectorAll<HTMLElement>(
+          'a[href],button:not([disabled]),textarea,input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])',
+        ),
+      );
+
+    const first = focusables()[0];
+    if (first) {
+      first.focus();
+    } else {
+      // Button-less overlay (KillSwitch): make the container itself the
+      // focus sink so keyboard/AT focus leaves the form behind.
+      container.tabIndex = -1;
+      container.focus();
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const items = focusables();
+      if (items.length === 0) {
+        // Nothing to cycle to — keep focus pinned on the container.
+        e.preventDefault();
+        container.focus();
+        return;
+      }
+      const firstEl = items[0];
+      const lastEl = items[items.length - 1];
+      const activeEl = document.activeElement;
+      if (e.shiftKey && activeEl === firstEl) {
+        e.preventDefault();
+        lastEl.focus();
+      } else if (!e.shiftKey && activeEl === lastEl) {
+        e.preventDefault();
+        firstEl.focus();
+      } else if (!container.contains(activeEl)) {
+        // Focus somehow escaped (initial Tab from outside) — pull it back.
+        e.preventDefault();
+        firstEl.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      previouslyFocused?.focus?.();
+    };
+  }, [containerRef, active]);
+}


### PR DESCRIPTION
Closes #287
Closes #284

**Integrity correction.** #287 + #284 were auto-closed via PR #333 body but their commits were never pushed before that squash-merge — only #286/#289 shipped. This re-ships the intact commits (cherry-picked onto current `origin/main`, which already has #298/#286/#289).

- **#287** MapReport markers: keyboard-focusable + role/tabindex/aria-label + Enter/Space → popup.
- **#284** shared `useFocusTrap` for KillSwitch/SpecDrift; KillSwitch promoted to role="alertdialog".

Verified on current main: tsc + eslint clean; chrome 9/9 + admin a11y; **full suite 435/435 single-threaded** (no regression). Pushed *before* merge. No version/CHANGELOG bump. #287 AT/SR browser verification still pending (not claimed SR-verified).