### PR TITLE
fix(f2-admin): #318 BulkImport modal a11y + #344 Roles delete optimistic UI

### DIFF
--- a/deliverables/F2/PWA/app/src/admin/roles/RolesDashboard.tsx
+++ b/deliverables/F2/PWA/app/src/admin/roles/RolesDashboard.tsx
@@ -108,6 +108,23 @@ export function RolesDashboard({ apiBaseUrl, fetchImpl }: RolesDashboardProps): 
       },
     );
     if (r.ok) {
+      // #344: optimistically drop the deleted role from the visible matrix
+      // so the row disappears immediately even if a downstream cache /
+      // service-worker layer briefly serves a stale roles list. The
+      // reloadTick refetch follows; if the server somehow still returns
+      // the role, the matrix repopulates with authoritative state.
+      setState((s) =>
+        s.kind === 'loaded'
+          ? {
+              kind: 'loaded',
+              data: {
+                ...s.data,
+                roles: s.data.roles.filter((r) => r.name !== name),
+                total: Math.max(0, s.data.total - 1),
+              },
+            }
+          : s,
+      );
       setReloadTick((n) => n + 1);
     } else if (r.error.code === 'E_CONFLICT') {
       window.alert('Cannot delete: this role is still assigned to one or more users.');

--- a/deliverables/F2/PWA/app/src/admin/users/BulkImportModal.tsx
+++ b/deliverables/F2/PWA/app/src/admin/users/BulkImportModal.tsx
@@ -13,7 +13,7 @@
  * Required: username, password, role_name. Optional: first_name,
  * last_name, email, phone.
  */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { adminFetch } from '../lib/api-client';
 import { useAdminAuth } from '../lib/auth-context';
@@ -73,6 +73,14 @@ export function BulkImportModal({
   const [parseError, setParseError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && phase !== 'submitting') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose, phase]);
 
   const handleFile = async (file: File) => {
     setParseError(null);
@@ -139,8 +147,11 @@ export function BulkImportModal({
       role="dialog"
       aria-modal="true"
       aria-label="Bulk import users"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && phase !== 'submitting') onClose();
+      }}
     >
-      <div className="w-full max-w-3xl border border-hairline bg-background p-6 shadow-lg">
+      <div className="flex max-h-[90vh] w-full max-w-3xl flex-col border border-hairline bg-background p-6 shadow-lg">
         <div className="flex items-start justify-between border-b border-hairline pb-3">
           <div>
             <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
@@ -159,6 +170,7 @@ export function BulkImportModal({
           </Button>
         </div>
 
+        <div className="-mx-6 flex-1 overflow-y-auto px-6">
         {phase === 'upload' ? (
           <div className="flex flex-col gap-4 pt-4">
             <p className="text-sm text-muted-foreground">
@@ -314,6 +326,7 @@ export function BulkImportModal({
             </div>
           </div>
         ) : null}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **#318**: BulkImport modal gets ESC handler, backdrop-click dismiss, and an internal scroll region. Brings it in line with the existing UserEditor / RoleEditor / CreateHCWModal / ReissueTokenModal pattern.
- **#344**: Roles delete now optimistically removes the row from the visible matrix on 2xx, in addition to the existing reloadTick refetch. Defensive against any downstream cache layer briefly serving stale state.

## #318 detail
Before: with many rejected rows, the `<details>` block ballooned the modal past the viewport, pushing the Close button offscreen. The browser back button was the only exit — which redirected to Apps & Settings (a separate, confusing state).

After:
- `useEffect` registers an Escape keydown listener (skipped during the `submitting` phase so an in-flight import isn't lost).
- Backdrop `onClick` calls `onClose` when `e.target === e.currentTarget` (same protection during `submitting`).
- Outer panel: `max-h-[90vh] flex flex-col`. Header stays pinned. Inner content section wraps in `-mx-6 flex-1 overflow-y-auto px-6` so long rejected lists scroll inside the modal instead of overflowing the page.

## #344 detail
Static code review of the delete flow is clean end-to-end (AS `deleteRow` → worker `roleCache.invalidate(name)` → frontend `setReloadTick`). I requested a DevTools Network capture from the reporter to pin down the root cause. In the meantime, this optimistic-UI patch makes the deleted row disappear immediately on 2xx response, so the user-visible bug closes even if a transient cache layer is involved. The follow-up refetch repopulates from authoritative state; if the role somehow returns, we know it's a real backend bug.

## Test plan
- [ ] Bulk-import a CSV with >20 rejected rows → expand "Rejected rows" → scroll within modal (not page); Close button stays visible; ESC closes; backdrop click closes; clicking inside the modal does NOT close.
- [ ] Bulk-import an actual batch → during 'Importing… please wait', ESC + backdrop click do NOT close (protect in-flight).
- [ ] Roles → Delete a non-builtin role → row disappears immediately. Refetch lands; matrix matches authoritative state.

Closes #318
Closes #344