### PR TITLE
fix(f2-admin): #343 — date filters default to empty

### DIFF
--- a/deliverables/F2/PWA/app/src/admin/data/AuditTab.tsx
+++ b/deliverables/F2/PWA/app/src/admin/data/AuditTab.tsx
@@ -45,17 +45,13 @@ interface UiFilters {
   q: string;
 }
 
-function defaultFromIso(): string {
-  return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-}
-
 function readFiltersFromUrl(): UiFilters {
   if (typeof window === 'undefined') {
-    return { from: defaultFromIso(), to: '', event_type: '', actor_username: '', q: '' };
+    return { from: '', to: '', event_type: '', actor_username: '', q: '' };
   }
   const p = new URLSearchParams(window.location.search);
   return {
-    from: p.get('from') ?? defaultFromIso(),
+    from: p.get('from') ?? '',
     to: p.get('to') ?? '',
     event_type: p.get('event_type') ?? '',
     actor_username: p.get('actor_username') ?? '',

--- a/deliverables/F2/PWA/app/src/admin/data/DLQTab.tsx
+++ b/deliverables/F2/PWA/app/src/admin/data/DLQTab.tsx
@@ -39,17 +39,13 @@ interface UiFilters {
   q: string;
 }
 
-function defaultFromIso(): string {
-  return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-}
-
 function readFiltersFromUrl(): UiFilters {
   if (typeof window === 'undefined') {
-    return { from: defaultFromIso(), to: '', q: '' };
+    return { from: '', to: '', q: '' };
   }
   const p = new URLSearchParams(window.location.search);
   return {
-    from: p.get('from') ?? defaultFromIso(),
+    from: p.get('from') ?? '',
     to: p.get('to') ?? '',
     q: p.get('q') ?? '',
   };

--- a/deliverables/F2/PWA/app/src/admin/report/MapReport.tsx
+++ b/deliverables/F2/PWA/app/src/admin/report/MapReport.tsx
@@ -100,17 +100,13 @@ const VERDE_MARKER_ICON_SELECTED = L.divIcon({
 // At very-zoomed-out views Carto falls back to the multilingual SCS stack,
 // which is acceptable for the rare case the user zooms beyond PH bounds.)
 
-function defaultFromIso(): string {
-  return new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-}
-
 function readFiltersFromUrl(): UiFilters {
   if (typeof window === 'undefined') {
-    return { from: defaultFromIso(), to: '', region_id: '' };
+    return { from: '', to: '', region_id: '' };
   }
   const p = new URLSearchParams(window.location.search);
   return {
-    from: p.get('from') ?? defaultFromIso(),
+    from: p.get('from') ?? '',
     to: p.get('to') ?? '',
     region_id: p.get('region_id') ?? '',
   };

--- a/deliverables/F2/PWA/app/src/admin/report/SyncReport.tsx
+++ b/deliverables/F2/PWA/app/src/admin/report/SyncReport.tsx
@@ -5,7 +5,7 @@
  * Spec: docs/superpowers/specs/2026-05-01-f2-admin-portal-design.md (§7.7)
  *
  * Pivot table of submissions by geography level (region / province /
- * facility). Default region-level, last 7 days. Each row links to the
+ * facility). Default region-level, no date filter. Each row links to the
  * Data dashboard pre-filtered (free-text q on the geo key) so admins
  * can drill from a low-pacing region straight to the rows.
  *
@@ -45,20 +45,16 @@ interface UiFilters {
   to: string;
 }
 
-function defaultFromIso(): string {
-  return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-}
-
 function readFiltersFromUrl(): UiFilters {
   if (typeof window === 'undefined') {
-    return { level: 'region', from: defaultFromIso(), to: '' };
+    return { level: 'region', from: '', to: '' };
   }
   const p = new URLSearchParams(window.location.search);
   const lvlRaw = p.get('level');
   const lvl: Level = lvlRaw === 'province' || lvlRaw === 'facility' ? lvlRaw : 'region';
   return {
     level: lvl,
-    from: p.get('from') ?? defaultFromIso(),
+    from: p.get('from') ?? '',
     to: p.get('to') ?? '',
   };
 }


### PR DESCRIPTION
## Summary
- Removes the trailing-window date defaults (`defaultFromIso()`) from Audit, DLQ, Sync, and Map tabs in the Admin Portal.
- Cold-load filters now match Data > Responses (empty-by-default). URL query params (`?from=2026-05-01`) still win when present.

## Why
UAT R3 reporter expected empty-by-default filters across the four affected tabs — the prefilled "random dates" caused confusion (the value was `today - 7d`, not actually random, but indistinguishable to the tester from junk state). Behavior is now consistent across all date-filtered tables.

## Files
- `app/src/admin/data/AuditTab.tsx`
- `app/src/admin/data/DLQTab.tsx`
- `app/src/admin/report/SyncReport.tsx` (header comment updated too)
- `app/src/admin/report/MapReport.tsx`

## Backend impact
Empty `from`/`to` falls back to AS-side `SCAN_CAP=50000` + `DEFAULT_LIMIT` pagination. No new server caps needed; performance bounded by existing scan limits.

## Test plan
- [ ] Open `/admin/data/audit` cold (no URL params) → From/To inputs are empty.
- [ ] Open `/admin/data/dlq` cold → From/To empty.
- [ ] Open `/admin/report/sync` cold → From/To empty, level still defaults to `region`.
- [ ] Open `/admin/report/map` cold → From/To empty.
- [ ] Open `/admin/data/audit?from=2026-05-01&to=2026-05-20` → URL params still apply.
- [ ] Audit list still loads (with default limit) — no perf regression.

Closes #343