### PR TITLE
Backlog: #331 password toggle + #297 DLQ routes (+ #295 dispositioned)

### DIFF
--- a/deliverables/F2/PWA/app/src/admin/Login.test.tsx
+++ b/deliverables/F2/PWA/app/src/admin/Login.test.tsx
@@ -28,9 +28,23 @@ describe('<Login />', () => {
     renderLogin(fetchImpl);
     expect(screen.getByRole('heading', { name: /sign in/i })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: /username/i })).toBeInTheDocument();
-    // password is type=password, no implicit role — find by label.
-    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    // password is type=password, no implicit role — find by exact label
+    // ('Password'); the #331 toggle is a separate button ('Show password').
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it('#331: toggles password visibility via the Show/Hide button', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    renderLogin(fetchImpl);
+    const pw = screen.getByLabelText('Password') as HTMLInputElement;
+    expect(pw.type).toBe('password');
+    const toggle = screen.getByRole('button', { name: /show password/i });
+    await userEvent.click(toggle);
+    expect(pw.type).toBe('text');
+    expect(screen.getByRole('button', { name: /hide password/i })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /hide password/i }));
+    expect(pw.type).toBe('password');
   });
 
   it('disables sign-in until both fields have content', () => {
@@ -57,7 +71,7 @@ describe('<Login />', () => {
     renderLogin(fetchImpl);
 
     await user.type(screen.getByRole('textbox', { name: /username/i }), 'alice');
-    await user.type(screen.getByLabelText(/password/i), 'wrong');
+    await user.type(screen.getByLabelText('Password'), 'wrong');
     await user.click(screen.getByRole('button', { name: /sign in/i }));
 
     await waitFor(() => {
@@ -74,7 +88,7 @@ describe('<Login />', () => {
     renderLogin(fetchImpl);
 
     await user.type(screen.getByRole('textbox', { name: /username/i }), 'alice');
-    await user.type(screen.getByLabelText(/password/i), 'x');
+    await user.type(screen.getByLabelText('Password'), 'x');
     await user.click(screen.getByRole('button', { name: /sign in/i }));
 
     await waitFor(() => {
@@ -100,7 +114,7 @@ describe('<Login />', () => {
     renderLogin(fetchImpl);
 
     await user.type(screen.getByRole('textbox', { name: /username/i }), 'alice');
-    await user.type(screen.getByLabelText(/password/i), 'CorrectPw1');
+    await user.type(screen.getByLabelText('Password'), 'CorrectPw1');
     await user.click(screen.getByRole('button', { name: /sign in/i }));
 
     await waitFor(() => expect(fetchImpl).toHaveBeenCalled());

--- a/deliverables/F2/PWA/app/src/admin/Login.tsx
+++ b/deliverables/F2/PWA/app/src/admin/Login.tsx
@@ -25,6 +25,9 @@ export function Login({ apiBaseUrl, fetchImpl }: LoginProps): JSX.Element {
   const { navigate } = useRouter();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  // #331: optional show/hide on the password field (tester suggestion —
+  // convenience when typing security credentials).
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<ApiError | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -98,15 +101,26 @@ export function Login({ apiBaseUrl, fetchImpl }: LoginProps): JSX.Element {
           <span className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
             Password
           </span>
-          <input
-            type="password"
-            name="password"
-            autoComplete="current-password"
-            required
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="border-0 border-b border-hairline bg-transparent py-2 text-base outline-none focus:border-signal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal focus:ring-0"
-          />
+          <div className="relative">
+            <input
+              type={showPassword ? 'text' : 'password'}
+              name="password"
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full border-0 border-b border-hairline bg-transparent py-2 pr-14 text-base outline-none focus:border-signal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal focus:ring-0"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((s) => !s)}
+              aria-pressed={showPassword}
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
+              className="absolute inset-y-0 right-0 flex items-center px-1 font-mono text-xs uppercase tracking-wider text-muted-foreground hover:text-signal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal"
+            >
+              {showPassword ? 'Hide' : 'Show'}
+            </button>
+          </div>
         </label>
 
         {error ? (

--- a/deliverables/F2/PWA/worker/src/admin/handlers/data.ts
+++ b/deliverables/F2/PWA/worker/src/admin/handlers/data.ts
@@ -251,6 +251,35 @@ export async function handleListDlq(
   return jsonResponse(r.data, 200);
 }
 
+// #297: DLQ replay/delete. The AS handlers (admin_dlq_replay /
+// admin_dlq_delete) existed, but the Worker had `DLQ_REPLAY_RE` /
+// `DLQ_DELETE_RE` defined yet never dispatched — every DLQ mutation
+// returned "route not found". Shared handler: both take `{ dlq_id }`
+// and return `{ dlq_id, status, ... }`; mirrors handleListDlq's
+// ok/data/error → Response shaping.
+export type DlqMutationAsCallable = (payload: {
+  dlq_id: string;
+}) => Promise<{
+  ok: boolean;
+  data?: { dlq_id: string; status: string; submission_id?: string | null };
+  error?: { code?: string; message?: string };
+}>;
+
+export async function handleDlqMutation(
+  dlqId: string,
+  asCallable: DlqMutationAsCallable,
+): Promise<Response> {
+  const r = await asCallable({ dlq_id: dlqId });
+  if (!r.ok || !r.data) {
+    return errorJson(
+      r.error?.code ?? 'E_BACKEND',
+      r.error?.message ?? 'Apps Script unavailable',
+      502,
+    );
+  }
+  return jsonResponse(r.data, 200);
+}
+
 // ----- HCWs lookup (Task 2.9) ---------------------------------------------
 
 export interface HcwRow {

--- a/deliverables/F2/PWA/worker/src/admin/routes.ts
+++ b/deliverables/F2/PWA/worker/src/admin/routes.ts
@@ -27,6 +27,7 @@ import {
   handleGetResponseById,
   handleListAudit,
   handleListDlq,
+  handleDlqMutation,
   handleListHcws,
   handleSyncReport,
   handleMapReport,
@@ -425,6 +426,48 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleListDlq(url, asCall);
+    return withRequestId(r, requestId);
+  }
+
+  // #297: replay/delete were dead route constants (defined, never
+  // dispatched) → "route not found". AS handlers already exist.
+  const dlqReplayMatch = url.pathname.match(DLQ_REPLAY_RE);
+  if (req.method === 'POST' && dlqReplayMatch) {
+    const auth = await requirePerm(req, 'dash_data', buildRbacOpts(env, requestId));
+    if (!auth.ok) {
+      return withRequestId(rbacFailureResponse(auth.status, auth.errorCode), requestId);
+    }
+    const dlqId = decodeURIComponent(dlqReplayMatch[1]!);
+    const asCall = (payload: { dlq_id: string }) =>
+      callAppsScript<{ dlq_id: string; status: string; submission_id?: string | null }>(
+        env.APPS_SCRIPT_URL,
+        env.APPS_SCRIPT_HMAC,
+        'admin_dlq_replay',
+        payload as unknown as Record<string, unknown>,
+        requestId,
+        env.F2_AUTH,
+      );
+    const r = await handleDlqMutation(dlqId, asCall);
+    return withRequestId(r, requestId);
+  }
+
+  const dlqDeleteMatch = url.pathname.match(DLQ_DELETE_RE);
+  if (req.method === 'DELETE' && dlqDeleteMatch) {
+    const auth = await requirePerm(req, 'dash_data', buildRbacOpts(env, requestId));
+    if (!auth.ok) {
+      return withRequestId(rbacFailureResponse(auth.status, auth.errorCode), requestId);
+    }
+    const dlqId = decodeURIComponent(dlqDeleteMatch[1]!);
+    const asCall = (payload: { dlq_id: string }) =>
+      callAppsScript<{ dlq_id: string; status: string }>(
+        env.APPS_SCRIPT_URL,
+        env.APPS_SCRIPT_HMAC,
+        'admin_dlq_delete',
+        payload as unknown as Record<string, unknown>,
+        requestId,
+        env.F2_AUTH,
+      );
+    const r = await handleDlqMutation(dlqId, asCall);
     return withRequestId(r, requestId);
   }
 


### PR DESCRIPTION
Closes #331
Closes #297

Two genuinely-ready fixes via the disciplined loop; #295 root-caused + dispositioned (deploy-pipeline, not a clean fix — see issue comment, stays OPEN).

- **#331** feat: Show/Hide toggle on the admin login password field (aria-pressed/label). Login suite 7/7, tsc+eslint clean.
- **#297** fix(worker): `DLQ_REPLAY_RE`/`DLQ_DELETE_RE` were dead route constants (defined, never dispatched) → "route not found". Wired both, mirroring the DLQ_LIST/runNow idiom + shared `handleDlqMutation`. Worker tsc clean, worker suite 193/193 (no regression), eslint clean. Ships via CF auto-deploy; full end-to-end delete also needs the AS DLQ handlers on the deployed Apps Script (activates with #294 clasp redeploy if they postdate the 2026-05-04 freeze — honest dependency; the route-not-found defect itself is fixed).
- **#295** NOT fixed here — `pwa_version` is a stale Worker `env.PWA_VERSION`; proper fix is build-time version injection (#289-class, Worker-deploy-gated). Root cause + recommendation commented on the issue.

Pushed before merge; no version/CHANGELOG bump.