### PR TITLE
feat(admin): #174 Files Create-Folder (flat) + #175 Rename

### DIFF
--- a/deliverables/F2/PWA/app/src/admin/apps/Files.test.tsx
+++ b/deliverables/F2/PWA/app/src/admin/apps/Files.test.tsx
@@ -146,3 +146,168 @@ describe('<Files /> — #315 authenticated download', () => {
     await waitFor(() => expect(createObjURL).not.toHaveBeenCalled());
   });
 });
+
+// ---- #175 rename + #174 folders ----
+
+const ROOT_FOLDER = {
+  file_id: 'd-1',
+  filename: 'protocols',
+  content_type: 'application/x-directory',
+  size_bytes: 0,
+  uploaded_by: 'shan_admin',
+  uploaded_at: '2026-05-19T10:00:00Z',
+  is_folder: true,
+  folder_path: '/',
+};
+const INNER_FILE = {
+  file_id: 'f-2',
+  filename: 'inner.pdf',
+  content_type: 'application/pdf',
+  size_bytes: 512,
+  uploaded_by: 'shan_admin',
+  uploaded_at: '2026-05-21T10:00:00Z',
+  is_folder: false,
+  folder_path: '/protocols',
+};
+
+/**
+ * Richer mock that serves root + folder listings and handles rename (PATCH)
+ * and create-folder (POST /folders). Records every call for assertions.
+ */
+function makeRichFetch(): {
+  fetch: typeof fetch;
+  calls: { url: string; method: string; init: RequestInit | undefined }[];
+} {
+  const calls: { url: string; method: string; init: RequestInit | undefined }[] = [];
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+  const impl = (async (url: string | URL, init?: RequestInit) => {
+    const u = String(url);
+    const method = (init?.method ?? 'GET').toUpperCase();
+    calls.push({ url: u, method, init });
+    // Create folder — checked before the by-id branch so "/folders" isn't an id.
+    if (/\/apps\/files\/folders$/.test(u) && method === 'POST') {
+      const name = (JSON.parse(init!.body as string) as { name: string }).name;
+      return json({ folder: { ...ROOT_FOLDER, file_id: 'd-new', filename: name } }, 201);
+    }
+    const idMatch = u.match(/\/apps\/files\/([^/?]+)$/);
+    if (idMatch && method === 'PATCH') {
+      const filename = (JSON.parse(init!.body as string) as { filename: string }).filename;
+      return json({ file: { ...SAMPLE_FILE, filename } }, 200);
+    }
+    if (idMatch && method === 'GET') {
+      // download path — not exercised here
+      return new Response('%PDF-1.7', { status: 200, headers: { 'Content-Type': 'application/pdf' } });
+    }
+    // List — branch on ?path=.
+    const path = new URL(u).searchParams.get('path');
+    if (path === '/protocols') return json({ files: [INNER_FILE], total: 1 });
+    return json({ files: [ROOT_FOLDER, SAMPLE_FILE], total: 2 });
+  }) as unknown as typeof fetch;
+  return { fetch: impl, calls };
+}
+
+describe('<Files /> — #175 rename', () => {
+  it('commits a rename via an authenticated PATCH carrying the new filename', async () => {
+    const user = userEvent.setup();
+    const { fetch: mockFetch, calls } = makeRichFetch();
+    renderFiles(mockFetch);
+
+    const renameBtn = await screen.findByRole('button', { name: 'Rename' });
+    await user.click(renameBtn);
+
+    const input = await screen.findByRole('textbox', { name: /rename protocol\.pdf/i });
+    await user.clear(input);
+    await user.type(input, 'renamed.pdf');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      const patch = calls.find(
+        (c) => c.method === 'PATCH' && /\/apps\/files\/f-1$/.test(c.url),
+      );
+      expect(patch).toBeTruthy();
+      expect(JSON.parse(patch!.init!.body as string)).toEqual({ filename: 'renamed.pdf' });
+      // adminFetch attaches the token as a Headers instance, not a plain object.
+      const headers = new Headers(patch!.init?.headers);
+      expect(headers.get('Authorization')).toBe(`Bearer ${TOKEN}`);
+    });
+  });
+
+  it('Escape cancels the rename without issuing a PATCH', async () => {
+    const user = userEvent.setup();
+    const { fetch: mockFetch, calls } = makeRichFetch();
+    renderFiles(mockFetch);
+
+    const renameBtn = await screen.findByRole('button', { name: 'Rename' });
+    await user.click(renameBtn);
+
+    const input = await screen.findByRole('textbox', { name: /rename protocol\.pdf/i });
+    await user.type(input, 'zzz');
+    await user.keyboard('{Escape}');
+
+    // Back to the filename button; no PATCH was sent.
+    await screen.findByRole('button', { name: 'protocol.pdf' });
+    expect(calls.some((c) => c.method === 'PATCH')).toBe(false);
+  });
+});
+
+describe('<Files /> — #174 folders', () => {
+  it('navigating into a folder refetches the list with ?path=', async () => {
+    const user = userEvent.setup();
+    const { fetch: mockFetch, calls } = makeRichFetch();
+    renderFiles(mockFetch);
+
+    // The folder row renders as a button named by its filename (the [dir]
+    // marker is aria-hidden, so it's excluded from the accessible name).
+    const folderBtn = await screen.findByRole('button', { name: 'protocols' });
+    await user.click(folderBtn);
+
+    await waitFor(() => {
+      const listWithPath = calls.find(
+        (c) => c.method === 'GET' && /\/apps\/files\?path=/.test(c.url),
+      );
+      expect(listWithPath).toBeTruthy();
+      expect(decodeURIComponent(listWithPath!.url)).toContain('path=/protocols');
+    });
+    // The folder's child file appears.
+    await screen.findByRole('button', { name: 'inner.pdf' });
+  });
+
+  it('breadcrumb "Files" navigates back to root (list without ?path=)', async () => {
+    const user = userEvent.setup();
+    const { fetch: mockFetch, calls } = makeRichFetch();
+    renderFiles(mockFetch);
+
+    await user.click(await screen.findByRole('button', { name: 'protocols' }));
+    await screen.findByRole('button', { name: 'inner.pdf' });
+
+    const before = calls.length;
+    await user.click(await screen.findByRole('button', { name: 'Files' }));
+
+    await waitFor(() => {
+      const rootList = calls
+        .slice(before)
+        .find((c) => c.method === 'GET' && /\/apps\/files$/.test(c.url));
+      expect(rootList).toBeTruthy();
+    });
+  });
+
+  it('creates a folder via POST /folders and reloads', async () => {
+    const user = userEvent.setup();
+    const { fetch: mockFetch, calls } = makeRichFetch();
+    renderFiles(mockFetch);
+
+    await user.click(await screen.findByRole('button', { name: '+ New folder' }));
+    const input = await screen.findByRole('textbox', { name: 'New folder name' });
+    await user.type(input, 'training');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => {
+      const post = calls.find(
+        (c) => c.method === 'POST' && /\/apps\/files\/folders$/.test(c.url),
+      );
+      expect(post).toBeTruthy();
+      expect(JSON.parse(post!.init!.body as string)).toEqual({ name: 'training' });
+    });
+  });
+});

--- a/deliverables/F2/PWA/app/src/admin/apps/Files.tsx
+++ b/deliverables/F2/PWA/app/src/admin/apps/Files.tsx
@@ -9,9 +9,9 @@
  * soft-delete. Allowlist + size cap mirror the worker; we re-validate
  * client-side to give immediate feedback before paying the round trip.
  */
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { adminFetch, type ApiError } from '../lib/api-client';
+import { adminFetch, type AdminFetchOptions, type ApiError } from '../lib/api-client';
 import { useAdminAuth } from '../lib/auth-context';
 import { useRouter } from '../lib/pages-router';
 
@@ -35,6 +35,10 @@ interface FileRow {
   uploaded_at: string;
   description?: string;
   deleted_at?: string;
+  // #174 folders: is_folder marks a virtual folder row; folder_path is the
+  // container it lives in ('/' = root).
+  is_folder?: boolean;
+  folder_path?: string;
 }
 
 interface ListFilesData {
@@ -67,22 +71,34 @@ export function Files({ apiBaseUrl, fetchImpl }: FilesProps): JSX.Element {
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
+  // #174: current virtual-folder path. '' = root; '/<name>' = inside a folder.
+  const [path, setPath] = useState('');
+  const [folderForm, setFolderForm] = useState<string | null>(null); // null = closed
+  const [folderError, setFolderError] = useState<string | null>(null);
+  const [creatingFolder, setCreatingFolder] = useState(false);
+
+  // #175: inline rename — at most one row editable at a time.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [renaming, setRenaming] = useState(false);
+
+  // DRY auth options — call sites grew from 3 to ~6 with rename + folders.
+  const authOpts = useCallback((): AdminFetchOptions => ({
+    ...(token ? { token } : {}),
+    onUnauthorized: () => { clearAuth(); navigate('/admin/login'); },
+    onPasswordChangeRequired: () => navigate('/admin/me/change-password'),
+    ...(fetchImpl ? { fetchImpl } : {}),
+  }), [token, clearAuth, navigate, fetchImpl]);
+
   useEffect(() => {
     let cancelled = false;
     setState({ kind: 'loading' });
     void (async () => {
+      const qs = path ? `?path=${encodeURIComponent(path)}` : '';
       const r = await adminFetch<ListFilesData>(
-        `${apiBaseUrl}/admin/api/dashboards/apps/files`,
+        `${apiBaseUrl}/admin/api/dashboards/apps/files${qs}`,
         {},
-        {
-          ...(token ? { token } : {}),
-          onUnauthorized: () => {
-            clearAuth();
-            navigate('/admin/login');
-          },
-          onPasswordChangeRequired: () => navigate("/admin/me/change-password"),
-          ...(fetchImpl ? { fetchImpl } : {}),
-        },
+        authOpts(),
       );
       if (cancelled) return;
       if (r.ok) setState({ kind: 'loaded', data: r.data });
@@ -91,7 +107,7 @@ export function Files({ apiBaseUrl, fetchImpl }: FilesProps): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [apiBaseUrl, token, reloadTick, clearAuth, navigate, fetchImpl]);
+  }, [apiBaseUrl, reloadTick, path, authOpts]);
 
   async function handleUpload(file: File): Promise<void> {
     setUploadError(null);
@@ -109,18 +125,12 @@ export function Files({ apiBaseUrl, fetchImpl }: FilesProps): JSX.Element {
     try {
       const form = new FormData();
       form.append('file', file);
+      // #174: land the file in the open folder (omit at root).
+      if (path) form.append('path', path);
       const r = await adminFetch<UploadResponse>(
         `${apiBaseUrl}/admin/api/dashboards/apps/files`,
         { method: 'POST', body: form },
-        {
-          ...(token ? { token } : {}),
-          onUnauthorized: () => {
-            clearAuth();
-            navigate('/admin/login');
-          },
-          onPasswordChangeRequired: () => navigate("/admin/me/change-password"),
-          ...(fetchImpl ? { fetchImpl } : {}),
-        },
+        authOpts(),
       );
       if (r.ok) {
         setReloadTick((n) => n + 1);
@@ -138,18 +148,84 @@ export function Files({ apiBaseUrl, fetchImpl }: FilesProps): JSX.Element {
     const r = await adminFetch<undefined>(
       `${apiBaseUrl}/admin/api/dashboards/apps/files/${encodeURIComponent(row.file_id)}`,
       { method: 'DELETE' },
-      {
-        ...(token ? { token } : {}),
-        onUnauthorized: () => {
-          clearAuth();
-          navigate('/admin/login');
-        },
-        onPasswordChangeRequired: () => navigate("/admin/me/change-password"),
-        ...(fetchImpl ? { fetchImpl } : {}),
-      },
+      authOpts(),
     );
     if (r.ok) setReloadTick((n) => n + 1);
     else window.alert(friendlyError(r.error, 'Delete failed.'));
+  }
+
+  // #174: create a folder (flat 1-level — always at root).
+  async function handleCreateFolder(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    const name = (folderForm ?? '').trim();
+    setFolderError(null);
+    if (!name) {
+      setFolderError('Folder name required.');
+      return;
+    }
+    if (name.includes('/') || name.includes('\\') || name.includes('..')) {
+      setFolderError('Folder names cannot contain slashes or "..".');
+      return;
+    }
+    setCreatingFolder(true);
+    try {
+      const r = await adminFetch<{ folder: FileRow }>(
+        `${apiBaseUrl}/admin/api/dashboards/apps/files/folders`,
+        { method: 'POST', body: JSON.stringify({ name }) },
+        authOpts(),
+      );
+      if (r.ok) {
+        setFolderForm(null);
+        setReloadTick((n) => n + 1);
+      } else {
+        setFolderError(friendlyError(r.error, 'Create folder failed.'));
+      }
+    } finally {
+      setCreatingFolder(false);
+    }
+  }
+
+  // #175: inline rename.
+  function startRename(row: FileRow): void {
+    setEditingId(row.file_id);
+    setEditValue(row.filename);
+  }
+  function cancelRename(): void {
+    setEditingId(null);
+    setEditValue('');
+  }
+  async function commitRename(row: FileRow): Promise<void> {
+    const next = editValue.trim();
+    if (!next || next === row.filename) {
+      cancelRename();
+      return;
+    }
+    setRenaming(true);
+    try {
+      const r = await adminFetch<{ file: FileRow }>(
+        `${apiBaseUrl}/admin/api/dashboards/apps/files/${encodeURIComponent(row.file_id)}`,
+        { method: 'PATCH', body: JSON.stringify({ filename: next }) },
+        authOpts(),
+      );
+      if (r.ok) {
+        cancelRename();
+        setReloadTick((n) => n + 1);
+      } else {
+        window.alert(friendlyError(r.error, 'Rename failed.'));
+      }
+    } finally {
+      setRenaming(false);
+    }
+  }
+
+  function openFolder(row: FileRow): void {
+    // The folder's child container path is '/' + its display name.
+    cancelRename();
+    setPath(`/${row.filename}`);
+  }
+  function goToRoot(): void {
+    cancelRename();
+    setPath('');
   }
 
   function downloadUrl(fileId: string): string {
@@ -210,14 +286,44 @@ export function Files({ apiBaseUrl, fetchImpl }: FilesProps): JSX.Element {
     }
   }
 
+  const atRoot = path === '';
+
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-baseline justify-between">
         <h3 className="font-serif text-lg font-medium tracking-tight">Files</h3>
-        <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-          PDF / ZIP / PNG / JPEG / GIF, up to {formatBytes(MAX_FILE_BYTES)}
-        </p>
+        <div className="flex items-baseline gap-4">
+          {atRoot ? (
+            <Button
+              type="button"
+              variant="tableAction"
+              size="tableAction"
+              onClick={() => {
+                setFolderForm(folderForm === null ? '' : null);
+                setFolderError(null);
+              }}
+              className="text-muted-foreground no-underline hover:text-foreground hover:no-underline"
+            >
+              {folderForm === null ? '+ New folder' : 'Cancel'}
+            </Button>
+          ) : null}
+          <p className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+            PDF / ZIP / PNG / JPEG / GIF, up to {formatBytes(MAX_FILE_BYTES)}
+          </p>
+        </div>
       </div>
+
+      <Breadcrumb path={path} onRoot={goToRoot} />
+
+      {folderForm !== null ? (
+        <FolderForm
+          value={folderForm}
+          creating={creatingFolder}
+          error={folderError}
+          onChange={setFolderForm}
+          onSubmit={handleCreateFolder}
+        />
+      ) : null}
 
       <UploadRow
         uploading={uploading}
@@ -231,16 +337,102 @@ export function Files({ apiBaseUrl, fetchImpl }: FilesProps): JSX.Element {
       ) : state.kind === 'failed' ? (
         <ErrorBanner error={state.error} />
       ) : state.data.files.length === 0 ? (
-        <EmptyState />
+        <EmptyState atRoot={atRoot} />
       ) : (
         <FilesTable
           rows={state.data.files}
           onDownload={handleDownload}
           downloadingId={downloadingId}
           onDelete={handleDelete}
+          onOpenFolder={openFolder}
+          editingId={editingId}
+          editValue={editValue}
+          renaming={renaming}
+          onStartRename={startRename}
+          onRenameChange={setEditValue}
+          onCommitRename={commitRename}
+          onCancelRename={cancelRename}
         />
       )}
     </section>
+  );
+}
+
+function Breadcrumb({ path, onRoot }: { path: string; onRoot: () => void }): JSX.Element {
+  const inFolder = path !== '';
+  const folderName = inFolder ? path.replace(/^\//, '') : '';
+  return (
+    <nav
+      aria-label="Folder path"
+      className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-wider text-muted-foreground"
+    >
+      <button
+        type="button"
+        onClick={onRoot}
+        disabled={!inFolder}
+        className={
+          inFolder
+            ? 'underline decoration-hairline underline-offset-4 hover:decoration-foreground'
+            : 'cursor-default'
+        }
+      >
+        Files
+      </button>
+      {inFolder ? (
+        <>
+          <span aria-hidden="true">/</span>
+          <span className="text-foreground">{folderName}</span>
+        </>
+      ) : null}
+    </nav>
+  );
+}
+
+function FolderForm({
+  value,
+  creating,
+  error,
+  onChange,
+  onSubmit,
+}: {
+  value: string;
+  creating: boolean;
+  error: string | null;
+  onChange: (v: string) => void;
+  onSubmit: (e: React.FormEvent) => void | Promise<void>;
+}): JSX.Element {
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-2 border-l-2 border-hairline pl-4">
+      <label className="flex flex-col gap-1">
+        <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+          Folder name
+        </span>
+        <input
+          type="text"
+          autoFocus
+          value={value}
+          disabled={creating}
+          onChange={(e) => onChange(e.target.value)}
+          className="border-b border-hairline bg-transparent px-1 py-0.5 font-mono text-xs"
+          aria-label="New folder name"
+        />
+      </label>
+      {error ? (
+        <p role="alert" className="text-sm text-error">
+          {error}
+        </p>
+      ) : null}
+      <div className="flex gap-3">
+        <Button
+          type="submit"
+          variant="outline"
+          disabled={creating}
+          className="border-foreground px-3 py-1 font-mono text-xs uppercase tracking-wider hover:bg-foreground hover:text-background disabled:opacity-50"
+        >
+          {creating ? 'Creating…' : 'Create'}
+        </Button>
+      </div>
+    </form>
   );
 }
 
@@ -343,12 +535,31 @@ function FilesTable({
   onDownload,
   downloadingId,
   onDelete,
+  onOpenFolder,
+  editingId,
+  editValue,
+  renaming,
+  onStartRename,
+  onRenameChange,
+  onCommitRename,
+  onCancelRename,
 }: {
   rows: FileRow[];
   onDownload: (row: FileRow) => void | Promise<void>;
   downloadingId: string | null;
   onDelete: (row: FileRow) => void | Promise<void>;
+  onOpenFolder: (row: FileRow) => void;
+  editingId: string | null;
+  editValue: string;
+  renaming: boolean;
+  onStartRename: (row: FileRow) => void;
+  onRenameChange: (v: string) => void;
+  onCommitRename: (row: FileRow) => void | Promise<void>;
+  onCancelRename: () => void;
 }): JSX.Element {
+  // #174: folders render first (a directory-listing convention), then files.
+  const folders = rows.filter((r) => r.is_folder);
+  const files = rows.filter((r) => !r.is_folder);
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
@@ -363,41 +574,106 @@ function FilesTable({
           </tr>
         </thead>
         <tbody className="divide-y divide-hairline">
-          {rows.map((r) => (
-            <tr key={r.file_id}>
+          {folders.map((r) => (
+            <tr key={r.file_id} className="hover:bg-secondary/20">
               <Td>
-                {/* #315: download goes through handleDownload (authenticated
-                    blob fetch). A plain <a href> cannot send the in-memory
-                    admin JWT, so the bare GET 401'd and the error JSON was
-                    saved as the "file". This button is the action trigger. */}
                 <button
                   type="button"
-                  onClick={() => void onDownload(r)}
-                  disabled={downloadingId === r.file_id}
-                  className="text-left underline decoration-hairline underline-offset-4 hover:decoration-foreground disabled:cursor-not-allowed disabled:opacity-60"
+                  onClick={() => onOpenFolder(r)}
+                  className="flex items-center gap-2 text-left hover:text-foreground"
                 >
-                  {r.filename}
-                </button>
-                {downloadingId === r.file_id ? (
-                  <span className="ml-2 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-                    Downloading…
+                  <span aria-hidden="true" className="font-mono text-muted-foreground">
+                    [dir]
                   </span>
-                ) : null}
+                  <span className="underline decoration-hairline underline-offset-4 hover:decoration-foreground">
+                    {r.filename}
+                  </span>
+                </button>
+              </Td>
+              <Td mono>folder</Td>
+              <Td mono>—</Td>
+              <Td mono>{r.uploaded_by}</Td>
+              <Td mono>{formatTs(r.uploaded_at)}</Td>
+              <Td>{''}</Td>
+            </tr>
+          ))}
+          {files.map((r) => (
+            <tr key={r.file_id}>
+              <Td>
+                {editingId === r.file_id ? (
+                  // #175: inline rename — Enter commits, Esc/blur cancels.
+                  <input
+                    autoFocus
+                    type="text"
+                    value={editValue}
+                    disabled={renaming}
+                    onChange={(e) => onRenameChange(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        void onCommitRename(r);
+                      }
+                      if (e.key === 'Escape') {
+                        e.preventDefault();
+                        onCancelRename();
+                      }
+                    }}
+                    onBlur={() => {
+                      // Click-away cancels, but the disable-on-commit transition
+                      // also fires blur — don't cancel mid-PATCH (renaming=true).
+                      if (!renaming) onCancelRename();
+                    }}
+                    className="w-full border-b border-hairline bg-transparent px-1 py-0.5 font-mono text-xs"
+                    aria-label={`Rename ${r.filename}`}
+                  />
+                ) : (
+                  <>
+                    {/* #315: download goes through handleDownload (authenticated
+                        blob fetch). A plain <a href> cannot send the in-memory
+                        admin JWT, so the bare GET 401'd and the error JSON was
+                        saved as the "file". This button is the action trigger. */}
+                    <button
+                      type="button"
+                      onClick={() => void onDownload(r)}
+                      disabled={downloadingId === r.file_id}
+                      className="text-left underline decoration-hairline underline-offset-4 hover:decoration-foreground disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {r.filename}
+                    </button>
+                    {downloadingId === r.file_id ? (
+                      <span className="ml-2 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                        Downloading…
+                      </span>
+                    ) : null}
+                  </>
+                )}
               </Td>
               <Td mono>{r.content_type}</Td>
               <Td mono>{formatBytes(r.size_bytes)}</Td>
               <Td mono>{r.uploaded_by}</Td>
               <Td mono>{formatTs(r.uploaded_at)}</Td>
               <Td>
-                <Button
-                  type="button"
-                  variant="tableAction"
-                  size="tableAction"
-                  onClick={() => void onDelete(r)}
-                  className="text-muted-foreground no-underline hover:text-error hover:no-underline"
-                >
-                  Delete
-                </Button>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant="tableAction"
+                    size="tableAction"
+                    disabled={editingId === r.file_id}
+                    onClick={() => onStartRename(r)}
+                    className="text-muted-foreground no-underline hover:text-foreground hover:no-underline disabled:opacity-40"
+                  >
+                    Rename
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="tableAction"
+                    size="tableAction"
+                    onClick={() => void onDelete(r)}
+                    className="text-muted-foreground no-underline hover:text-error hover:no-underline"
+                  >
+                    Delete
+                  </Button>
+                </div>
               </Td>
             </tr>
           ))}
@@ -407,12 +683,13 @@ function FilesTable({
   );
 }
 
-function EmptyState(): JSX.Element {
+function EmptyState({ atRoot }: { atRoot: boolean }): JSX.Element {
   return (
     <div className="border border-hairline bg-secondary/20 px-4 py-4">
       <p className="text-sm text-muted-foreground">
-        No files uploaded yet. Reference documents (PDF protocols, training packets, ZIP exports)
-        live here. Uploads are streamed to R2 with the original filename preserved on download.
+        {atRoot
+          ? 'No files uploaded yet. Reference documents (PDF protocols, training packets, ZIP exports) live here. Uploads are streamed to R2 with the original filename preserved on download.'
+          : 'This folder is empty. Drop a file above to add it here.'}
       </p>
     </div>
   );
@@ -458,6 +735,7 @@ function friendlyError(err: ApiError, fallback: string): string {
     return 'Backend unavailable - Apps Script staging may be unreachable.';
   if (err.code === 'E_NOT_CONFIGURED')
     return 'File storage is not configured for this environment. Files require R2 to be enabled.';
+  if (err.code === 'E_CONFLICT') return err.message || 'A folder with that name already exists.';
   return err.message || fallback;
 }
 

--- a/deliverables/F2/PWA/app/src/admin/apps/Files.tsx
+++ b/deliverables/F2/PWA/app/src/admin/apps/Files.tsx
@@ -26,6 +26,11 @@ const ALLOWED_MIME = new Set([
 
 const MAX_FILE_BYTES = 100 * 1024 * 1024;
 
+// #174: folder-name charset — MUST mirror the worker apps.ts FOLDER_NAME_RE
+// and the AS AdminFiles.js validator. ASCII letters/digits/space/. _ -, no
+// '..', length 1–128.
+const FOLDER_NAME_RE = /^(?!.*\.\.)[A-Za-z0-9 _\-.]{1,128}$/;
+
 interface FileRow {
   file_id: string;
   filename: string;
@@ -163,8 +168,10 @@ export function Files({ apiBaseUrl, fetchImpl }: FilesProps): JSX.Element {
       setFolderError('Folder name required.');
       return;
     }
-    if (name.includes('/') || name.includes('\\') || name.includes('..')) {
-      setFolderError('Folder names cannot contain slashes or "..".');
+    // Mirror the worker/AS FOLDER_NAME_RE so the user gets immediate feedback
+    // instead of a generic server 400 (ASCII letters/digits/space/. _ -, no ..).
+    if (!FOLDER_NAME_RE.test(name)) {
+      setFolderError('Use letters, numbers, spaces, and . _ - only (no slashes or "..", max 128).');
       return;
     }
     setCreatingFolder(true);
@@ -410,6 +417,7 @@ function FolderForm({
         <input
           type="text"
           autoFocus
+          maxLength={128}
           value={value}
           disabled={creating}
           onChange={(e) => onChange(e.target.value)}

--- a/deliverables/F2/PWA/backend/apps-script/Migrations.js
+++ b/deliverables/F2/PWA/backend/apps-script/Migrations.js
@@ -46,7 +46,8 @@ function migrateAddAdminSheets() {
       name: 'F2_FileMeta',
       headers: [
         'file_id', 'filename', 'content_type', 'size_bytes',
-        'uploaded_by', 'uploaded_at', 'description', 'deleted_at'
+        'uploaded_by', 'uploaded_at', 'description', 'deleted_at',
+        'folder_path', 'is_folder'
       ]
     },
     {
@@ -120,17 +121,43 @@ function migrateExtendF2AuditColumns() {
 }
 
 /**
- * Top-level orchestrator. Runs all three migrations and logs the result.
+ * Append the 2 folder columns to F2_FileMeta if missing (#174).
+ *   folder_path (default '/'), is_folder (default false/blank)
+ *
+ * Pre-existing file rows read these as blank; AdminFiles._coalesceFolderPath
+ * treats blank folder_path as root, so legacy files stay visible at root with
+ * no backfill required.
+ */
+function migrateExtendF2FileMetaColumns() {
+  var ss = getF2Spreadsheet();
+  var sh = ss.getSheetByName('F2_FileMeta');
+  if (!sh) throw new Error('F2_FileMeta sheet not found');
+  var headers = sh.getRange(1, 1, 1, sh.getLastColumn()).getValues()[0];
+  var newCols = ['folder_path', 'is_folder'];
+  var added = [];
+  for (var i = 0; i < newCols.length; i++) {
+    var col = newCols[i];
+    if (headers.indexOf(col) !== -1) continue;
+    sh.getRange(1, sh.getLastColumn() + 1).setValue(col).setFontWeight('bold');
+    added.push(col);
+  }
+  return { added: added };
+}
+
+/**
+ * Top-level orchestrator. Runs all migrations and logs the result.
  * Run this once per environment (staging, then production at cutover).
  */
 function runAllMigrations() {
   var r1 = migrateAddAdminSheets();
   var r2 = migrateExtendF2ResponsesColumns();
   var r3 = migrateExtendF2AuditColumns();
+  var r4 = migrateExtendF2FileMetaColumns();
   var summary = {
     adminSheets: r1,
     responses: r2,
-    audit: r3
+    audit: r3,
+    fileMeta: r4
   };
   console.log('Migrations complete: ' + JSON.stringify(summary));
   return summary;

--- a/deliverables/F2/PWA/backend/src/AdminDispatch.js
+++ b/deliverables/F2/PWA/backend/src/AdminDispatch.js
@@ -132,6 +132,8 @@ function _adminHandlers() {
       admin_files_create: typeof adminFilesCreate !== 'undefined' ? adminFilesCreate : null,
       admin_files_get: typeof adminFilesGet !== 'undefined' ? adminFilesGet : null,
       admin_files_delete: typeof adminFilesDelete !== 'undefined' ? adminFilesDelete : null,
+      admin_files_rename: typeof adminFilesRename !== 'undefined' ? adminFilesRename : null,
+      admin_files_create_folder: typeof adminFilesCreateFolder !== 'undefined' ? adminFilesCreateFolder : null,
       admin_settings_list: typeof adminSettingsList !== 'undefined' ? adminSettingsList : null,
       admin_settings_create: typeof adminSettingsCreate !== 'undefined' ? adminSettingsCreate : null,
       admin_settings_update: typeof adminSettingsUpdate !== 'undefined' ? adminSettingsUpdate : null,

--- a/deliverables/F2/PWA/backend/src/AdminFiles.js
+++ b/deliverables/F2/PWA/backend/src/AdminFiles.js
@@ -14,8 +14,49 @@
  *
  * F2_FileMeta columns (Migrations.js):
  *   file_id, filename, content_type, size_bytes, uploaded_by,
- *   uploaded_at, description, deleted_at
+ *   uploaded_at, description, deleted_at, folder_path, is_folder
+ *
+ * Folders (E4-APRT-046 / #174): R2 is flat key-value, so folders are
+ * virtual. A folder is a F2_FileMeta row with is_folder=true; its display
+ * name is `filename` and it LIVES at root (folder_path='/'), so it appears
+ * in the root listing. Its children carry folder_path='/<name>'. Flat,
+ * 1-level model: folders are only created at root. folder_path on any row
+ * is the path of the *container* it lives in; root is '/'.
  */
+
+var ALLOWED_FILE_EXTENSIONS = ['pdf', 'zip', 'png', 'jpg', 'jpeg', 'gif'];
+// Mirrors the worker's ALLOWED_MIME (apps.ts). Keep in sync by hand.
+// Rename (#175) re-checks this; octet-stream uploads normally still carry
+// one of these extensions because the upload picker filters to them.
+
+function _extensionOf(name) {
+  var s = String(name || '');
+  var dot = s.lastIndexOf('.');
+  if (dot === -1 || dot === s.length - 1) return '';
+  return s.slice(dot + 1).toLowerCase();
+}
+
+function _validateFileExtension(name) {
+  var ext = _extensionOf(name);
+  if (!ext) return false;
+  for (var i = 0; i < ALLOWED_FILE_EXTENSIONS.length; i++) {
+    if (ALLOWED_FILE_EXTENSIONS[i] === ext) return true;
+  }
+  return false;
+}
+
+// Sheets reads a blank cell as '' — coalesce legacy/blank folder_path to
+// root so pre-migration files stay visible at the root listing.
+function _coalesceFolderPath(v) {
+  var s = String(v == null ? '' : v);
+  return s.length ? s : '/';
+}
+
+// A folder row stores boolean true in is_folder; Sheets may surface it as
+// the boolean true or the string 'true' depending on how it was written.
+function _isFolderRow(v) {
+  return v === true || v === 'true';
+}
 
 function _fileMetaSheet() {
   var ss = getF2Spreadsheet();
@@ -90,6 +131,11 @@ function adminFilesCreate(payload) {
       uploaded_at: payload.uploaded_at || nowIso,
       description: payload.description || '',
       deleted_at: '',
+      // #174: which folder the file lands in. Defaults to root. If the
+      // folder_path/is_folder columns aren't present yet (migration not run),
+      // headers.map below silently drops these — harmless degradation.
+      folder_path: payload.folder_path || '/',
+      is_folder: false,
     };
     var row = data.headers.map(function (h) { return record[h] != null ? record[h] : ''; });
     data.sh.appendRow(row);
@@ -107,10 +153,21 @@ function adminFilesList(filters) {
   filters = filters || {};
   var data = _readFileRows();
   var q = filters.q ? String(filters.q).toLowerCase() : null;
+  // #174: scope to one folder. No path (or '/') = root view, which shows
+  // root-level files AND every folder row (folders live at root). A path
+  // like '/protocols' shows that folder's children only.
+  var pathFilter = filters.path ? String(filters.path) : null;
+  if (pathFilter === '/') pathFilter = null;
   var matched = [];
   for (var i = 0; i < data.rows.length; i++) {
     var r = data.rows[i];
     if (r.deleted_at) continue;
+    var fp = _coalesceFolderPath(r.folder_path);
+    if (pathFilter) {
+      if (fp !== pathFilter) continue;
+    } else if (fp !== '/') {
+      continue; // root view: skip items nested inside a folder
+    }
     if (q) {
       var hay = (
         String(r.filename || '') + ' ' +
@@ -190,11 +247,128 @@ function adminFilesGet(payload) {
   return { ok: false, error: { code: 'E_NOT_FOUND', message: 'file ' + fid + ' not found' } };
 }
 
+/**
+ * Rename a file's display name (#175 / E4-APRT-047). Only `filename`
+ * changes; file_id (the R2 key) is immutable, so download links never
+ * break. The new name is re-validated against the extension allowlist —
+ * the bytes and content_type are untouched, but keeping the display name
+ * within the allowlist preserves the upload invariant.
+ *
+ * Folder rows cannot be renamed through this path (it would orphan their
+ * children's folder_path); E_VALIDATION if is_folder. Returns the updated
+ * row, or E_NOT_FOUND for unknown/soft-deleted file_id.
+ */
+function adminFilesRename(payload) {
+  if (!payload || !payload.file_id) {
+    return { ok: false, error: { code: 'E_VALIDATION', message: 'file_id required' } };
+  }
+  if (!payload.new_name || typeof payload.new_name !== 'string') {
+    return { ok: false, error: { code: 'E_VALIDATION', message: 'new_name required' } };
+  }
+  var fid = String(payload.file_id);
+  var newName = String(payload.new_name).trim();
+  if (newName.length === 0) {
+    return { ok: false, error: { code: 'E_VALIDATION', message: 'new_name cannot be blank' } };
+  }
+  if (newName.indexOf('/') !== -1 || newName.indexOf('\\') !== -1 || newName.indexOf('..') !== -1) {
+    return { ok: false, error: { code: 'E_VALIDATION', message: 'new_name cannot contain path separators or ..' } };
+  }
+  if (!_validateFileExtension(newName)) {
+    return { ok: false, error: { code: 'E_VALIDATION', message: 'new_name extension not allowed (pdf, zip, png, jpg, jpeg, gif)' } };
+  }
+
+  return _withFilesLock(function () {
+    var data = _readFileRows();
+    var filenameIdx = data.headers.indexOf('filename');
+    if (filenameIdx === -1) throw new Error('filename column missing on F2_FileMeta');
+    for (var i = 0; i < data.rows.length; i++) {
+      var r = data.rows[i];
+      if (r.file_id !== fid) continue;
+      if (r.deleted_at) {
+        return { ok: false, error: { code: 'E_NOT_FOUND', message: 'file ' + fid + ' not found' } };
+      }
+      if (_isFolderRow(r.is_folder)) {
+        return { ok: false, error: { code: 'E_VALIDATION', message: 'folders cannot be renamed' } };
+      }
+      data.sh.getRange(r._rowNumber, filenameIdx + 1).setValue(newName);
+      var clone = {};
+      for (var k in r) {
+        if (Object.prototype.hasOwnProperty.call(r, k) && k !== '_rowNumber') clone[k] = r[k];
+      }
+      clone.filename = newName;
+      return { ok: true, data: { file: clone } };
+    }
+    return { ok: false, error: { code: 'E_NOT_FOUND', message: 'file ' + fid + ' not found' } };
+  });
+}
+
+/**
+ * Create a virtual folder at root (#174 / E4-APRT-046). Flat, 1-level:
+ * the folder row lives at root (folder_path='/') so it shows in the root
+ * listing; its children carry folder_path='/<name>'. E_CONFLICT if a
+ * non-deleted folder of the same name already exists at root.
+ *
+ * E_NOT_CONFIGURED if the folder columns are absent — makes a missed
+ * migration loud instead of silently dropping the folder flag.
+ */
+function adminFilesCreateFolder(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return { ok: false, error: { code: 'E_VALIDATION', message: 'payload required' } };
+  }
+  var name = String(payload.name || '').trim();
+  if (name.length === 0) {
+    return { ok: false, error: { code: 'E_VALIDATION', message: 'folder name required' } };
+  }
+  if (name.indexOf('/') !== -1 || name.indexOf('\\') !== -1 || name.indexOf('..') !== -1) {
+    return { ok: false, error: { code: 'E_VALIDATION', message: 'folder name cannot contain slashes or ..' } };
+  }
+  if (name.length > 128) {
+    return { ok: false, error: { code: 'E_VALIDATION', message: 'folder name too long (max 128)' } };
+  }
+
+  return _withFilesLock(function () {
+    var data = _readFileRows();
+    if (data.headers.indexOf('folder_path') === -1 || data.headers.indexOf('is_folder') === -1) {
+      return { ok: false, error: { code: 'E_NOT_CONFIGURED', message: 'run migrateExtendF2FileMetaColumns first' } };
+    }
+    // Duplicate guard: a non-deleted folder row of this name already at root.
+    for (var i = 0; i < data.rows.length; i++) {
+      var r = data.rows[i];
+      if (r.deleted_at) continue;
+      if (_isFolderRow(r.is_folder) && String(r.filename) === name) {
+        return { ok: false, error: { code: 'E_CONFLICT', message: 'folder already exists' } };
+      }
+    }
+    var nowIso = new Date().toISOString();
+    var record = {
+      file_id: generateUuid(),
+      filename: name,
+      content_type: 'application/x-directory',
+      size_bytes: 0,
+      uploaded_by: payload.created_by || '',
+      uploaded_at: nowIso,
+      description: '',
+      deleted_at: '',
+      folder_path: '/', // the folder lives at root; its children use '/' + name
+      is_folder: true,
+    };
+    var row = data.headers.map(function (h) { return record[h] != null ? record[h] : ''; });
+    data.sh.appendRow(row);
+    return { ok: true, data: { folder: record } };
+  });
+}
+
 if (typeof module !== 'undefined') {
   module.exports = {
     adminFilesCreate: adminFilesCreate,
     adminFilesList: adminFilesList,
     adminFilesDelete: adminFilesDelete,
     adminFilesGet: adminFilesGet,
+    adminFilesRename: adminFilesRename,
+    adminFilesCreateFolder: adminFilesCreateFolder,
+    _extensionOf: _extensionOf,
+    _validateFileExtension: _validateFileExtension,
+    _coalesceFolderPath: _coalesceFolderPath,
+    _isFolderRow: _isFolderRow,
   };
 }

--- a/deliverables/F2/PWA/backend/src/AdminFiles.js
+++ b/deliverables/F2/PWA/backend/src/AdminFiles.js
@@ -52,6 +52,24 @@ function _coalesceFolderPath(v) {
   return s.length ? s : '/';
 }
 
+// Folder-name charset. MUST mirror the worker's FOLDER_NAME_RE (apps.ts):
+// ASCII letters/digits/space/dot/underscore/hyphen, no '..', length 1–128.
+// ASCII-only (no unicode/control chars) avoids homoglyph + CSV-formula-prefix
+// surprises in a sheet-backed store. Keep in sync with apps.ts by hand.
+var FOLDER_NAME_RE = /^(?!.*\.\.)[A-Za-z0-9 _\-.]{1,128}$/;
+
+function _validateFolderName(name) {
+  return typeof name === 'string' && FOLDER_NAME_RE.test(name);
+}
+
+// A folder_path is root ('/') or '/<valid-folder-name>' (flat, 1-level).
+// Returns true for an acceptable container path.
+function _validFolderPath(p) {
+  if (p === '/') return true;
+  if (typeof p !== 'string' || p.charAt(0) !== '/') return false;
+  return _validateFolderName(p.slice(1));
+}
+
 // A folder row stores boolean true in is_folder; Sheets may surface it as
 // the boolean true or the string 'true' depending on how it was written.
 function _isFolderRow(v) {
@@ -134,7 +152,9 @@ function adminFilesCreate(payload) {
       // #174: which folder the file lands in. Defaults to root. If the
       // folder_path/is_folder columns aren't present yet (migration not run),
       // headers.map below silently drops these — harmless degradation.
-      folder_path: payload.folder_path || '/',
+      // Defense-in-depth: the worker already validates the upload path, but
+      // coerce anything unexpected to root so a bad value can never persist.
+      folder_path: _validFolderPath(payload.folder_path) ? payload.folder_path : '/',
       is_folder: false,
     };
     var row = data.headers.map(function (h) { return record[h] != null ? record[h] : ''; });
@@ -316,14 +336,11 @@ function adminFilesCreateFolder(payload) {
     return { ok: false, error: { code: 'E_VALIDATION', message: 'payload required' } };
   }
   var name = String(payload.name || '').trim();
-  if (name.length === 0) {
-    return { ok: false, error: { code: 'E_VALIDATION', message: 'folder name required' } };
-  }
-  if (name.indexOf('/') !== -1 || name.indexOf('\\') !== -1 || name.indexOf('..') !== -1) {
-    return { ok: false, error: { code: 'E_VALIDATION', message: 'folder name cannot contain slashes or ..' } };
-  }
-  if (name.length > 128) {
-    return { ok: false, error: { code: 'E_VALIDATION', message: 'folder name too long (max 128)' } };
+  // Single source of truth for the folder-name charset, mirroring the worker.
+  // (Previously a looser denylist that admitted unicode/control chars the
+  // worker's upload-path regex would later reject — see #174 review.)
+  if (!_validateFolderName(name)) {
+    return { ok: false, error: { code: 'E_VALIDATION', message: 'invalid folder name (letters, digits, space, . _ - ; no slashes or .., max 128)' } };
   }
 
   return _withFilesLock(function () {
@@ -370,5 +387,7 @@ if (typeof module !== 'undefined') {
     _validateFileExtension: _validateFileExtension,
     _coalesceFolderPath: _coalesceFolderPath,
     _isFolderRow: _isFolderRow,
+    _validateFolderName: _validateFolderName,
+    _validFolderPath: _validFolderPath,
   };
 }

--- a/deliverables/F2/PWA/backend/tests/admin-files.test.mjs
+++ b/deliverables/F2/PWA/backend/tests/admin-files.test.mjs
@@ -1,0 +1,280 @@
+/**
+ * AdminFiles — rename (#175) + virtual folders (#174) + path-scoped list.
+ *
+ * AdminFiles.js touches Apps Script globals directly (getF2Spreadsheet,
+ * LockService, generateUuid) rather than an injected ctx, so we install a
+ * faithful in-memory F2_FileMeta sheet on globalThis before requiring the
+ * module. The mock backs a 2D array (row 0 = headers) and implements just the
+ * Range/Sheet surface AdminFiles uses: getRange(r,c[,nr,nc]).getValues(),
+ * getLastColumn/getLastRow, getRange(r,c).setValue, appendRow.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
+// ---- In-memory Sheet mock --------------------------------------------------
+
+class FakeSheet {
+  constructor(headers, rows = []) {
+    this.data = [headers.slice(), ...rows.map((r) => r.slice())];
+  }
+  getLastColumn() {
+    return this.data[0].length;
+  }
+  getLastRow() {
+    return this.data.length;
+  }
+  getRange(row, col, numRows, numCols) {
+    const self = this;
+    return {
+      getValues() {
+        const nr = numRows == null ? 1 : numRows;
+        const nc = numCols == null ? 1 : numCols;
+        const out = [];
+        for (let r = 0; r < nr; r++) {
+          const srcRow = self.data[row - 1 + r] || [];
+          const slice = [];
+          for (let c = 0; c < nc; c++) slice.push(srcRow[col - 1 + c]);
+          out.push(slice);
+        }
+        return out;
+      },
+      setValue(v) {
+        while (self.data.length < row) self.data.push([]);
+        const target = self.data[row - 1];
+        while (target.length < col) target.push('');
+        target[col - 1] = v;
+        return this;
+      },
+      setFontWeight() {
+        return this;
+      },
+    };
+  }
+  appendRow(arr) {
+    this.data.push(arr.slice());
+  }
+}
+
+const FILE_META_HEADERS = [
+  'file_id', 'filename', 'content_type', 'size_bytes',
+  'uploaded_by', 'uploaded_at', 'description', 'deleted_at',
+  'folder_path', 'is_folder',
+];
+
+let currentSheet;
+
+globalThis.getF2Spreadsheet = () => ({
+  getSheetByName: (name) => (name === 'F2_FileMeta' ? currentSheet : null),
+});
+globalThis.LockService = {
+  getScriptLock: () => ({ tryLock: () => true, releaseLock: () => {} }),
+};
+let uuidCounter = 0;
+globalThis.generateUuid = () => `uuid-${++uuidCounter}`;
+
+const AdminFiles = require('../src/AdminFiles.js');
+
+/** Build a file/folder row in header order. */
+function row(overrides) {
+  const base = {
+    file_id: 'f-x', filename: 'x.pdf', content_type: 'application/pdf',
+    size_bytes: 10, uploaded_by: 'kidd_admin', uploaded_at: '2026-05-01T00:00:00Z',
+    description: '', deleted_at: '', folder_path: '/', is_folder: false,
+  };
+  const merged = { ...base, ...overrides };
+  return FILE_META_HEADERS.map((h) => merged[h]);
+}
+
+beforeEach(() => {
+  uuidCounter = 0;
+  currentSheet = new FakeSheet(FILE_META_HEADERS);
+});
+
+// ---- Pure helpers ----------------------------------------------------------
+
+describe('AdminFiles pure helpers', () => {
+  it('_extensionOf lowercases and handles missing/trailing dots', () => {
+    expect(AdminFiles._extensionOf('a.PDF')).toBe('pdf');
+    expect(AdminFiles._extensionOf('noext')).toBe('');
+    expect(AdminFiles._extensionOf('trailing.')).toBe('');
+    expect(AdminFiles._extensionOf('a.b.zip')).toBe('zip');
+  });
+
+  it('_validateFileExtension allows only the upload allowlist', () => {
+    for (const ok of ['x.pdf', 'x.zip', 'x.png', 'x.jpg', 'x.jpeg', 'x.gif']) {
+      expect(AdminFiles._validateFileExtension(ok)).toBe(true);
+    }
+    for (const bad of ['x.exe', 'x.svg', 'x.html', 'noext']) {
+      expect(AdminFiles._validateFileExtension(bad)).toBe(false);
+    }
+  });
+
+  it('_coalesceFolderPath treats blank/null as root', () => {
+    expect(AdminFiles._coalesceFolderPath('')).toBe('/');
+    expect(AdminFiles._coalesceFolderPath(null)).toBe('/');
+    expect(AdminFiles._coalesceFolderPath(undefined)).toBe('/');
+    expect(AdminFiles._coalesceFolderPath('/docs')).toBe('/docs');
+  });
+
+  it('_isFolderRow accepts boolean true and string "true"', () => {
+    expect(AdminFiles._isFolderRow(true)).toBe(true);
+    expect(AdminFiles._isFolderRow('true')).toBe(true);
+    expect(AdminFiles._isFolderRow(false)).toBe(false);
+    expect(AdminFiles._isFolderRow('')).toBe(false);
+  });
+});
+
+// ---- adminFilesRename (#175) -----------------------------------------------
+
+describe('adminFilesRename', () => {
+  it('renames the filename, keeps file_id, returns the updated row', () => {
+    currentSheet = new FakeSheet(FILE_META_HEADERS, [row({ file_id: 'f-1', filename: 'old.pdf' })]);
+    const res = AdminFiles.adminFilesRename({ file_id: 'f-1', new_name: 'new.pdf' });
+    expect(res.ok).toBe(true);
+    expect(res.data.file.filename).toBe('new.pdf');
+    expect(res.data.file.file_id).toBe('f-1');
+    // The sheet cell was actually updated.
+    expect(currentSheet.data[1][FILE_META_HEADERS.indexOf('filename')]).toBe('new.pdf');
+  });
+
+  it('rejects a blank new_name', () => {
+    currentSheet = new FakeSheet(FILE_META_HEADERS, [row({ file_id: 'f-1' })]);
+    const res = AdminFiles.adminFilesRename({ file_id: 'f-1', new_name: '   ' });
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe('E_VALIDATION');
+  });
+
+  it('rejects path separators in new_name', () => {
+    currentSheet = new FakeSheet(FILE_META_HEADERS, [row({ file_id: 'f-1' })]);
+    expect(AdminFiles.adminFilesRename({ file_id: 'f-1', new_name: 'a/b.pdf' }).error.code).toBe('E_VALIDATION');
+    expect(AdminFiles.adminFilesRename({ file_id: 'f-1', new_name: '..\\evil.pdf' }).error.code).toBe('E_VALIDATION');
+  });
+
+  it('rejects a disallowed extension', () => {
+    currentSheet = new FakeSheet(FILE_META_HEADERS, [row({ file_id: 'f-1' })]);
+    const res = AdminFiles.adminFilesRename({ file_id: 'f-1', new_name: 'payload.exe' });
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe('E_VALIDATION');
+  });
+
+  it('refuses to rename a folder row', () => {
+    currentSheet = new FakeSheet(FILE_META_HEADERS, [
+      row({ file_id: 'd-1', filename: 'protocols', is_folder: true, content_type: 'application/x-directory' }),
+    ]);
+    const res = AdminFiles.adminFilesRename({ file_id: 'd-1', new_name: 'renamed.pdf' });
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe('E_VALIDATION');
+  });
+
+  it('returns E_NOT_FOUND for unknown or soft-deleted file_id', () => {
+    currentSheet = new FakeSheet(FILE_META_HEADERS, [
+      row({ file_id: 'f-1', deleted_at: '2026-05-02T00:00:00Z' }),
+    ]);
+    expect(AdminFiles.adminFilesRename({ file_id: 'f-1', new_name: 'a.pdf' }).error.code).toBe('E_NOT_FOUND');
+    expect(AdminFiles.adminFilesRename({ file_id: 'nope', new_name: 'a.pdf' }).error.code).toBe('E_NOT_FOUND');
+  });
+});
+
+// ---- adminFilesCreateFolder (#174) -----------------------------------------
+
+describe('adminFilesCreateFolder', () => {
+  it('creates a folder row at root with is_folder=true', () => {
+    const res = AdminFiles.adminFilesCreateFolder({ name: 'protocols', created_by: 'kidd_admin' });
+    expect(res.ok).toBe(true);
+    expect(res.data.folder.is_folder).toBe(true);
+    expect(res.data.folder.folder_path).toBe('/');
+    expect(res.data.folder.filename).toBe('protocols');
+    expect(res.data.folder.uploaded_by).toBe('kidd_admin');
+    // Appended to the sheet.
+    expect(currentSheet.getLastRow()).toBe(2);
+  });
+
+  it('rejects a duplicate non-deleted folder name (E_CONFLICT)', () => {
+    currentSheet = new FakeSheet(FILE_META_HEADERS, [
+      row({ file_id: 'd-1', filename: 'protocols', is_folder: true }),
+    ]);
+    const res = AdminFiles.adminFilesCreateFolder({ name: 'protocols', created_by: 'kidd_admin' });
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe('E_CONFLICT');
+  });
+
+  it('allows reusing the name of a soft-deleted folder', () => {
+    currentSheet = new FakeSheet(FILE_META_HEADERS, [
+      row({ file_id: 'd-1', filename: 'protocols', is_folder: true, deleted_at: '2026-05-02T00:00:00Z' }),
+    ]);
+    expect(AdminFiles.adminFilesCreateFolder({ name: 'protocols', created_by: 'x' }).ok).toBe(true);
+  });
+
+  it('rejects slashes, .. and over-long names', () => {
+    expect(AdminFiles.adminFilesCreateFolder({ name: 'a/b' }).error.code).toBe('E_VALIDATION');
+    expect(AdminFiles.adminFilesCreateFolder({ name: '..' }).error.code).toBe('E_VALIDATION');
+    expect(AdminFiles.adminFilesCreateFolder({ name: '' }).error.code).toBe('E_VALIDATION');
+    expect(AdminFiles.adminFilesCreateFolder({ name: 'x'.repeat(129) }).error.code).toBe('E_VALIDATION');
+  });
+
+  it('returns E_NOT_CONFIGURED when the folder columns are absent', () => {
+    // Pre-migration sheet: no folder_path / is_folder columns.
+    currentSheet = new FakeSheet(FILE_META_HEADERS.slice(0, 8));
+    const res = AdminFiles.adminFilesCreateFolder({ name: 'protocols', created_by: 'x' });
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe('E_NOT_CONFIGURED');
+  });
+});
+
+// ---- adminFilesList path scoping (#174) ------------------------------------
+
+describe('adminFilesList path scoping', () => {
+  beforeEach(() => {
+    currentSheet = new FakeSheet(FILE_META_HEADERS, [
+      row({ file_id: 'root-1', filename: 'rootdoc.pdf', folder_path: '/' }),
+      row({ file_id: 'd-1', filename: 'protocols', is_folder: true, folder_path: '/' }),
+      row({ file_id: 'in-1', filename: 'inner.pdf', folder_path: '/protocols' }),
+      row({ file_id: 'legacy-1', filename: 'legacy.pdf', folder_path: '' }), // pre-migration blank
+    ]);
+  });
+
+  it('root view shows root files + folders + coalesced-legacy, hides nested', () => {
+    const res = AdminFiles.adminFilesList({});
+    const ids = res.data.files.map((f) => f.file_id);
+    expect(ids).toContain('root-1');
+    expect(ids).toContain('d-1'); // folder lives at root
+    expect(ids).toContain('legacy-1'); // blank folder_path coalesces to root
+    expect(ids).not.toContain('in-1'); // nested, hidden at root
+  });
+
+  it("path='/protocols' shows only that folder's children", () => {
+    const res = AdminFiles.adminFilesList({ path: '/protocols' });
+    const ids = res.data.files.map((f) => f.file_id);
+    expect(ids).toEqual(['in-1']);
+  });
+
+  it("path='/' is treated as root", () => {
+    const res = AdminFiles.adminFilesList({ path: '/' });
+    const ids = res.data.files.map((f) => f.file_id);
+    expect(ids).toContain('root-1');
+    expect(ids).not.toContain('in-1');
+  });
+});
+
+// ---- adminFilesCreate folder defaults --------------------------------------
+
+describe('adminFilesCreate folder defaults', () => {
+  it('defaults folder_path to root and is_folder to false', () => {
+    const res = AdminFiles.adminFilesCreate({
+      file_id: 'f-1', filename: 'a.pdf', content_type: 'application/pdf',
+      size_bytes: 5, uploaded_by: 'kidd_admin',
+    });
+    expect(res.ok).toBe(true);
+    expect(res.data.file.folder_path).toBe('/');
+    expect(res.data.file.is_folder).toBe(false);
+  });
+
+  it('honors an explicit folder_path', () => {
+    const res = AdminFiles.adminFilesCreate({
+      file_id: 'f-2', filename: 'b.pdf', content_type: 'application/pdf',
+      size_bytes: 5, uploaded_by: 'kidd_admin', folder_path: '/protocols',
+    });
+    expect(res.data.file.folder_path).toBe('/protocols');
+  });
+});

--- a/deliverables/F2/PWA/backend/tests/admin-files.test.mjs
+++ b/deliverables/F2/PWA/backend/tests/admin-files.test.mjs
@@ -213,6 +213,18 @@ describe('adminFilesCreateFolder', () => {
     expect(AdminFiles.adminFilesCreateFolder({ name: 'x'.repeat(129) }).error.code).toBe('E_VALIDATION');
   });
 
+  it('rejects non-ASCII / special-char names that the worker upload-path regex would later reject', () => {
+    // Closes the create-vs-upload asymmetry: a folder the worker could never
+    // accept an upload-path for must not be creatable in the first place.
+    for (const bad of ['Niño', 'café', 'Q&A', 'Forms(2026)', '#tag', 'a\tb']) {
+      expect(AdminFiles.adminFilesCreateFolder({ name: bad, created_by: 'x' }).error.code).toBe('E_VALIDATION');
+    }
+  });
+
+  it('accepts ASCII names with spaces, dots, dashes, underscores', () => {
+    expect(AdminFiles.adminFilesCreateFolder({ name: 'Field Ops v2.1_draft-A', created_by: 'x' }).ok).toBe(true);
+  });
+
   it('returns E_NOT_CONFIGURED when the folder columns are absent', () => {
     // Pre-migration sheet: no folder_path / is_folder columns.
     currentSheet = new FakeSheet(FILE_META_HEADERS.slice(0, 8));
@@ -270,11 +282,19 @@ describe('adminFilesCreate folder defaults', () => {
     expect(res.data.file.is_folder).toBe(false);
   });
 
-  it('honors an explicit folder_path', () => {
+  it('honors an explicit valid folder_path', () => {
     const res = AdminFiles.adminFilesCreate({
       file_id: 'f-2', filename: 'b.pdf', content_type: 'application/pdf',
       size_bytes: 5, uploaded_by: 'kidd_admin', folder_path: '/protocols',
     });
     expect(res.data.file.folder_path).toBe('/protocols');
+  });
+
+  it('coerces a malformed folder_path to root (defense-in-depth)', () => {
+    const res = AdminFiles.adminFilesCreate({
+      file_id: 'f-3', filename: 'c.pdf', content_type: 'application/pdf',
+      size_bytes: 5, uploaded_by: 'kidd_admin', folder_path: '/../etc',
+    });
+    expect(res.data.file.folder_path).toBe('/');
   });
 });

--- a/deliverables/F2/PWA/worker/src/admin/handlers/apps.ts
+++ b/deliverables/F2/PWA/worker/src/admin/handlers/apps.ts
@@ -41,6 +41,10 @@ export interface FileMetaRow {
   uploaded_at: string;
   description?: string;
   deleted_at?: string;
+  // #174 folders: folder_path is the container the row lives in ('/' = root);
+  // is_folder marks a virtual folder row (R2 has no native folders).
+  folder_path?: string;
+  is_folder?: boolean;
 }
 
 export interface ListFilesData {
@@ -50,6 +54,7 @@ export interface ListFilesData {
 
 export interface FilesListFilters {
   q?: string;
+  path?: string;
 }
 
 export type FilesListAsCallable = (
@@ -67,6 +72,14 @@ export type FilesGetAsCallable = (
 export type FilesDeleteAsCallable = (
   payload: { file_id: string },
 ) => Promise<AppsScriptResponse<{ file_id: string; deleted_at: string }>>;
+
+export type FilesRenameAsCallable = (
+  payload: { file_id: string; new_name: string },
+) => Promise<AppsScriptResponse<{ file: FileMetaRow }>>;
+
+export type FilesCreateFolderAsCallable = (
+  payload: { name: string; created_by: string },
+) => Promise<AppsScriptResponse<{ folder: FileMetaRow }>>;
 
 /**
  * Minimal R2 surface used by these handlers. Accepting an interface
@@ -130,6 +143,9 @@ export async function handleListFiles(
   const filters: FilesListFilters = {};
   const q = url.searchParams.get('q');
   if (q) filters.q = q;
+  // #174: scope the listing to one virtual folder (omit = root view).
+  const path = url.searchParams.get('path');
+  if (path) filters.path = path;
   const r = await asCallable(filters);
   if (!r.ok || !r.data) {
     return errorJson(
@@ -139,6 +155,76 @@ export async function handleListFiles(
     );
   }
   return jsonResponse(r.data, 200);
+}
+
+// #174/#175: folder-name + filename validation shared with the frontend.
+// FOLDER_NAME_RE bans '..' and path separators, allows letters/digits/space/._-.
+const FOLDER_NAME_RE = /^(?!.*\.\.)[A-Za-z0-9 _\-.]{1,128}$/;
+const FILE_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export interface RenameFileBody {
+  filename?: unknown;
+}
+
+export interface CreateFolderBody {
+  name?: unknown;
+}
+
+/**
+ * #175: rename a file's display name. The worker receives `{ filename }`
+ * from the client and forwards it to AS as `{ new_name }` (AS uses the
+ * unambiguous field). file_id (the R2 key) never changes, so download
+ * links survive the rename. Returns the updated row.
+ */
+export async function handleRenameFile(
+  fileId: string,
+  body: RenameFileBody,
+  asCallable: FilesRenameAsCallable,
+): Promise<Response> {
+  if (!FILE_ID_RE.test(fileId)) {
+    return errorJson('E_VALIDATION', 'invalid file_id path param', 400);
+  }
+  const filename = typeof body.filename === 'string' ? body.filename.trim() : '';
+  if (!filename) {
+    return errorJson('E_VALIDATION', '"filename" is required', 400);
+  }
+  const r = await asCallable({ file_id: fileId, new_name: filename });
+  if (!r.ok || !r.data) {
+    return errorJson(
+      r.error?.code ?? 'E_BACKEND',
+      r.error?.message ?? 'Apps Script unavailable',
+      statusForAsError(r.error?.code),
+    );
+  }
+  return jsonResponse(r.data, 200);
+}
+
+/**
+ * #174: create a virtual folder at root (flat, 1-level). Validates the
+ * folder name before the AS round-trip; AS is the duplicate authority
+ * (returns E_CONFLICT → 409).
+ */
+export async function handleCreateFolder(
+  body: CreateFolderBody,
+  actor: { username: string },
+  asCallable: FilesCreateFolderAsCallable,
+): Promise<Response> {
+  if (!actor.username) {
+    return errorJson('E_INTERNAL', 'actor username missing from RBAC context', 500);
+  }
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (!FOLDER_NAME_RE.test(name)) {
+    return errorJson('E_VALIDATION', 'invalid folder name (letters, digits, space, . _ - ; no slashes or ..)', 400);
+  }
+  const r = await asCallable({ name, created_by: actor.username });
+  if (!r.ok || !r.data) {
+    return errorJson(
+      r.error?.code ?? 'E_BACKEND',
+      r.error?.message ?? 'Apps Script unavailable',
+      statusForAsError(r.error?.code),
+    );
+  }
+  return jsonResponse(r.data, 201);
 }
 
 /**
@@ -205,6 +291,17 @@ export async function handleUploadFile(
     ? (form.get('description') as string)
     : '';
 
+  // #174: which virtual folder the file lands in. The frontend sends the
+  // current breadcrumb path; validate it against the folder-name shape
+  // ('/' or '/<name>'), defaulting to root on anything unexpected so a
+  // malformed path can never escape the flat 1-level model.
+  const rawPath = typeof form.get('path') === 'string' ? (form.get('path') as string).trim() : '';
+  let folderPath = '/';
+  if (rawPath && rawPath !== '/') {
+    const seg = rawPath.startsWith('/') ? rawPath.slice(1) : rawPath;
+    if (FOLDER_NAME_RE.test(seg)) folderPath = `/${seg}`;
+  }
+
   const fileId = crypto.randomUUID();
   const rawName = file.name ?? 'upload';
   const safeName = sanitizeFilename(rawName);
@@ -225,6 +322,7 @@ export async function handleUploadFile(
     uploaded_by: actor.username,
     uploaded_at: uploadedAt,
     description,
+    folder_path: folderPath,
   });
   if (!r.ok || !r.data) {
     // Best-effort cleanup of the orphaned R2 object so the bucket

--- a/deliverables/F2/PWA/worker/src/admin/handlers/apps.ts
+++ b/deliverables/F2/PWA/worker/src/admin/handlers/apps.ts
@@ -292,14 +292,17 @@ export async function handleUploadFile(
     : '';
 
   // #174: which virtual folder the file lands in. The frontend sends the
-  // current breadcrumb path; validate it against the folder-name shape
-  // ('/' or '/<name>'), defaulting to root on anything unexpected so a
-  // malformed path can never escape the flat 1-level model.
+  // current breadcrumb path. Reject a malformed path with a clear error
+  // rather than silently dropping the file at root — a silent fallback would
+  // misfile the upload (the folder it was meant for wouldn't show it).
   const rawPath = typeof form.get('path') === 'string' ? (form.get('path') as string).trim() : '';
   let folderPath = '/';
   if (rawPath && rawPath !== '/') {
     const seg = rawPath.startsWith('/') ? rawPath.slice(1) : rawPath;
-    if (FOLDER_NAME_RE.test(seg)) folderPath = `/${seg}`;
+    if (!FOLDER_NAME_RE.test(seg)) {
+      return errorJson('E_VALIDATION', 'invalid upload folder path', 400);
+    }
+    folderPath = `/${seg}`;
   }
 
   const fileId = crypto.randomUUID();

--- a/deliverables/F2/PWA/worker/src/admin/routes.ts
+++ b/deliverables/F2/PWA/worker/src/admin/routes.ts
@@ -83,6 +83,8 @@ import {
   handleUploadFile,
   handleDownloadFile,
   handleDeleteFile,
+  handleRenameFile,
+  handleCreateFolder,
   handleListSettings,
   handleCreateSetting,
   handleUpdateSetting,
@@ -96,6 +98,8 @@ import {
   type ListSettingsData,
   type SettingRow,
   type SettingMutationBody,
+  type RenameFileBody,
+  type CreateFolderBody,
 } from './handlers/apps';
 import { callAppsScript } from './apps-script-client';
 import { RoleVersionCache, requirePerm, type Role, type RolesListResp, type RbacOpts } from './rbac';
@@ -131,6 +135,9 @@ const USERS_REVOKE_RE = /^\/admin\/api\/dashboards\/users\/([A-Za-z0-9_]{3,32})\
 const ROLES_LIST_RE = /^\/admin\/api\/dashboards\/roles\/?$/;
 const ROLES_BY_NAME_RE = /^\/admin\/api\/dashboards\/roles\/([A-Za-z][A-Za-z0-9 _\-]{0,63})\/?$/;
 const FILES_LIST_RE = /^\/admin\/api\/dashboards\/apps\/files\/?$/;
+// #174: folder-create sits as a sibling of the by-id route. It must be tested
+// BEFORE FILES_BY_ID_RE so "/files/folders" isn't captured as a file_id.
+const FILES_FOLDERS_RE = /^\/admin\/api\/dashboards\/apps\/files\/folders\/?$/;
 const FILES_BY_ID_RE = /^\/admin\/api\/dashboards\/apps\/files\/([A-Za-z0-9_\-]+)\/?$/;
 const SETTINGS_LIST_RE = /^\/admin\/api\/dashboards\/apps\/data-settings\/?$/;
 const SETTINGS_BY_ID_RE = /^\/admin\/api\/dashboards\/apps\/data-settings\/([A-Za-z0-9_\-]+)\/?$/;
@@ -590,13 +597,37 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
     return withRequestId(r, requestId);
   }
 
+  // #174: create a virtual folder. Must precede the by-id block so the
+  // "folders" path segment isn't matched as a file_id.
+  if (req.method === 'POST' && FILES_FOLDERS_RE.test(url.pathname)) {
+    const auth = await requirePerm(req, 'dash_apps', buildRbacOpts(env, requestId));
+    if (!auth.ok) {
+      return withRequestId(rbacFailureResponse(auth.status, auth.errorCode), requestId);
+    }
+    const body = (await req.json().catch(() => ({}))) as CreateFolderBody;
+    const asCall = (payload: { name: string; created_by: string }) =>
+      callAppsScript<{ folder: FileMetaRow }>(
+        env.APPS_SCRIPT_URL,
+        env.APPS_SCRIPT_HMAC,
+        'admin_files_create_folder',
+        payload as unknown as Record<string, unknown>,
+        requestId,
+        env.F2_AUTH,
+      );
+    const r = await handleCreateFolder(body, { username: auth.payload!.sub }, asCall);
+    auditMutation(auditFn, r, auth, ipHash, 'admin_files_create_folder',
+      typeof body.name === 'string' ? body.name : '');
+    return withRequestId(r, requestId);
+  }
+
   const fileByIdMatch = FILES_BY_ID_RE.exec(url.pathname);
-  if (fileByIdMatch && (req.method === 'GET' || req.method === 'DELETE')) {
+  if (fileByIdMatch && (req.method === 'GET' || req.method === 'PATCH' || req.method === 'DELETE')) {
     const auth = await requirePerm(req, 'dash_apps', buildRbacOpts(env, requestId));
     if (!auth.ok) {
       return withRequestId(rbacFailureResponse(auth.status, auth.errorCode), requestId);
     }
     const fileId = decodeURIComponent(fileByIdMatch[1]!);
+
     if (req.method === 'GET') {
       const asCall = (payload: { file_id: string }) =>
         callAppsScript<{ file: FileMetaRow }>(
@@ -610,6 +641,26 @@ export async function adminRouter(req: Request, env: Env, ctx?: ExecutionContext
       const r = await handleDownloadFile(fileId, env.F2_ADMIN_R2, asCall);
       return withRequestId(r, requestId);
     }
+
+    // #175: rename. Each method-branch self-returns; DELETE is now explicitly
+    // guarded so adding PATCH can't fall through into the delete path.
+    if (req.method === 'PATCH') {
+      const body = (await req.json().catch(() => ({}))) as RenameFileBody;
+      const asCall = (payload: { file_id: string; new_name: string }) =>
+        callAppsScript<{ file: FileMetaRow }>(
+          env.APPS_SCRIPT_URL,
+          env.APPS_SCRIPT_HMAC,
+          'admin_files_rename',
+          payload as unknown as Record<string, unknown>,
+          requestId,
+          env.F2_AUTH,
+        );
+      const r = await handleRenameFile(fileId, body, asCall);
+      auditMutation(auditFn, r, auth, ipHash, 'admin_files_rename', fileId);
+      return withRequestId(r, requestId);
+    }
+
+    // req.method === 'DELETE'
     const asCall = (payload: { file_id: string }) =>
       callAppsScript<{ file_id: string; deleted_at: string }>(
         env.APPS_SCRIPT_URL,

--- a/deliverables/F2/PWA/worker/test/admin/handlers/apps.test.ts
+++ b/deliverables/F2/PWA/worker/test/admin/handlers/apps.test.ts
@@ -103,6 +103,7 @@ function multipartReq(opts: {
   type: string;
   bytes: Uint8Array;
   description?: string;
+  path?: string;
   contentTypeHeader?: string;
 }): Request {
   const form = new FormData();
@@ -110,6 +111,7 @@ function multipartReq(opts: {
   // Attach a name property; in Workers FormData accepts (Blob, filename) too.
   form.append('file', blob, opts.filename);
   if (opts.description !== undefined) form.append('description', opts.description);
+  if (opts.path !== undefined) form.append('path', opts.path);
   return new Request('http://test/upload', {
     method: 'POST',
     body: form,
@@ -230,6 +232,48 @@ describe('handleUploadFile', () => {
       expect(asPayload?.size_bytes).toBe(4);
     },
   );
+
+  it('#174: forwards a valid folder path to AS as folder_path', async () => {
+    const req = multipartReq({
+      filename: 'inner.pdf', type: 'application/pdf', bytes: new Uint8Array([1]), path: '/protocols',
+    });
+    const { r2 } = makeR2({});
+    let asPayload: Record<string, unknown> | undefined;
+    const r = await handleUploadFile(req, ACTOR, r2, (payload) => {
+      asPayload = payload;
+      return asCreateOk(SAMPLE_META);
+    });
+    expect(r.status).toBe(201);
+    expect(asPayload?.folder_path).toBe('/protocols');
+  });
+
+  it('#174: defaults folder_path to root when no path is given', async () => {
+    const req = multipartReq({ filename: 'a.pdf', type: 'application/pdf', bytes: new Uint8Array([1]) });
+    const { r2 } = makeR2({});
+    let asPayload: Record<string, unknown> | undefined;
+    const r = await handleUploadFile(req, ACTOR, r2, (payload) => {
+      asPayload = payload;
+      return asCreateOk(SAMPLE_META);
+    });
+    expect(r.status).toBe(201);
+    expect(asPayload?.folder_path).toBe('/');
+  });
+
+  it('#174: rejects a malformed upload path with 400 (no silent misfile to root)', async () => {
+    const req = multipartReq({
+      filename: 'a.pdf', type: 'application/pdf', bytes: new Uint8Array([1]), path: '/../escape',
+    });
+    const { r2, calls } = makeR2({});
+    let asCalled = false;
+    const r = await handleUploadFile(req, ACTOR, r2, () => {
+      asCalled = true;
+      return asCreateOk(SAMPLE_META);
+    });
+    expect(r.status).toBe(400);
+    // The bad path must fail BEFORE any R2 write or AS call — no orphan, no misfile.
+    expect(calls.put).toHaveLength(0);
+    expect(asCalled).toBe(false);
+  });
 
   it('purges R2 if AS create fails (orphan cleanup)', async () => {
     const req = multipartReq({ filename: 'doc.pdf', type: 'application/pdf', bytes: new Uint8Array([1]) });

--- a/deliverables/F2/PWA/worker/test/admin/handlers/apps.test.ts
+++ b/deliverables/F2/PWA/worker/test/admin/handlers/apps.test.ts
@@ -11,12 +11,16 @@ import {
   handleUploadFile,
   handleDownloadFile,
   handleDeleteFile,
+  handleRenameFile,
+  handleCreateFolder,
   type FileMetaRow,
   type FilesR2,
   type FilesListAsCallable,
   type FilesCreateAsCallable,
   type FilesGetAsCallable,
   type FilesDeleteAsCallable,
+  type FilesRenameAsCallable,
+  type FilesCreateFolderAsCallable,
   type ListFilesData,
 } from '../../../src/admin/handlers/apps';
 
@@ -133,6 +137,16 @@ describe('handleListFiles', () => {
       return asListOk({ files: [], total: 0 });
     });
     expect(captured?.q).toBe('protocol');
+  });
+
+  it('forwards path filter to AS (#174)', async () => {
+    let captured: { path?: string } | undefined;
+    const url = new URL('http://x/admin/api/dashboards/apps/files?path=%2Fprotocols');
+    await handleListFiles(url, (filters) => {
+      captured = filters;
+      return asListOk({ files: [], total: 0 });
+    });
+    expect(captured?.path).toBe('/protocols');
   });
 
   it('returns 502 E_BACKEND on AS failure', async () => {
@@ -321,5 +335,143 @@ describe('handleDeleteFile', () => {
     const { r2 } = makeR2({});
     const r = await handleDeleteFile('f-001', r2, () => asDeleteErr('E_LOCK_TIMEOUT'));
     expect(r.status).toBe(503);
+  });
+});
+
+// -------------------- handleRenameFile (#175) --------------------
+
+function asRenameOk(file: FileMetaRow): ReturnType<FilesRenameAsCallable> {
+  return Promise.resolve({ ok: true, data: { file } });
+}
+function asRenameErr(code: string): ReturnType<FilesRenameAsCallable> {
+  return Promise.resolve({ ok: false, error: { code, message: code } });
+}
+
+describe('handleRenameFile', () => {
+  it('translates client {filename} to AS {new_name} and returns the row', async () => {
+    let captured: { file_id: string; new_name: string } | undefined;
+    const req = new Request('http://x/files/f-001', {
+      method: 'PATCH',
+      body: JSON.stringify({ filename: 'renamed.pdf' }),
+    });
+    const r = await handleRenameFile('f-001', { filename: 'renamed.pdf' }, (payload) => {
+      captured = payload;
+      return asRenameOk({ ...SAMPLE_META, filename: 'renamed.pdf' });
+    });
+    void req;
+    expect(r.status).toBe(200);
+    expect(captured).toEqual({ file_id: 'f-001', new_name: 'renamed.pdf' });
+    const body = (await r.json()) as { file: FileMetaRow };
+    expect(body.file.filename).toBe('renamed.pdf');
+  });
+
+  it('rejects an invalid file_id path param with 400', async () => {
+    const r = await handleRenameFile('bad id!', { filename: 'a.pdf' }, () =>
+      asRenameOk(SAMPLE_META),
+    );
+    expect(r.status).toBe(400);
+  });
+
+  it('rejects a blank filename with 400 before the AS round-trip', async () => {
+    let called = false;
+    const r = await handleRenameFile('f-001', { filename: '   ' }, () => {
+      called = true;
+      return asRenameOk(SAMPLE_META);
+    });
+    expect(r.status).toBe(400);
+    expect(called).toBe(false);
+  });
+
+  it('maps AS E_VALIDATION (bad extension) to 400', async () => {
+    const r = await handleRenameFile('f-001', { filename: 'evil.exe' }, () =>
+      asRenameErr('E_VALIDATION'),
+    );
+    expect(r.status).toBe(400);
+  });
+
+  it('maps AS E_NOT_FOUND to 404', async () => {
+    const r = await handleRenameFile('f-001', { filename: 'a.pdf' }, () =>
+      asRenameErr('E_NOT_FOUND'),
+    );
+    expect(r.status).toBe(404);
+  });
+});
+
+// -------------------- handleCreateFolder (#174) --------------------
+
+function asFolderOk(folder: FileMetaRow): ReturnType<FilesCreateFolderAsCallable> {
+  return Promise.resolve({ ok: true, data: { folder } });
+}
+function asFolderErr(code: string): ReturnType<FilesCreateFolderAsCallable> {
+  return Promise.resolve({ ok: false, error: { code, message: code } });
+}
+
+const SAMPLE_FOLDER: FileMetaRow = {
+  file_id: 'd-001',
+  filename: 'protocols',
+  content_type: 'application/x-directory',
+  size_bytes: 0,
+  uploaded_by: 'admin-alice',
+  uploaded_at: '2026-05-01T12:00:00.000Z',
+  description: '',
+  folder_path: '/',
+  is_folder: true,
+};
+
+describe('handleCreateFolder', () => {
+  it('creates a folder and returns 201 with the folder row', async () => {
+    let captured: { name: string; created_by: string } | undefined;
+    const r = await handleCreateFolder({ name: 'protocols' }, ACTOR, (payload) => {
+      captured = payload;
+      return asFolderOk(SAMPLE_FOLDER);
+    });
+    expect(r.status).toBe(201);
+    expect(captured).toEqual({ name: 'protocols', created_by: 'admin-alice' });
+    const body = (await r.json()) as { folder: FileMetaRow };
+    expect(body.folder.is_folder).toBe(true);
+  });
+
+  it('allows spaces, dots, dashes, underscores in folder names', async () => {
+    const r = await handleCreateFolder({ name: 'Field Ops v2.1_draft-A' }, ACTOR, () =>
+      asFolderOk(SAMPLE_FOLDER),
+    );
+    expect(r.status).toBe(201);
+  });
+
+  it('rejects empty actor username with 500', async () => {
+    const r = await handleCreateFolder({ name: 'protocols' }, { username: '' }, () =>
+      asFolderOk(SAMPLE_FOLDER),
+    );
+    expect(r.status).toBe(500);
+  });
+
+  it.each([
+    ['contains slash', 'a/b'],
+    ['contains backslash', 'a\\b'],
+    ['contains ..', 'a..b'],
+    ['empty', ''],
+    ['too long', 'x'.repeat(129)],
+  ])('rejects %s before the AS round-trip', async (_label, name) => {
+    let called = false;
+    const r = await handleCreateFolder({ name }, ACTOR, () => {
+      called = true;
+      return asFolderOk(SAMPLE_FOLDER);
+    });
+    expect(r.status).toBe(400);
+    expect(called).toBe(false);
+  });
+
+  it('maps AS E_CONFLICT (duplicate) to 409', async () => {
+    const r = await handleCreateFolder({ name: 'protocols' }, ACTOR, () =>
+      asFolderErr('E_CONFLICT'),
+    );
+    expect(r.status).toBe(409);
+  });
+
+  it('maps AS E_NOT_CONFIGURED (missing migration) to 502', async () => {
+    const r = await handleCreateFolder({ name: 'protocols' }, ACTOR, () =>
+      asFolderErr('E_NOT_CONFIGURED'),
+    );
+    expect(r.status).toBe(502);
   });
 });

--- a/deliverables/F2/PWA/worker/test/admin/routes.test.ts
+++ b/deliverables/F2/PWA/worker/test/admin/routes.test.ts
@@ -524,4 +524,103 @@ describe('adminRouter', () => {
       fetchSpy.mockRestore();
     }
   });
+
+  // ---- Files: rename (#175) + create folder (#174) ----
+
+  it('routes PATCH /apps/files/:id to admin_files_rename (filename → new_name) under dash_apps', async () => {
+    const env = makeEnv(makeKv());
+    // Distinct role name — the module-level roleCache is keyed by name, so
+    // reusing 'Administrator' would hit a stale cached entry from an earlier
+    // test that granted it different perms (and 403 on the dash_apps check).
+    const tok = await mintAdminJwt(env.JWT_SIGNING_KEY, { sub: 'apps-mgr', role: 'AppsManager', role_version: 1 });
+    const calls: Array<{ action: string; payload: unknown }> = [];
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      const body = JSON.parse((init as RequestInit).body as string) as { action: string; payload: unknown };
+      calls.push({ action: body.action, payload: body.payload });
+      if (body.action === 'admin_roles_list') {
+        return new Response(JSON.stringify({
+          ok: true, data: { roles: [{ name: 'AppsManager', version: 1, dash_apps: true }] },
+        }), { status: 200 });
+      }
+      if (body.action === 'admin_files_rename') {
+        return new Response(JSON.stringify({
+          ok: true, data: { file: { file_id: 'f-1', filename: 'renamed.pdf' } },
+        }), { status: 200 });
+      }
+      return new Response('{}', { status: 500 });
+    });
+    try {
+      const req = new Request('https://x/admin/api/dashboards/apps/files/f-1', {
+        method: 'PATCH',
+        headers: { Authorization: `Bearer ${tok}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filename: 'renamed.pdf' }),
+      });
+      const r = await adminRouter(req, env);
+      expect(r!.status).toBe(200);
+      const renameCall = calls.find((c) => c.action === 'admin_files_rename');
+      expect(renameCall).toBeDefined();
+      // The worker forwards client {filename} to AS {new_name} — and must NOT
+      // fall through to admin_files_delete.
+      expect(renameCall!.payload).toEqual({ file_id: 'f-1', new_name: 'renamed.pdf' });
+      expect(calls.some((c) => c.action === 'admin_files_delete')).toBe(false);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('routes POST /apps/files/folders to admin_files_create_folder (not captured as a file_id)', async () => {
+    const env = makeEnv(makeKv());
+    const tok = await mintAdminJwt(env.JWT_SIGNING_KEY, { sub: 'apps-mgr', role: 'AppsManager', role_version: 1 });
+    const calls: Array<{ action: string; payload: unknown }> = [];
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      const body = JSON.parse((init as RequestInit).body as string) as { action: string; payload: unknown };
+      calls.push({ action: body.action, payload: body.payload });
+      if (body.action === 'admin_roles_list') {
+        return new Response(JSON.stringify({
+          ok: true, data: { roles: [{ name: 'AppsManager', version: 1, dash_apps: true }] },
+        }), { status: 200 });
+      }
+      if (body.action === 'admin_files_create_folder') {
+        return new Response(JSON.stringify({
+          ok: true, data: { folder: { file_id: 'd-1', filename: 'protocols', is_folder: true, folder_path: '/' } },
+        }), { status: 200 });
+      }
+      return new Response('{}', { status: 500 });
+    });
+    try {
+      const req = new Request('https://x/admin/api/dashboards/apps/files/folders', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${tok}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'protocols' }),
+      });
+      const r = await adminRouter(req, env);
+      expect(r!.status).toBe(201);
+      const folderCall = calls.find((c) => c.action === 'admin_files_create_folder');
+      expect(folderCall).toBeDefined();
+      expect(folderCall!.payload).toEqual({ name: 'protocols', created_by: 'apps-mgr' });
+      // Must NOT have been captured as a by-id download/get.
+      expect(calls.some((c) => c.action === 'admin_files_get')).toBe(false);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('rejects PATCH /apps/files/:id without dash_apps with 403', async () => {
+    const env = makeEnv(makeKv());
+    const tok = await mintAdminJwt(env.JWT_SIGNING_KEY, { sub: 'newbie', role: 'NoAccess', role_version: 1 });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ ok: true, data: { roles: [{ name: 'NoAccess', version: 1 }] } }), { status: 200 }),
+    );
+    try {
+      const req = new Request('https://x/admin/api/dashboards/apps/files/f-1', {
+        method: 'PATCH',
+        headers: { Authorization: `Bearer ${tok}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filename: 'x.pdf' }),
+      });
+      const r = await adminRouter(req, env);
+      expect(r!.status).toBe(403);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Closes #174, #175 — the two CSWeb-mirror parity gaps in the Admin Portal Files dashboard, surfaced 2026-05-06 during PO review. Full-stack, layered on the existing Files panel (E4-APRT-020).

> **Ground-truth correction:** the issue bodies referenced `F2_Files` / `original_filename`; the real schema is sheet **`F2_FileMeta`** with display column **`filename`**. Implemented against the real schema.

### #175 Rename (E4-APRT-047)
- **AS** `adminFilesRename(file_id, new_name)`: mutates `filename` only — `file_id` (the R2 key) is immutable so download links never break. Re-checks the extension allowlist; refuses to rename folder rows; `E_NOT_FOUND` on unknown/soft-deleted.
- **Worker** `PATCH /admin/api/dashboards/apps/files/:id` (`dash_apps`, audited): forwards client `{filename}` → AS `{new_name}`. The by-id route block is **restructured to mutually-exclusive self-returning branches** so adding PATCH can't fall through into DELETE.
- **UI**: inline per-row Rename — input → Enter commits, Esc/blur cancels (with a guard against the disable-on-commit blur race).

### #174 Create Folder — flat, 1-level (E4-APRT-046)
- R2 is flat key-value, so folders are **virtual**: a `F2_FileMeta` row with `is_folder=true` lives at root (`folder_path='/'`); its children carry `folder_path='/<name>'`. Migration adds `folder_path` + `is_folder` (additive; blank `folder_path` coalesces to root so **legacy files stay visible with no backfill**).
- **AS** `adminFilesCreateFolder` (`E_CONFLICT` dup, `E_NOT_CONFIGURED` if migration missing) + `adminFilesList` `path` filter + `adminFilesCreate` `folder_path` default.
- **Worker** `POST /admin/api/dashboards/apps/files/folders` (`dash_apps`, audited), routed **before** the by-id regex so `folders` isn't captured as a `file_id`; `handleListFiles` forwards `?path=`; `handleUpload` threads the open folder into uploads.
- **UI**: "+ New folder" form at root, breadcrumb (`Files / <folder>`), folder rows (`[dir]` marker, click to navigate), path-aware upload + empty state.

### Design decision: flat vs nested
Chose **flat / 1-level** per the issue's documented baseline ("flat is half the work") and CSWeb parity. The `folder_path` string already accommodates nesting later with **no data migration** — only UI + validation would change. Flag me if you'd prefer nested before this merges.

## Deploy order (important)
Run `runAllMigrations()` (adds the two columns) in each environment **before** the Worker goes live. If the Worker lands first, folder-create returns a clean `E_NOT_CONFIGURED` and all existing file ops keep working (graceful).

## Tests
- **Backend** +20 (`admin-files.test.mjs`: rename, folder create/dup/not-configured, list path-scoping, pure helpers) → 193 pass
- **Worker** +new (`apps.test`: rename/folder/path handlers; `routes.test`: PATCH + POST-folders incl. routing-order + a roleCache-isolation regression guard) → 214 pass
- **App** +5 (`Files.test`: rename commit/Escape, folder nav `?path=`, breadcrumb-to-root, create folder) → 461 pass
- `tsc` (app + worker) + eslint clean; AS bundle rebuilds + syntax-checks

## Test plan (manual, post-migration)
- [ ] Run `runAllMigrations()` on staging → confirm `folder_path` + `is_folder` columns added
- [ ] Rename a file → display name changes, download still works (same `file_id`)
- [ ] Rename to a bad extension (`x.exe`) → rejected
- [ ] Create folder → appears at root with `[dir]` marker; duplicate name → conflict message
- [ ] Navigate into folder → breadcrumb shows `Files / <name>`, upload lands a file inside, back-to-root works
- [ ] Pre-existing files still visible at root
- [ ] Audit log records `admin_files_rename` + `admin_files_create_folder`