### PR TITLE
fix(f2-admin): #327 — audit every admin mutation route

### DIFF
--- a/deliverables/F2/PWA/worker/src/admin/routes.ts
+++ b/deliverables/F2/PWA/worker/src/admin/routes.ts
@@ -244,6 +244,34 @@ function buildLastLoginDispatcher(
 }
 
 /**
+ * #327: emit a success-gated audit row for a mutation route. Before this,
+ * the Admin Portal audited only auth events plus a few HCW/session
+ * mutations — user/role/file/settings/DLQ/encode mutations wrote data with
+ * no trail. Call this immediately before returning a mutation route's
+ * response: it fires only on a 2xx and only when the actor's JWT payload is
+ * present, mirroring the existing fire-and-forget pattern (the AS RPC runs
+ * via ctx.waitUntil inside auditFn).
+ */
+function auditMutation(
+  auditFn: (ctx: AuthAuditCtx) => void,
+  r: Response,
+  auth: { payload?: { sub: string; jti: string; role: string } | null },
+  ipHash: string,
+  eventType: string,
+  resource: string,
+): void {
+  if (r.status < 200 || r.status >= 300 || !auth.payload) return;
+  auditFn({
+    event_type: eventType,
+    actor_username: auth.payload.sub,
+    actor_jti: auth.payload.jti,
+    actor_role: auth.payload.role,
+    client_ip_hash: ipHash,
+    event_resource: resource,
+  });
+}
+
+/**
  * Returns the response for an /admin/api/ request, or null when the path
  * isn't an admin-portal route (so the caller can fall through to legacy).
  *
@@ -352,6 +380,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
       { username: auth.payload!.sub },
       asCall,
     );
+    auditMutation(auditFn, r, auth, ipHash, 'admin_encode_submit', hcwId);
     return withRequestId(r, requestId);
   }
 
@@ -448,6 +477,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleDlqMutation(dlqId, asCall);
+    auditMutation(auditFn, r, auth, ipHash, 'admin_dlq_replay', dlqId);
     return withRequestId(r, requestId);
   }
 
@@ -468,6 +498,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleDlqMutation(dlqId, asCall);
+    auditMutation(auditFn, r, auth, ipHash, 'admin_dlq_delete', dlqId);
     return withRequestId(r, requestId);
   }
 
@@ -540,6 +571,17 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleUploadFile(req, { username: auth.payload!.sub }, env.F2_ADMIN_R2, asCall);
+    // Resource = the stored filename, read from the success response body.
+    let uploadedName = '';
+    if (r.status >= 200 && r.status < 300) {
+      try {
+        const j = (await r.clone().json()) as { file?: { filename?: string } };
+        uploadedName = typeof j.file?.filename === 'string' ? j.file.filename : '';
+      } catch {
+        /* leave blank — audit row still records the create */
+      }
+    }
+    auditMutation(auditFn, r, auth, ipHash, 'admin_files_create', uploadedName);
     return withRequestId(r, requestId);
   }
 
@@ -573,6 +615,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleDeleteFile(fileId, env.F2_ADMIN_R2, asCall);
+    auditMutation(auditFn, r, auth, ipHash, 'admin_files_delete', fileId);
     return withRequestId(r, requestId);
   }
 
@@ -604,6 +647,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleRunNowSetting(sid, asCall);
+    auditMutation(auditFn, r, auth, ipHash, 'admin_settings_run_now', sid);
     return withRequestId(r, requestId);
   }
 
@@ -641,6 +685,14 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleCreateSetting(body, { username: auth.payload!.sub }, asCall);
+    auditMutation(
+      auditFn,
+      r,
+      auth,
+      ipHash,
+      'admin_settings_create',
+      typeof body.instrument === 'string' ? body.instrument : '',
+    );
     return withRequestId(r, requestId);
   }
 
@@ -663,6 +715,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
           env.F2_AUTH,
         );
       const r = await handleUpdateSetting(sid, body, asCall);
+      auditMutation(auditFn, r, auth, ipHash, 'admin_settings_update', sid);
       return withRequestId(r, requestId);
     }
     const asCall = (payload: { setting_id: string }) =>
@@ -675,6 +728,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleDeleteSetting(sid, asCall);
+    auditMutation(auditFn, r, auth, ipHash, 'admin_settings_delete', sid);
     return withRequestId(r, requestId);
   }
 
@@ -761,6 +815,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleBulkImportUsers(body, { username: auth.payload!.sub }, asCall);
+    auditMutation(auditFn, r, auth, ipHash, 'admin_users_bulk_import', '');
     return withRequestId(r, requestId);
   }
 
@@ -780,6 +835,14 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleCreateUser(body, { username: auth.payload!.sub }, asCall);
+    auditMutation(
+      auditFn,
+      r,
+      auth,
+      ipHash,
+      'admin_users_create',
+      typeof body.username === 'string' ? body.username : '',
+    );
     return withRequestId(r, requestId);
   }
 
@@ -822,6 +885,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
           env.F2_AUTH,
         );
       const r = await handleUpdateUser(username, body, asCall);
+      auditMutation(auditFn, r, auth, ipHash, 'admin_users_update', username);
       return withRequestId(r, requestId);
     }
     // DELETE
@@ -835,6 +899,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleDeleteUser(username, auth.payload!.sub, asCall);
+    auditMutation(auditFn, r, auth, ipHash, 'admin_users_delete', username);
     return withRequestId(r, requestId);
   }
 
@@ -872,6 +937,14 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
         env.F2_AUTH,
       );
     const r = await handleCreateRole(body, { username: auth.payload!.sub }, asCall);
+    auditMutation(
+      auditFn,
+      r,
+      auth,
+      ipHash,
+      'admin_roles_create',
+      typeof body.name === 'string' ? body.name : '',
+    );
     return withRequestId(r, requestId);
   }
 
@@ -898,6 +971,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
       // request for any user holding this role refetches authoritative
       // F2_Roles data instead of trusting the now-stale entry.
       if (r.status >= 200 && r.status < 300) roleCache.invalidate(name);
+      auditMutation(auditFn, r, auth, ipHash, 'admin_roles_update', name);
       return withRequestId(r, requestId);
     }
     // DELETE
@@ -914,6 +988,7 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
     // R2-#56: deleting a role evicts the cache entry too — any extant JWT
     // for this role will fall through to refetch + 401 (role not in list).
     if (r.status >= 200 && r.status < 300) roleCache.invalidate(name);
+    auditMutation(auditFn, r, auth, ipHash, 'admin_roles_delete', name);
     return withRequestId(r, requestId);
   }
 

--- a/deliverables/F2/PWA/worker/test/admin/routes.test.ts
+++ b/deliverables/F2/PWA/worker/test/admin/routes.test.ts
@@ -416,4 +416,112 @@ describe('adminRouter', () => {
       fetchSpy.mockRestore();
     }
   });
+
+  // #327: mutation routes beyond auth/HCW/session previously emitted no audit
+  // row. These confirm a representative mutation (user-create) now writes one
+  // on success and stays silent on failure (the auditMutation success gate).
+  it('#327: a successful user-create mutation emits admin_audit_write', async () => {
+    const env = makeEnv(makeKv());
+    const tok = await mintAdminJwt(env.JWT_SIGNING_KEY, {
+      sub: 'admin-bob',
+      role: 'Administrator',
+      role_version: 1,
+    });
+    const calls: Array<{ action: string; payload: Record<string, unknown> }> = [];
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      const body = JSON.parse((init as RequestInit).body as string) as {
+        action: string;
+        payload: Record<string, unknown>;
+      };
+      calls.push({ action: body.action, payload: body.payload });
+      if (body.action === 'admin_roles_list') {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: { roles: [{ name: 'Administrator', version: 1, dash_users: true }] },
+        }), { status: 200 });
+      }
+      if (body.action === 'admin_users_create') {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: { user: { username: 'newbie' } },
+        }), { status: 200 });
+      }
+      if (body.action === 'admin_audit_write') {
+        return new Response(JSON.stringify({ ok: true, data: { ok: true } }), { status: 200 });
+      }
+      return new Response('{}', { status: 500 });
+    });
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const ctx = {
+      waitUntil: (p: Promise<unknown>) => { waitUntilPromises.push(p); },
+      passThroughOnException: () => undefined,
+    } as unknown as ExecutionContext;
+    try {
+      const req = new Request('https://x/admin/api/dashboards/users', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${tok}`,
+          'Content-Type': 'application/json',
+          'cf-connecting-ip': '203.0.113.7',
+        },
+        body: JSON.stringify({ username: 'newbie', password: 'StrongPw123', role_name: 'Administrator' }),
+      });
+      const r = await adminRouter(req, env, ctx);
+      expect(r!.status).toBe(200);
+      await Promise.all(waitUntilPromises);
+
+      const audit = calls.find((c) => c.action === 'admin_audit_write');
+      expect(audit).toBeDefined();
+      expect(audit!.payload.event_type).toBe('admin_users_create');
+      expect(audit!.payload.actor_username).toBe('admin-bob');
+      expect(audit!.payload.event_resource).toBe('newbie');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('#327: a rejected user-create mutation emits no admin_audit_write', async () => {
+    const env = makeEnv(makeKv());
+    const tok = await mintAdminJwt(env.JWT_SIGNING_KEY, {
+      sub: 'admin-bob',
+      role: 'Administrator',
+      role_version: 1,
+    });
+    const calls: Array<{ action: string }> = [];
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      const body = JSON.parse((init as RequestInit).body as string) as { action: string };
+      calls.push({ action: body.action });
+      if (body.action === 'admin_roles_list') {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: { roles: [{ name: 'Administrator', version: 1, dash_users: true }] },
+        }), { status: 200 });
+      }
+      if (body.action === 'admin_users_create') {
+        return new Response(JSON.stringify({
+          ok: false,
+          error: { code: 'E_CONFLICT', message: 'username already exists' },
+        }), { status: 200 });
+      }
+      return new Response('{}', { status: 500 });
+    });
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const ctx = {
+      waitUntil: (p: Promise<unknown>) => { waitUntilPromises.push(p); },
+      passThroughOnException: () => undefined,
+    } as unknown as ExecutionContext;
+    try {
+      const req = new Request('https://x/admin/api/dashboards/users', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${tok}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: 'newbie', password: 'StrongPw123', role_name: 'Administrator' }),
+      });
+      const r = await adminRouter(req, env, ctx);
+      expect(r!.status).toBeGreaterThanOrEqual(400);
+      await Promise.all(waitUntilPromises);
+      expect(calls.some((c) => c.action === 'admin_audit_write')).toBe(false);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

UAT R3 finding **#327** (5B.5, audit-log completeness): the audit log only recorded `login` and `reissue_token`, despite the tester performing 5 distinct admin actions.

Root cause: the Worker's audit dispatcher (`auditFn`, fire-and-forget via `ctx.waitUntil` → `admin_audit_write`) was wired into only **6 of ~22 mutation routes**. The other 16 — user/role/file/settings CRUD, bulk-import, DLQ ops, encode submit — wrote data and emitted **no audit event**. This is **not** the #294 Apps Script deploy gap: the Worker never dispatched an audit write for those routes in the first place.

## Fix

- **`routes.ts`** — added `auditMutation(auditFn, r, auth, ipHash, eventType, resource)`: a success-gated helper that emits exactly one audit row, only on a 2xx response and only when the actor's JWT payload is present (mirrors the existing fire-and-forget pattern). Wired into all **16** previously-unaudited mutation routes:
  - users: create, update, delete, bulk-import
  - roles: create, update, delete
  - files: upload, delete
  - settings: create, update, delete, run-now
  - DLQ: replay, delete
  - encode: submit
  - `event_type` follows the existing `admin_<noun>_<verb>` convention; actor (`sub`/`jti`/`role`) + target identifier captured per route.
- **`routes.test.ts`** — regression tests: a successful user-create emits `admin_audit_write` (`event_type: admin_users_create`, correct actor + resource); a rejected user-create emits **none** (proves the success gate).

## Scope note

This is independent of #294 — even a correct Apps Script redeploy would not have helped, because the audit write was never dispatched. Compliance-relevant: a PII system should leave a trail for every meaningful admin action.

## Test Coverage

Worker test suite: **195/195 pass** (18 files). `tsc --noEmit` clean.

## Pre-Landing Review

No issues. The change only *adds* audit logging — fire-and-forget, success-gated, cannot affect the user-facing response or route behavior. No new attack surface.

## Version / CHANGELOG

Not bumped — consistent with #339/#341; the release-notes workflow owns versioning.

## Test plan

- [x] Worker vitest suite passes (195/195)
- [x] `tsc --noEmit` clean
- [ ] Manual: perform user/role/file/settings mutations, confirm each appears in the Audit dashboard (post-merge)

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)