### PR TITLE
fix(f2-survey): Q35 — drop duplicated partial-date hint (follow-up to #306)

### DIFF
--- a/deliverables/F2/PWA/app/src/components/survey/Question.test.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Question.test.tsx
@@ -203,6 +203,7 @@ describe('<Question>', () => {
       required: true,
       conditional: true,
       label: dual('Since when?'),
+      help: dual("Year is required. Leave month or day blank if you don't recall them."),
     };
     function PartialHarness() {
       const methods = useForm();
@@ -222,6 +223,11 @@ describe('<Question>', () => {
     const month = screen.getByLabelText(/month/i);
     const day = screen.getByLabelText(/day/i);
     const val = () => screen.getByTestId('q35val').textContent;
+
+    // The guidance comes from the spec-driven item.help only — it must render
+    // exactly once (regression guard: a chrome `partialDate.hint` line used to
+    // duplicate it under the inputs).
+    expect(screen.getAllByText(/leave month or day blank/i)).toHaveLength(1);
 
     // Day is disabled until a month is entered (ISO 8601 has no day-without-month).
     expect(day).toBeDisabled();

--- a/deliverables/F2/PWA/app/src/components/survey/Question.tsx
+++ b/deliverables/F2/PWA/app/src/components/survey/Question.tsx
@@ -334,7 +334,6 @@ function renderControl(
               />
             </div>
           </div>
-          <p className="text-xs text-muted-foreground">{t('question.partialDate.hint')}</p>
         </div>
       );
     }

--- a/deliverables/F2/PWA/app/src/i18n/locales/en.ts
+++ b/deliverables/F2/PWA/app/src/i18n/locales/en.ts
@@ -79,7 +79,6 @@ export const en = {
       month: 'Month',
       day: 'Day',
       optional: 'Optional',
-      hint: "Year is required. Leave month or day blank if you don't recall them.",
     },
   },
   review: {

--- a/deliverables/F2/PWA/app/src/i18n/locales/fil.ts
+++ b/deliverables/F2/PWA/app/src/i18n/locales/fil.ts
@@ -83,7 +83,6 @@ export const fil: EnBundle = {
       month: 'Month',
       day: 'Day',
       optional: 'Optional',
-      hint: "Year is required. Leave month or day blank if you don't recall them.",
     },
   },
   review: {


### PR DESCRIPTION
Follow-up to #349. #306 showed the Q35 guidance **twice** — the spec-driven `item.help` above the inputs and a hardcoded chrome `partialDate.hint` line below them (identical text). Removes the chrome line + unused `question.partialDate.hint` key; the spec `help` is the single, translatable source. Also trims one string from the translation surface ahead of the 06-12 PSA gate.

Regression guard added (guidance renders exactly once). tsc + eslint clean; Question + i18n suites green.