### PR TITLE
fix(f2-admin): #328 — clickable username → change-password entry point

### DIFF
--- a/deliverables/F2/PWA/app/src/admin/Layout.test.tsx
+++ b/deliverables/F2/PWA/app/src/admin/Layout.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Regression tests for the F2 Admin Portal sidebar Layout.
+ *
+ * #328 (UAT R3, 5A.19): the sidebar username rendered as a plain <p>, so
+ * clicking it only selected the text — there was no UI path to the
+ * change-password screen for a user not under a forced first-login rotation.
+ * These tests assert the username is now a link to /admin/me/change-password.
+ */
+import { describe, expect, it } from 'vitest';
+import { useEffect } from 'react';
+import { render, screen } from '@testing-library/react';
+import { Layout } from './Layout';
+import { AdminAuthProvider, useAdminAuth } from './lib/auth-context';
+import { RouterProvider } from './lib/pages-router';
+
+/** Primes the auth context to an authenticated state before children render. */
+function AuthPrime({ children }: { children: React.ReactNode }): JSX.Element | null {
+  const { setAuth, isAuthenticated } = useAdminAuth();
+  useEffect(() => {
+    setAuth('kidd_admin', {
+      token: 'test-token',
+      role: 'Administrator',
+      role_version: 0,
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      password_must_change: false,
+    });
+  }, [setAuth]);
+  return isAuthenticated ? <>{children}</> : null;
+}
+
+function renderAuthedLayout() {
+  return render(
+    <AdminAuthProvider>
+      <RouterProvider>
+        <AuthPrime>
+          <Layout>
+            <section>
+              <h2>Content</h2>
+            </section>
+          </Layout>
+        </AuthPrime>
+      </RouterProvider>
+    </AdminAuthProvider>,
+  );
+}
+
+describe('<Layout /> — #328 username change-password entry point', () => {
+  it('renders the username as a link to the change-password page', () => {
+    renderAuthedLayout();
+    // Desktop sidebar footer + mobile header both render the username link
+    // (CSS hides one per viewport; both are in the DOM under JSDOM).
+    const links = screen.getAllByRole('link', { name: /kidd_admin.*change password/i });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', '/admin/me/change-password');
+    }
+  });
+
+  it('keeps Sign out as a separate control', () => {
+    renderAuthedLayout();
+    expect(screen.getAllByRole('button', { name: /sign out/i }).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/deliverables/F2/PWA/app/src/admin/Layout.tsx
+++ b/deliverables/F2/PWA/app/src/admin/Layout.tsx
@@ -185,7 +185,17 @@ export function Layout({ children }: LayoutProps): JSX.Element {
         <div className="flex flex-col gap-3 border-t border-hairline px-5 py-4">
           {isAuthenticated ? (
             <>
-              <div className="flex items-center gap-3">
+              {/* #328: the username profile is a link to /admin/me/change-password.
+                  Before this it was a plain <p> — clicking it only selected the
+                  text, so a user under no forced rotation had no UI path to the
+                  change-password screen (the login redirect was the only entry).
+                  Tooltip + aria-label make the affordance discoverable. */}
+              <Link
+                to="/admin/me/change-password"
+                title="Account — change your password"
+                aria-label={`${username ?? 'Account'} (${role ?? 'role unknown'}) — change password`}
+                className="-mx-2 flex items-center gap-3 rounded-sm px-2 py-1 hover:bg-secondary/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal"
+              >
                 <div
                   aria-hidden="true"
                   className="flex h-9 w-9 shrink-0 items-center justify-center rounded-sm border border-hairline bg-secondary/40 font-mono text-sm text-ink"
@@ -198,7 +208,7 @@ export function Layout({ children }: LayoutProps): JSX.Element {
                     {role ?? '—'}
                   </p>
                 </div>
-              </div>
+              </Link>
               <Button
                 type="button"
                 variant="outline"
@@ -237,7 +247,16 @@ export function Layout({ children }: LayoutProps): JSX.Element {
           <div className="flex items-center gap-3">
             {isAuthenticated ? (
               <>
-                <span className="text-sm">{username ?? '—'}</span>
+                {/* #328: clickable username (mobile parity with the desktop
+                    sidebar footer) — links to the change-password screen. */}
+                <Link
+                  to="/admin/me/change-password"
+                  title="Account — change your password"
+                  aria-label={`${username ?? 'Account'} — change password`}
+                  className="text-sm text-ink hover:text-signal"
+                >
+                  {username ?? '—'}
+                </Link>
                 <Button
                   type="button"
                   variant="tableAction"

--- a/deliverables/F2/PWA/app/src/admin/me/ChangePasswordPage.test.tsx
+++ b/deliverables/F2/PWA/app/src/admin/me/ChangePasswordPage.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Regression tests for ChangePasswordPage.
+ *
+ * #328: the page renders chrome-less (no sidebar). A user who reaches it
+ * voluntarily (via the sidebar username link) needs an escape hatch — the
+ * "Cancel — back to portal" link. A forced first-login rotation
+ * (password_must_change) must NOT show the escape hatch.
+ */
+import { describe, expect, it } from 'vitest';
+import { useEffect } from 'react';
+import { render, screen } from '@testing-library/react';
+import { ChangePasswordPage } from './ChangePasswordPage';
+import { AdminAuthProvider, useAdminAuth } from '../lib/auth-context';
+import { RouterProvider } from '../lib/pages-router';
+
+/** Primes the auth context, optionally with password_must_change set. */
+function AuthPrime({
+  mustChange,
+  children,
+}: {
+  mustChange: boolean;
+  children: React.ReactNode;
+}): JSX.Element | null {
+  const { setAuth, isAuthenticated } = useAdminAuth();
+  useEffect(() => {
+    setAuth('kidd_admin', {
+      token: 'test-token',
+      role: 'Administrator',
+      role_version: 0,
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      password_must_change: mustChange,
+    });
+  }, [setAuth, mustChange]);
+  return isAuthenticated ? <>{children}</> : null;
+}
+
+function renderPage(mustChange: boolean) {
+  const noopFetch = (() => Promise.reject(new Error('not used'))) as unknown as typeof fetch;
+  return render(
+    <AdminAuthProvider>
+      <RouterProvider>
+        <AuthPrime mustChange={mustChange}>
+          <ChangePasswordPage apiBaseUrl="https://worker.example" fetchImpl={noopFetch} />
+        </AuthPrime>
+      </RouterProvider>
+    </AdminAuthProvider>,
+  );
+}
+
+describe('<ChangePasswordPage /> — #328 escape hatch', () => {
+  it('shows a Cancel link back to the portal for a voluntary visit', () => {
+    renderPage(false);
+    const cancel = screen.getByRole('link', { name: /cancel.*back to portal/i });
+    expect(cancel).toHaveAttribute('href', '/admin/data');
+  });
+
+  it('hides the Cancel link under a forced password_must_change rotation', () => {
+    renderPage(true);
+    expect(screen.queryByRole('link', { name: /cancel/i })).not.toBeInTheDocument();
+    // Forced-mode copy still renders.
+    expect(screen.getByText(/requires a password change/i)).toBeInTheDocument();
+  });
+});

--- a/deliverables/F2/PWA/app/src/admin/me/ChangePasswordPage.tsx
+++ b/deliverables/F2/PWA/app/src/admin/me/ChangePasswordPage.tsx
@@ -17,7 +17,7 @@ import { useState, type FormEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import { adminFetch, type ApiError } from '../lib/api-client';
 import { useAdminAuth, type AdminLoginResponse } from '../lib/auth-context';
-import { useRouter } from '../lib/pages-router';
+import { Link, useRouter } from '../lib/pages-router';
 
 export interface ChangePasswordPageProps {
   apiBaseUrl: string;
@@ -155,6 +155,20 @@ export function ChangePasswordPage({ apiBaseUrl, fetchImpl }: ChangePasswordPage
         <Button type="submit" disabled={submitting || !currentPw || !newPw || !confirmPw}>
           {submitting ? 'Saving…' : 'Update password'}
         </Button>
+
+        {/* #328: this page renders chrome-less (no sidebar). When the user
+            arrived here voluntarily (via the sidebar username link, not the
+            forced first-login redirect) they need an escape hatch — otherwise
+            the only way off the page is submitting a password change. Hidden
+            under password_must_change: a forced rotation has no opt-out. */}
+        {!passwordMustChange ? (
+          <Link
+            to="/admin/data"
+            className="self-start font-mono text-xs uppercase tracking-wider text-muted-foreground hover:text-signal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal"
+          >
+            Cancel — back to portal
+          </Link>
+        ) : null}
       </form>
 
       <footer className="mt-16 border-t border-hairline pt-4">


### PR DESCRIPTION
## Summary

UAT R3 finding **#328** (Admin Portal 5A.19, user-self password rotation): the sidebar username rendered as a plain `<p>`, so clicking it only selected the text. A user **not** under a forced first-login rotation had no UI path to `/admin/me/change-password` at all — the login redirect was the only entry point.

- **`Layout.tsx`** — the username profile (desktop sidebar footer + mobile header) is now a `Link` to `/admin/me/change-password`, with `title` + `aria-label` for discoverability. `Sign out` stays a separate control.
- **`ChangePasswordPage.tsx`** — the page renders chrome-less (no sidebar). A voluntary visitor needs an escape hatch, so this adds a `Cancel — back to portal` link. It is hidden under `password_must_change` — a forced rotation has no opt-out.

## Scope / known limitation

This fixes the **missing frontend affordance only**. End-to-end password change is still blocked by **#294** (the Apps Script deploy gap — the deployed dispatcher lacks the `admin_users_change_password` action). Once #294 is deployed, this entry point completes the flow.

## Test Coverage

New regression tests (would fail without this change):
- `Layout.test.tsx` — username renders as a link to `/admin/me/change-password` (desktop + mobile); `Sign out` stays separate.
- `ChangePasswordPage.test.tsx` — `Cancel` link shown on a voluntary visit, hidden under `password_must_change`.

Admin test suite: **39/39 pass**. `tsc --noEmit` + `eslint` clean on all 4 files.

> Note: a full `vitest run` showed 2 timeout failures in `src/components/survey/MultiSectionForm.test.tsx` (HCW survey, unrelated to this branch). They pass 11/11 in isolation — environment flakiness under parallel load, not a regression.

## Pre-Landing Review

No issues. The diff is a `<div>`→`<Link>` swap plus a conditional cancel link — no SQL, no auth-logic change, no trust-boundary surface.

## Version / CHANGELOG

Not bumped — per `deliverables/F2/PWA/app/CLAUDE.md`, `/ship` for this app must not bump version or write CHANGELOG (the release-notes workflow owns those).

## Test plan

- [x] Admin vitest suite passes (39/39)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [ ] Manual: click username in sidebar → lands on change-password screen (post-merge, on a deploy preview)

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)