### PR TITLE
fix(f2-admin): #315 — authenticate the Files download path

### DIFF
--- a/deliverables/F2/PWA/app/src/admin/apps/Files.test.tsx
+++ b/deliverables/F2/PWA/app/src/admin/apps/Files.test.tsx
@@ -30,9 +30,9 @@ const SAMPLE_FILE = {
 /** Mock fetch: records calls, serves the file list, and the download bytes. */
 function makeFetch(downloadStatus = 200): {
   fetch: typeof fetch;
-  calls: { url: string; init?: RequestInit }[];
+  calls: { url: string; init: RequestInit | undefined }[];
 } {
-  const calls: { url: string; init?: RequestInit }[] = [];
+  const calls: { url: string; init: RequestInit | undefined }[] = [];
   const impl = (async (url: string | URL, init?: RequestInit) => {
     const u = String(url);
     calls.push({ url: u, init });

--- a/deliverables/F2/PWA/app/src/admin/apps/Files.test.tsx
+++ b/deliverables/F2/PWA/app/src/admin/apps/Files.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Regression tests for the Files panel download path.
+ *
+ * #315 (UAT R3, 5A.7): the filename was a plain `<a href download>`. A bare
+ * anchor navigation cannot carry the Authorization header, and the admin JWT
+ * lives in memory only — so every download hit the worker unauthenticated,
+ * got a 401, and the error JSON ("access denied") was saved as the "file".
+ *
+ * These tests assert the download now goes through an authenticated fetch
+ * (Authorization header present) and resolves the bytes into a blob.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { useEffect } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Files } from './Files';
+import { AdminAuthProvider, useAdminAuth } from '../lib/auth-context';
+import { RouterProvider } from '../lib/pages-router';
+
+const TOKEN = 'test-token';
+const SAMPLE_FILE = {
+  file_id: 'f-1',
+  filename: 'protocol.pdf',
+  content_type: 'application/pdf',
+  size_bytes: 2048,
+  uploaded_by: 'shan_admin',
+  uploaded_at: '2026-05-20T10:00:00Z',
+};
+
+/** Mock fetch: records calls, serves the file list, and the download bytes. */
+function makeFetch(downloadStatus = 200): {
+  fetch: typeof fetch;
+  calls: { url: string; init?: RequestInit }[];
+} {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const impl = (async (url: string | URL, init?: RequestInit) => {
+    const u = String(url);
+    calls.push({ url: u, init });
+    if (/\/apps\/files\/[^/]+$/.test(u)) {
+      // Download path (has a file-id segment).
+      if (downloadStatus !== 200) {
+        return new Response(
+          JSON.stringify({ ok: false, error: { code: 'E_AUTH_INVALID', message: 'access denied' } }),
+          { status: downloadStatus, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      // String body — Response.blob() still resolves to a Blob, and a string
+      // body avoids the cross-realm Blob mismatch undici throws on.
+      return new Response('%PDF-1.7 bytes', {
+        status: 200,
+        headers: { 'Content-Type': 'application/pdf' },
+      });
+    }
+    // List path.
+    return new Response(JSON.stringify({ files: [SAMPLE_FILE], total: 1 }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+  return { fetch: impl, calls };
+}
+
+function AuthPrime({ children }: { children: React.ReactNode }): JSX.Element | null {
+  const { setAuth, isAuthenticated } = useAdminAuth();
+  useEffect(() => {
+    setAuth('shan_admin', {
+      token: TOKEN,
+      role: 'Administrator',
+      role_version: 0,
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      password_must_change: false,
+    });
+  }, [setAuth]);
+  return isAuthenticated ? <>{children}</> : null;
+}
+
+function renderFiles(fetchImpl: typeof fetch) {
+  return render(
+    <AdminAuthProvider>
+      <RouterProvider>
+        <AuthPrime>
+          <Files apiBaseUrl="https://worker.example" fetchImpl={fetchImpl} />
+        </AuthPrime>
+      </RouterProvider>
+    </AdminAuthProvider>,
+  );
+}
+
+let createObjURL: ReturnType<typeof vi.fn>;
+let revokeObjURL: ReturnType<typeof vi.fn>;
+let origCreate: typeof URL.createObjectURL;
+let origRevoke: typeof URL.revokeObjectURL;
+
+beforeEach(() => {
+  origCreate = URL.createObjectURL;
+  origRevoke = URL.revokeObjectURL;
+  createObjURL = vi.fn(() => 'blob:fake-object-url');
+  revokeObjURL = vi.fn();
+  URL.createObjectURL = createObjURL as unknown as typeof URL.createObjectURL;
+  URL.revokeObjectURL = revokeObjURL as unknown as typeof URL.revokeObjectURL;
+});
+
+afterEach(() => {
+  URL.createObjectURL = origCreate;
+  URL.revokeObjectURL = origRevoke;
+});
+
+describe('<Files /> — #315 authenticated download', () => {
+  it('downloads via an authenticated fetch carrying the Bearer token', async () => {
+    const user = userEvent.setup();
+    const { fetch: mockFetch, calls } = makeFetch();
+    renderFiles(mockFetch);
+
+    // The filename is a button (an action), not a bare <a href> link.
+    const btn = await screen.findByRole('button', { name: 'protocol.pdf' });
+    expect(screen.queryByRole('link', { name: 'protocol.pdf' })).toBeNull();
+
+    await user.click(btn);
+
+    // Wait for the full async chain — fetch → resp.blob() → createObjectURL.
+    await waitFor(() => expect(createObjURL).toHaveBeenCalledTimes(1));
+
+    const dl = calls.find((c) => /\/apps\/files\/f-1$/.test(c.url));
+    expect(dl).toBeTruthy();
+    const headers = (dl!.init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe(`Bearer ${TOKEN}`);
+
+    // The bytes were resolved into a blob and handed to the browser to save.
+    // (Identity check via toBeInstanceOf is unreliable here — undici's Blob
+    // and jsdom's global Blob are different realms — so assert on shape.)
+    const savedBlob = createObjURL.mock.calls[0][0] as Blob;
+    expect(savedBlob.size).toBe('%PDF-1.7 bytes'.length);
+    expect(savedBlob.type).toBe('application/pdf');
+  });
+
+  it('does not start a browser save when the download is rejected', async () => {
+    const user = userEvent.setup();
+    const { fetch: mockFetch } = makeFetch(401);
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+    renderFiles(mockFetch);
+
+    const btn = await screen.findByRole('button', { name: 'protocol.pdf' });
+    await user.click(btn);
+
+    // A 401 must not produce a blob save — the old bug saved the error body.
+    await waitFor(() => expect(createObjURL).not.toHaveBeenCalled());
+  });
+});

--- a/deliverables/F2/PWA/app/src/admin/apps/Files.tsx
+++ b/deliverables/F2/PWA/app/src/admin/apps/Files.tsx
@@ -63,6 +63,8 @@ export function Files({ apiBaseUrl, fetchImpl }: FilesProps): JSX.Element {
   const [reloadTick, setReloadTick] = useState(0);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
+  // #315: id of the row whose download is in flight (authenticated blob fetch).
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -154,6 +156,60 @@ export function Files({ apiBaseUrl, fetchImpl }: FilesProps): JSX.Element {
     return `${apiBaseUrl}/admin/api/dashboards/apps/files/${encodeURIComponent(fileId)}`;
   }
 
+  // #315: the file download MUST be an authenticated fetch, not a plain
+  // <a href> navigation. The admin JWT lives in memory only and is sent
+  // exclusively via the Authorization header; a bare anchor click carries no
+  // header, so the worker rejected every download with 401 and the error JSON
+  // ("access denied") was what got saved as the "file". Fetch the bytes with
+  // the token, then trigger a client-side save from the resulting blob.
+  async function handleDownload(row: FileRow): Promise<void> {
+    setDownloadingId(row.file_id);
+    try {
+      const fetchFn = fetchImpl ?? fetch;
+      let resp: Response;
+      try {
+        resp = await fetchFn(downloadUrl(row.file_id), {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+      } catch {
+        window.alert('Network unavailable. Try the download again.');
+        return;
+      }
+      if (resp.status === 401) {
+        clearAuth();
+        navigate('/admin/login');
+        return;
+      }
+      if (!resp.ok) {
+        // Error responses are JSON envelopes; a successful download is raw bytes.
+        let message = `Download failed (HTTP ${resp.status}).`;
+        try {
+          const env = (await resp.json()) as { error?: { code?: string; message?: string } };
+          if (env?.error?.code === 'E_PASSWORD_CHANGE_REQUIRED') {
+            navigate('/admin/me/change-password');
+            return;
+          }
+          if (env?.error?.message) message = env.error.message;
+        } catch {
+          // Non-JSON error body — keep the generic message.
+        }
+        window.alert(message);
+        return;
+      }
+      const blob = await resp.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = objectUrl;
+      a.download = row.filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(objectUrl);
+    } finally {
+      setDownloadingId(null);
+    }
+  }
+
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-baseline justify-between">
@@ -177,7 +233,12 @@ export function Files({ apiBaseUrl, fetchImpl }: FilesProps): JSX.Element {
       ) : state.data.files.length === 0 ? (
         <EmptyState />
       ) : (
-        <FilesTable rows={state.data.files} downloadUrl={downloadUrl} onDelete={handleDelete} />
+        <FilesTable
+          rows={state.data.files}
+          onDownload={handleDownload}
+          downloadingId={downloadingId}
+          onDelete={handleDelete}
+        />
       )}
     </section>
   );
@@ -279,11 +340,13 @@ function UploadRow({
 
 function FilesTable({
   rows,
-  downloadUrl,
+  onDownload,
+  downloadingId,
   onDelete,
 }: {
   rows: FileRow[];
-  downloadUrl: (id: string) => string;
+  onDownload: (row: FileRow) => void | Promise<void>;
+  downloadingId: string | null;
   onDelete: (row: FileRow) => void | Promise<void>;
 }): JSX.Element {
   return (
@@ -303,17 +366,23 @@ function FilesTable({
           {rows.map((r) => (
             <tr key={r.file_id}>
               <Td>
-                {/* FX-013 (2026-05-03): `download` attr is defense-in-depth; the
-                    worker already sets Content-Disposition: attachment, but
-                    listing `download` here makes the save-dialog deterministic
-                    across browsers and surfaces the filename in the prompt. */}
-                <a
-                  href={downloadUrl(r.file_id)}
-                  download={r.filename}
-                  className="underline decoration-hairline underline-offset-4 hover:decoration-foreground"
+                {/* #315: download goes through handleDownload (authenticated
+                    blob fetch). A plain <a href> cannot send the in-memory
+                    admin JWT, so the bare GET 401'd and the error JSON was
+                    saved as the "file". This button is the action trigger. */}
+                <button
+                  type="button"
+                  onClick={() => void onDownload(r)}
+                  disabled={downloadingId === r.file_id}
+                  className="text-left underline decoration-hairline underline-offset-4 hover:decoration-foreground disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   {r.filename}
-                </a>
+                </button>
+                {downloadingId === r.file_id ? (
+                  <span className="ml-2 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                    Downloading…
+                  </span>
+                ) : null}
               </Td>
               <Td mono>{r.content_type}</Td>
               <Td mono>{formatBytes(r.size_bytes)}</Td>


### PR DESCRIPTION
## Summary

UAT R3 finding **#315** (Admin Portal 5A.7, Files sub-tab): files upload fine (byte size matches) but **cannot be downloaded**.

Root cause: the filename was a plain `<a href download>` link — a bare browser navigation. The admin JWT lives **in memory only** and is sent exclusively via the `Authorization` header (through `adminFetch`); an anchor click cannot carry that header. Every download hit the Worker unauthenticated → **401** → the JSON error body (`{"error":{"code":"E_AUTH_INVALID","message":"access denied"}}`) was what got saved as the "file". The issue screenshot shows exactly this response.

## Fix

- **`Files.tsx`** — the filename is now a `<button>` that calls `handleDownload`: an **authenticated `fetch`** with `Authorization: Bearer <jwt>`. On success it resolves the bytes to a blob and triggers a client-side save via a programmatic `<a download>`. On 401 it clears auth + redirects to login; on 403 password-change it redirects; other errors surface an alert. Adds a per-row `Downloading…` indicator (downloads can be up to 100 MB).
- **`Files.test.tsx`** — new regression tests: the download carries the Bearer token and resolves a blob; a 401 produces no browser save (the old bug saved the error body).

## Test Coverage

Admin test suite: **37/37 pass**. `tsc --noEmit` + `eslint` clean on both files.

## Pre-Landing Review

No issues. The change *closes* an auth gap — it adds no new attack surface; the download now uses the same Bearer-token path as every other admin API call.

## Version / CHANGELOG

Not bumped — per `deliverables/F2/PWA/app/CLAUDE.md`, `/ship` for this app must not bump version or write CHANGELOG.

## Test plan

- [x] Admin vitest suite passes (37/37)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [ ] Manual: upload a PDF, click the filename, confirm the real file downloads (post-merge, deploy preview)

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)