### PR TITLE
#314 — sharpened diagnosis (fault is Section's form host, not MatrixQuestion)

### DIFF
--- a/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.tsx
@@ -1,138 +1,22 @@
 import type * as React from 'react';
-import { useController, useFormContext, type Control, type FieldValues } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import type { TFunction } from 'i18next';
 import { useLocale } from '@/i18n/locale-context';
 import { localized } from '@/i18n/localized';
 import type { Choice, Item } from '@/types/survey';
-import type { Locale } from '@/i18n/locale-context';
 
 interface MatrixQuestionProps {
   items: Item[];
   choices: Choice[];
 }
 
-// #314: MatrixQuestion renders every radio TWICE (desktop <table> + mobile
-// cards). When both copies used uncontrolled `{...register(item.id)}`, RHF
-// got duplicate refs for one radio-group name and applied `defaultValues`
-// to only ONE copy — the desktop table (what tablet/desktop users see)
-// rendered blank on the Edit-from-review remount.
-//
-// Fix: bind each row through `useController`. Controller is RHF's official
-// controlled binding — `field.value` deterministically reflects
-// `defaultValues` (no uncontrolled-ref ambiguity, none of the
-// `useWatch`-pre-registration timing issues under Section's
-// resolver+onChange useForm config). Two controllers for the same name
-// (one per layout) is supported by RHF and is the idiomatic way to render
-// one field in two places; both read the same field state, so both layout
-// copies — and the rehydrated state — are deterministic.
-
-function useRowField(name: string, control: Control<FieldValues>) {
-  const { field, fieldState } = useController({ name, control });
-  return {
-    value: field.value as string | undefined,
-    onChange: (v: string) => field.onChange(v),
-    error: fieldState.error?.message,
-    hasError: fieldState.error != null,
-  };
-}
-
-function DesktopRow({
-  item,
-  choices,
-  control,
-  locale,
-  t,
-}: {
-  item: Item;
-  choices: Choice[];
-  control: Control<FieldValues>;
-  locale: Locale;
-  t: TFunction;
-}): React.ReactElement {
-  const { value, onChange, error, hasError } = useRowField(item.id, control);
-  return (
-    <>
-      <tr className="border-b">
-        <th scope="row" className="py-2 pr-2 text-left text-sm font-normal">
-          <span className="mr-1 text-muted-foreground">{item.id}.</span>
-          {localized(item.label, locale)}
-          {item.required ? <span className="ml-1 text-destructive">*</span> : null}
-        </th>
-        {choices.map((c) => (
-          <td key={c.value} className="py-2 px-1 text-center">
-            <input
-              type="radio"
-              name={item.id}
-              value={c.value}
-              aria-label={`${item.id} ${localized(c.label, locale)}`}
-              checked={value === c.value}
-              onChange={() => onChange(c.value)}
-            />
-          </td>
-        ))}
-      </tr>
-      {hasError ? (
-        <tr>
-          <td colSpan={choices.length + 1} className="py-1 text-xs text-destructive" role="alert">
-            {error ?? t('question.requiredFallback')}
-          </td>
-        </tr>
-      ) : null}
-    </>
-  );
-}
-
-function MobileRow({
-  item,
-  choices,
-  control,
-  locale,
-  t,
-}: {
-  item: Item;
-  choices: Choice[];
-  control: Control<FieldValues>;
-  locale: Locale;
-  t: TFunction;
-}): React.ReactElement {
-  const { value, onChange, error, hasError } = useRowField(item.id, control);
-  const groupId = `${item.id}-statement`;
-  return (
-    <div className="flex flex-col gap-2 border-t pt-3">
-      <p id={groupId} className="text-sm font-medium">
-        <span className="mr-1 text-muted-foreground">{item.id}.</span>
-        {localized(item.label, locale)}
-        {item.required ? <span className="ml-1 text-destructive">*</span> : null}
-      </p>
-      <div role="radiogroup" aria-labelledby={groupId} className="flex flex-wrap gap-3">
-        {choices.map((c) => (
-          <label key={c.value} className="flex items-center gap-1 text-sm">
-            <input
-              type="radio"
-              name={item.id}
-              value={c.value}
-              aria-label={`${item.id} ${localized(c.label, locale)}`}
-              checked={value === c.value}
-              onChange={() => onChange(c.value)}
-            />
-            {localized(c.label, locale)}
-          </label>
-        ))}
-      </div>
-      {hasError ? (
-        <p role="alert" className="text-xs text-destructive">
-          {error ?? t('question.requiredFallback')}
-        </p>
-      ) : null}
-    </div>
-  );
-}
-
 export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
   const { t } = useTranslation();
   const { locale } = useLocale();
-  const { control } = useFormContext();
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext();
 
   return (
     <div className="flex flex-col gap-2 py-3">
@@ -151,31 +35,80 @@ export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
           </tr>
         </thead>
         <tbody>
-          {items.map((item) => (
-            <DesktopRow
-              key={item.id}
-              item={item}
-              choices={choices}
-              control={control}
-              locale={locale}
-              t={t}
-            />
-          ))}
+          {items.flatMap((item) => {
+            const error = errors[item.id];
+            const errorMessage = typeof error?.message === 'string' ? error.message : undefined;
+            const out: React.ReactElement[] = [
+              <tr key={item.id} className="border-b">
+                <th scope="row" className="py-2 pr-2 text-left text-sm font-normal">
+                  <span className="mr-1 text-muted-foreground">{item.id}.</span>
+                  {localized(item.label, locale)}
+                  {item.required ? <span className="ml-1 text-destructive">*</span> : null}
+                </th>
+                {choices.map((c) => (
+                  <td key={c.value} className="py-2 px-1 text-center">
+                    <input
+                      type="radio"
+                      value={c.value}
+                      aria-label={`${item.id} ${localized(c.label, locale)}`}
+                      {...register(item.id)}
+                    />
+                  </td>
+                ))}
+              </tr>,
+            ];
+            if (errorMessage || error) {
+              out.push(
+                <tr key={`${item.id}-err`}>
+                  <td
+                    colSpan={choices.length + 1}
+                    className="py-1 text-xs text-destructive"
+                    role="alert"
+                  >
+                    {errorMessage ?? t('question.requiredFallback')}
+                  </td>
+                </tr>,
+              );
+            }
+            return out;
+          })}
         </tbody>
       </table>
 
       {/* Mobile (below md): stacked card per row */}
       <div className="flex flex-col gap-3 md:hidden">
-        {items.map((item) => (
-          <MobileRow
-            key={item.id}
-            item={item}
-            choices={choices}
-            control={control}
-            locale={locale}
-            t={t}
-          />
-        ))}
+        {items.map((item) => {
+          const error = errors[item.id];
+          const errorMessage = typeof error?.message === 'string' ? error.message : undefined;
+          const groupId = `${item.id}-statement`;
+          return (
+            <div key={item.id} className="flex flex-col gap-2 border-t pt-3">
+              <p id={groupId} className="text-sm font-medium">
+                <span className="mr-1 text-muted-foreground">{item.id}.</span>
+                {localized(item.label, locale)}
+                {item.required ? <span className="ml-1 text-destructive">*</span> : null}
+              </p>
+              <div role="radiogroup" aria-labelledby={groupId} className="flex flex-wrap gap-3">
+                {choices.map((c) => (
+                  <label key={c.value} className="flex items-center gap-1 text-sm">
+                    <input
+                      type="radio"
+                      value={c.value}
+                      aria-label={`${item.id} ${localized(c.label, locale)}`}
+                      {...register(item.id)}
+                    />
+                    {localized(c.label, locale)}
+                  </label>
+                ))}
+              </div>
+              {errorMessage || error ? (
+                <p role="alert" className="text-xs text-destructive">
+                  {errorMessage ?? t('question.requiredFallback')}
+                </p>
+              ) : null}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/MatrixQuestion.tsx
@@ -1,22 +1,138 @@
 import type * as React from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useController, useFormContext, type Control, type FieldValues } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { useLocale } from '@/i18n/locale-context';
 import { localized } from '@/i18n/localized';
 import type { Choice, Item } from '@/types/survey';
+import type { Locale } from '@/i18n/locale-context';
 
 interface MatrixQuestionProps {
   items: Item[];
   choices: Choice[];
 }
 
+// #314: MatrixQuestion renders every radio TWICE (desktop <table> + mobile
+// cards). When both copies used uncontrolled `{...register(item.id)}`, RHF
+// got duplicate refs for one radio-group name and applied `defaultValues`
+// to only ONE copy — the desktop table (what tablet/desktop users see)
+// rendered blank on the Edit-from-review remount.
+//
+// Fix: bind each row through `useController`. Controller is RHF's official
+// controlled binding — `field.value` deterministically reflects
+// `defaultValues` (no uncontrolled-ref ambiguity, none of the
+// `useWatch`-pre-registration timing issues under Section's
+// resolver+onChange useForm config). Two controllers for the same name
+// (one per layout) is supported by RHF and is the idiomatic way to render
+// one field in two places; both read the same field state, so both layout
+// copies — and the rehydrated state — are deterministic.
+
+function useRowField(name: string, control: Control<FieldValues>) {
+  const { field, fieldState } = useController({ name, control });
+  return {
+    value: field.value as string | undefined,
+    onChange: (v: string) => field.onChange(v),
+    error: fieldState.error?.message,
+    hasError: fieldState.error != null,
+  };
+}
+
+function DesktopRow({
+  item,
+  choices,
+  control,
+  locale,
+  t,
+}: {
+  item: Item;
+  choices: Choice[];
+  control: Control<FieldValues>;
+  locale: Locale;
+  t: TFunction;
+}): React.ReactElement {
+  const { value, onChange, error, hasError } = useRowField(item.id, control);
+  return (
+    <>
+      <tr className="border-b">
+        <th scope="row" className="py-2 pr-2 text-left text-sm font-normal">
+          <span className="mr-1 text-muted-foreground">{item.id}.</span>
+          {localized(item.label, locale)}
+          {item.required ? <span className="ml-1 text-destructive">*</span> : null}
+        </th>
+        {choices.map((c) => (
+          <td key={c.value} className="py-2 px-1 text-center">
+            <input
+              type="radio"
+              name={item.id}
+              value={c.value}
+              aria-label={`${item.id} ${localized(c.label, locale)}`}
+              checked={value === c.value}
+              onChange={() => onChange(c.value)}
+            />
+          </td>
+        ))}
+      </tr>
+      {hasError ? (
+        <tr>
+          <td colSpan={choices.length + 1} className="py-1 text-xs text-destructive" role="alert">
+            {error ?? t('question.requiredFallback')}
+          </td>
+        </tr>
+      ) : null}
+    </>
+  );
+}
+
+function MobileRow({
+  item,
+  choices,
+  control,
+  locale,
+  t,
+}: {
+  item: Item;
+  choices: Choice[];
+  control: Control<FieldValues>;
+  locale: Locale;
+  t: TFunction;
+}): React.ReactElement {
+  const { value, onChange, error, hasError } = useRowField(item.id, control);
+  const groupId = `${item.id}-statement`;
+  return (
+    <div className="flex flex-col gap-2 border-t pt-3">
+      <p id={groupId} className="text-sm font-medium">
+        <span className="mr-1 text-muted-foreground">{item.id}.</span>
+        {localized(item.label, locale)}
+        {item.required ? <span className="ml-1 text-destructive">*</span> : null}
+      </p>
+      <div role="radiogroup" aria-labelledby={groupId} className="flex flex-wrap gap-3">
+        {choices.map((c) => (
+          <label key={c.value} className="flex items-center gap-1 text-sm">
+            <input
+              type="radio"
+              name={item.id}
+              value={c.value}
+              aria-label={`${item.id} ${localized(c.label, locale)}`}
+              checked={value === c.value}
+              onChange={() => onChange(c.value)}
+            />
+            {localized(c.label, locale)}
+          </label>
+        ))}
+      </div>
+      {hasError ? (
+        <p role="alert" className="text-xs text-destructive">
+          {error ?? t('question.requiredFallback')}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
   const { t } = useTranslation();
   const { locale } = useLocale();
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext();
+  const { control } = useFormContext();
 
   return (
     <div className="flex flex-col gap-2 py-3">
@@ -35,80 +151,31 @@ export function MatrixQuestion({ items, choices }: MatrixQuestionProps) {
           </tr>
         </thead>
         <tbody>
-          {items.flatMap((item) => {
-            const error = errors[item.id];
-            const errorMessage = typeof error?.message === 'string' ? error.message : undefined;
-            const out: React.ReactElement[] = [
-              <tr key={item.id} className="border-b">
-                <th scope="row" className="py-2 pr-2 text-left text-sm font-normal">
-                  <span className="mr-1 text-muted-foreground">{item.id}.</span>
-                  {localized(item.label, locale)}
-                  {item.required ? <span className="ml-1 text-destructive">*</span> : null}
-                </th>
-                {choices.map((c) => (
-                  <td key={c.value} className="py-2 px-1 text-center">
-                    <input
-                      type="radio"
-                      value={c.value}
-                      aria-label={`${item.id} ${localized(c.label, locale)}`}
-                      {...register(item.id)}
-                    />
-                  </td>
-                ))}
-              </tr>,
-            ];
-            if (errorMessage || error) {
-              out.push(
-                <tr key={`${item.id}-err`}>
-                  <td
-                    colSpan={choices.length + 1}
-                    className="py-1 text-xs text-destructive"
-                    role="alert"
-                  >
-                    {errorMessage ?? t('question.requiredFallback')}
-                  </td>
-                </tr>,
-              );
-            }
-            return out;
-          })}
+          {items.map((item) => (
+            <DesktopRow
+              key={item.id}
+              item={item}
+              choices={choices}
+              control={control}
+              locale={locale}
+              t={t}
+            />
+          ))}
         </tbody>
       </table>
 
       {/* Mobile (below md): stacked card per row */}
       <div className="flex flex-col gap-3 md:hidden">
-        {items.map((item) => {
-          const error = errors[item.id];
-          const errorMessage = typeof error?.message === 'string' ? error.message : undefined;
-          const groupId = `${item.id}-statement`;
-          return (
-            <div key={item.id} className="flex flex-col gap-2 border-t pt-3">
-              <p id={groupId} className="text-sm font-medium">
-                <span className="mr-1 text-muted-foreground">{item.id}.</span>
-                {localized(item.label, locale)}
-                {item.required ? <span className="ml-1 text-destructive">*</span> : null}
-              </p>
-              <div role="radiogroup" aria-labelledby={groupId} className="flex flex-wrap gap-3">
-                {choices.map((c) => (
-                  <label key={c.value} className="flex items-center gap-1 text-sm">
-                    <input
-                      type="radio"
-                      value={c.value}
-                      aria-label={`${item.id} ${localized(c.label, locale)}`}
-                      {...register(item.id)}
-                    />
-                    {localized(c.label, locale)}
-                  </label>
-                ))}
-              </div>
-              {errorMessage || error ? (
-                <p role="alert" className="text-xs text-destructive">
-                  {errorMessage ?? t('question.requiredFallback')}
-                </p>
-              ) : null}
-            </div>
-          );
-        })}
+        {items.map((item) => (
+          <MobileRow
+            key={item.id}
+            item={item}
+            choices={choices}
+            control={control}
+            locale={locale}
+            t={t}
+          />
+        ))}
       </div>
     </div>
   );

--- a/deliverables/F2/PWA/app/src/components/survey/Section.test.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Section.test.tsx
@@ -201,17 +201,32 @@ describe('<Section>', () => {
     expect(onSubmit.mock.calls[0][0]).toEqual({ Q98: '2', Q99: '3' });
   });
 
-  // #314 — FIXED. Root cause: MatrixQuestion rendered every radio TWICE
-  // (desktop `<table>` + mobile cards) with uncontrolled
-  // `{...register(item.id)}`; RHF got duplicate refs for one radio-group
-  // name and applied `defaultValues` to only ONE copy, so the desktop
-  // table (what tablet/desktop users see) rendered blank on the
-  // Edit-from-review remount. Fix: each row now binds through
-  // `useController` (RHF's controlled pattern; `field.value`
-  // deterministically reflects `defaultValues`, and two controllers for
-  // one name across the two layouts is supported). This test is the
-  // regression gate — it must stay green.
-  it('matrix rehydrates from defaultValues after the round-trip (#314)', () => {
+  // #314 — REPRODUCED, NOT YET FIXED. `.skip` = runnable repro; flip to
+  // `it(` when fixed and it must pass.
+  //
+  // DECISIVE REFRAME (2026-05-19): the fault is NOT in MatrixQuestion's
+  // render pattern. Three architecturally-distinct MatrixQuestion fixes —
+  // (1) uncontrolled `register` (shipped), (2) controlled `useWatch`,
+  // (3) `useController` per row — ALL fail THIS Section-level test, while
+  // the *isolated* MatrixQuestion rehydrate test (bare
+  // `useForm({defaultValues})`) PASSES with the same component under
+  // approaches (1) and (3). Same component, same Controller, opposite
+  // result. The only differing variable is the form host:
+  //   - isolated harness: `useForm({ defaultValues })`            → rehydrates
+  //   - Section.tsx:      `useForm({ resolver, mode:'onChange',
+  //                                  defaultValues })`            → does NOT
+  // So #314's root cause is in **Section.tsx's useForm configuration /
+  // defaultValues handling on the Edit re-mount** (the resolver wraps
+  // values via `stripNulls`; `mode:'onChange'` + resolver may revalidate/
+  // reset before child fields register), NOT in MatrixQuestion. The
+  // earlier "duplicate radio refs" theory explained the original symptom
+  // but is disproven as the *root* cause by the Controller result.
+  //
+  // Per systematic-debugging Phase 4.5 (3+ fixes failed = wrong
+  // architecture/understanding): STOPPED here deliberately. Next
+  // investigation belongs in Section.tsx's form host, not MatrixQuestion —
+  // do NOT re-attempt MatrixQuestion-side patches.
+  it.skip('matrix rehydrates from defaultValues after the round-trip (#314)', () => {
     renderWithProviders(
       <Section
         section={matrixFixture}

--- a/deliverables/F2/PWA/app/src/components/survey/Section.test.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Section.test.tsx
@@ -201,34 +201,17 @@ describe('<Section>', () => {
     expect(onSubmit.mock.calls[0][0]).toEqual({ Q98: '2', Q99: '3' });
   });
 
-  // #314 — REPRODUCED + ROOT-CAUSED, fix pending an architectural decision.
-  // `.skip` because it fails on purpose (it's the runnable reproduction);
-  // flip to `it(` once MatrixQuestion is fixed and this should pass.
-  //
-  // Root cause: MatrixQuestion renders every radio TWICE — once in the
-  // desktop `<table>` (md:table) and once in the mobile cards (md:hidden) —
-  // both attaching `{...register(item.id)}`. RHF gets duplicate refs for a
-  // single radio-group name and applies `defaultValues` to only ONE copy.
-  // On the Edit-from-review remount (Section re-mounts with sectionDefaults),
-  // the *desktop* table — what tablet/desktop users actually see — renders
-  // blank. (An earlier isolated probe passed spuriously by asserting
-  // `.some(checked)`, which the mobile copy satisfied; this asserts the
-  // desktop `[0]` copy, i.e. the real-user view.)
-  //
-  // Why the obvious fixes don't work:
-  //  - Controlled-via-`useWatch` (no register): fields never register, so
-  //    `useWatch` returns undefined → never checked.
-  //  - register-once-in-body + controlled `useWatch`: Section's
-  //    `useForm({ resolver, mode:'onChange' })` config doesn't surface
-  //    defaultValues through `useWatch` reliably (works with a bare
-  //    `useForm({defaultValues})`, not with the resolver+onChange config).
-  //
-  // Correct fix is architectural (Phase 4.5): eliminate the dual-DOM
-  // duplication — render the inputs once and make the layout responsive via
-  // CSS, OR wrap each row in an RHF `<Controller>` (the official controlled
-  // pattern, which surfaces defaultValues deterministically) spanning both
-  // layout copies. Both are deliberate refactors, not one-liners.
-  it.skip('matrix rehydrates from defaultValues after the round-trip (#314)', () => {
+  // #314 — FIXED. Root cause: MatrixQuestion rendered every radio TWICE
+  // (desktop `<table>` + mobile cards) with uncontrolled
+  // `{...register(item.id)}`; RHF got duplicate refs for one radio-group
+  // name and applied `defaultValues` to only ONE copy, so the desktop
+  // table (what tablet/desktop users see) rendered blank on the
+  // Edit-from-review remount. Fix: each row now binds through
+  // `useController` (RHF's controlled pattern; `field.value`
+  // deterministically reflects `defaultValues`, and two controllers for
+  // one name across the two layouts is supported). This test is the
+  // regression gate — it must stay green.
+  it('matrix rehydrates from defaultValues after the round-trip (#314)', () => {
     renderWithProviders(
       <Section
         section={matrixFixture}


### PR DESCRIPTION
Refs #314 (stays OPEN). Doc-only: MatrixQuestion **pristine** (3 speculative fixes tried + reverted). Updates the `.skip` repro with the decisive reframe — isolated MatrixQuestion rehydrates; Section-hosted does not; only variable is `useForm({resolver,mode:onChange})` vs bare `useForm({defaultValues})`. Root cause is in Section.tsx`s form host, not MatrixQuestion. Phase 4.5 stop. Safe: 16 passed | 1 skipped, tsc+eslint clean, zero behavior change.