### PR TITLE
feat(admin): #324 FX-002 — role-aware nav gating via login permission set

### DIFF
--- a/deliverables/F2/PWA/2026-06-02-fx-002-permission-set-design.md
+++ b/deliverables/F2/PWA/2026-06-02-fx-002-permission-set-design.md
@@ -1,0 +1,199 @@
+# FX-002 — Backend permission-set surface for role-aware nav gating
+
+**Issue:** #324 (ADMIN PORTAL 5A.15) · **Date:** 2026-06-02 · **Status:** Design — ready to build
+**Scope:** Unblock the cosmetic "hide controls the current role can't use" enhancement (FX-002) by deciding what the backend surfaces so the frontend can role-gate the sidebar.
+
+---
+
+## 1. Summary & decision
+
+**Decision: return the user's resolved permission set in the login response body** (and the change-password re-mint response), store it in the in-memory admin auth context, and filter `NAV_GROUPS` against it in `Layout.tsx`. **No JWT change, no new endpoint, no AS change, no migration.**
+
+The permission set is **advisory UI-only**. The Worker's `requirePerm` (`rbac.ts`) remains the sole authorization boundary and is untouched. Nav gating **fails open** (show the item when in doubt) while enforcement **fails closed** (server returns 403). A user who tampers with their in-memory perm map to reveal a hidden link gains nothing — the actual request is still rejected server-side.
+
+---
+
+## 2. Problem & why it was blocked
+
+`Layout.tsx` `NAV_GROUPS` renders **every** nav item to every authenticated user (documented at `Layout.tsx:32-33`: *"Role-aware filtering still TBD (FX-002 follow-up). Today every link is visible to every authenticated user; Worker enforces 403 on actual access."*). A user whose role lacks `dash_users` still sees the **Users** link; clicking it 401/403s and bounces — functional, but confusing.
+
+It was design-blocked because **custom roles exist** (admins define roles in `F2_Roles`). The frontend cannot hardcode which items a role may see — it must learn the current user's resolved permissions from the backend. The unmade decision was: **in what shape, and surfaced where?**
+
+---
+
+## 3. Chosen approach & rationale
+
+**Surface the perm set in the login response body.** `handleLogin` (`worker/src/admin/handlers/auth.ts`) *already* fetches `admin_roles_list` and resolves the user's full `F2_Roles` row to read `role.version` for the JWT. The perm columns are sitting right there — projecting them into a map is near-zero extra cost.
+
+Why this wins over the alternatives:
+
+| Option | Verdict |
+|---|---|
+| **(A) Perms in login response body** ✅ chosen | The role object is already in hand; the admin JWT is in-memory only, so a perm map in auth-context has the *exact same lifecycle* as the token (cleared on reload/logout). Zero new round-trips, zero JWT bloat, custom roles "just work." |
+| (B) Perms as a JWT claim | Rejected. The JWT is sent on every request → bloat for data that's only read once at app load. The in-memory JWT gives a claim **no persistence advantage** over the response body. Larger attack surface (claim tampering is meaningless for an advisory map, but it muddies the "JWT = identity, not UI state" line). |
+| (C) Dedicated `GET /admin/api/me/permissions` | Rejected for now. An extra round-trip for data login already has. Useful only if perms must refresh mid-session without re-login — but `role_version` invalidation (below) already bounds staleness. Noted as the natural extension point if live-refresh is ever needed. |
+
+---
+
+## 4. Backend changes
+
+**No Apps Script change.** `admin_roles_list` already returns each role row with all perm columns; `handleLogin` already resolves the user's role from it. **No migration.** **JWT untouched.**
+
+### 4.1 `worker/src/admin/handlers/auth.ts`
+
+Add an explicit perm-key allowlist (auditable; won't leak `name`/`version`/`created_by`/`created_at`/`is_builtin`, and won't accidentally expose a future non-perm column):
+
+```ts
+// The RBAC permission columns on F2_Roles, in display order. The single
+// source of truth for what the client may learn about its own role. Keep in
+// sync with the F2_Roles schema (Migrations.js) and rbac.ts perm checks.
+export const PERM_KEYS = [
+  'dash_data', 'dash_report', 'dash_apps', 'dash_users', 'dash_roles',
+  'dict_self_admin_up', 'dict_self_admin_down',
+  'dict_paper_encoded_up', 'dict_paper_encoded_down',
+  'dict_capi_up', 'dict_capi_down',
+] as const;
+
+export type PermissionSet = Record<string, boolean>;
+
+/** Project a resolved F2_Roles row into a boolean perm map (advisory, UI-only). */
+export function projectPermissions(role: Record<string, unknown>): PermissionSet {
+  const out: PermissionSet = {};
+  for (const k of PERM_KEYS) out[k] = !!role[k];
+  return out;
+}
+```
+
+Extend the success contract:
+
+```ts
+interface LoginSuccess {
+  token: string;
+  role: string;
+  role_version: number;
+  expires_at: number;
+  password_must_change: boolean;
+  permissions: PermissionSet; // NEW — advisory nav-gating hint
+}
+```
+
+In `handleLogin`, after the role is resolved (the `role` object already exists for `role.version`), set `permissions: projectPermissions(role)` on the returned `success`.
+
+In `handleChangeMyPassword`, the same `LoginSuccess` is returned after the JWT re-mint and the role is re-resolved (`rolesResp` → `role`); set `permissions: projectPermissions(role)` there too, so a post-rotation client keeps a consistent perm map without a re-login.
+
+> Both handlers already fetch roles and find the role row; this adds one pure projection call and one response field. ~15 lines total.
+
+### 4.2 Worker tests (`test/admin/handlers/auth.test.ts`)
+- `handleLogin` returns `permissions` reflecting the role's columns for a **built-in** role (e.g. Administrator → all true) **and** a **custom** role (e.g. a role with only `dash_data` true → `{dash_data:true, dash_report:false, …}`).
+- `handleChangeMyPassword` returns `permissions` for the resolved role.
+- `projectPermissions` unit: ignores non-perm columns, coerces truthy/falsy to boolean.
+
+---
+
+## 5. Frontend changes
+
+### 5.1 `app/src/admin/lib/auth-context.tsx`
+- `AdminLoginResponse` gains `permissions?: Record<string, boolean>` (optional → backward-compatible with an old Worker).
+- `AdminAuthState` gains `permissions: Record<string, boolean> | null` (default `null` in `INITIAL_STATE`).
+- `setAuth` stores `resp.permissions ?? null`.
+- `useAdminAuth()` already spreads state, so `permissions` is exposed automatically.
+
+### 5.2 `app/src/admin/Layout.tsx`
+
+Add `requiredPerm` to `NavItemSpec` and tag each item (Help omits it → always visible):
+
+```ts
+interface NavItemSpec { to: string; label: string; description: string;
+  icon: (props: SVGProps<SVGSVGElement>) => JSX.Element; requiredPerm?: string; }
+```
+
+| Nav item | `to` | `requiredPerm` |
+|---|---|---|
+| Data | `/admin/data` | `dash_data` |
+| Reports | `/admin/report` | `dash_report` |
+| Encode | `/admin/encode` | `dict_paper_encoded_up` |
+| Apps & Settings | `/admin/apps` | `dash_apps` |
+| Users | `/admin/users` | `dash_users` |
+| Roles | `/admin/roles` | `dash_roles` |
+| Help | `/admin/help` | *(none — always visible)* |
+
+Filter at the render callsite, with the **graceful-degradation default**:
+
+```ts
+const { permissions } = useAdminAuth();
+const canSee = (item: NavItemSpec) =>
+  !item.requiredPerm ||           // Help, etc. — always visible
+  permissions === null ||         // old client / Worker didn't send perms → show all
+  permissions[item.requiredPerm]; // role grants it
+// ...
+NAV_GROUPS
+  .map((g) => ({ ...g, items: g.items.filter(canSee) }))
+  .filter((g) => g.items.length > 0)   // hide a group whose eyebrow header would be orphaned
+  .map((group) => ( /* existing render */ ))
+```
+
+The mobile `FLAT_NAV` strip applies the same `canSee` filter.
+
+### 5.3 Frontend tests (`Layout.test.tsx`)
+- Renders only items whose `requiredPerm` is `true` in `permissions`; an item whose perm is `false` is **absent**.
+- **Help is always rendered**, regardless of perms.
+- `permissions === null` → **all** items render (graceful degradation).
+- A group whose items all filter out → its eyebrow header is **not** rendered.
+
+---
+
+## 6. Security posture
+
+- **Advisory only.** The perm map gates *visibility*, never *access*. `rbac.ts requirePerm` is unchanged and remains the sole authorization gate; every protected route still calls it.
+- **Fail-open nav / fail-closed enforcement.** Missing/null/tampered perms → the nav shows the item (no worse than today). The server still 403s the actual request. There is no path where hiding fails *open* on enforcement.
+- **No new trust.** The client already receives `role` + `role_version`; it now also receives the boolean projection of that role's perm columns — strictly less sensitive than the role name it already holds. Nothing secret is exposed.
+
+---
+
+## 7. Edge cases
+
+- **Custom roles** — handled natively: `permissions` is the projection of the *resolved* role row, not a built-in assumption.
+- **Demoted mid-session** — the nav reflects login-time perms. When a role's perms change, `F2_Roles.version` bumps; the stale-`role_version` JWT is rejected (`E_AUTH_EXPIRED`) on the next gated request or within the 5-min `RoleVersionCache` TTL → re-login → fresh perm map. The menu does **not** live-update (a demoted user briefly still sees, e.g., the Users link), but clicking it 403s and redirects — **cosmetic lag, no security impact**. This is the accepted behavior from the issue's first triage (option 1); live menu refresh would be the `/me/permissions` follow-up.
+- **JWT** — untouched (size, claims, verify path all unchanged).
+- **Old client / version skew** — fully backward-compatible **both** directions. New Worker + old frontend: extra field ignored, shows all (today's behavior). New frontend + old Worker: `permissions` absent → `null` → shows all.
+- **Unauthenticated** — unchanged. The existing Help-only branch renders only Help; the filter runs only on the authenticated branch.
+
+---
+
+## 8. Scope
+
+**IN:** coarse **top-level** nav gating — one `requiredPerm` per sidebar item.
+
+**OUT (clearly-scoped follow-up):** intra-page **sub-tab** gating. The **Data** page aggregates Responses/Audit/DLQ/HCWs and the **Apps & Settings** page aggregates Files/DataSettings/Versioning/Kill-switch/Quota. Today every sub-tab under a page shares that page's single perm (`dash_data` / `dash_apps`), so there is nothing finer to gate **without first introducing new perm columns** in `F2_Roles`. That is a larger schema + RBAC change; it is not required to ship FX-002. When it happens, the same `permissions` map extends to it and the gate attaches at each page's tab bar.
+
+---
+
+## 9. Test plan (summary)
+
+| Layer | Assertion |
+|---|---|
+| Worker | login + change-password return `permissions` matching the role columns (built-in **and** custom role); `projectPermissions` ignores non-perm columns |
+| Frontend | nav filtered by perm map; Help always shown; `permissions===null` shows all; false-perm item absent; empty group header hidden; mobile strip filtered identically |
+| Manual | log in as a custom role granting only `dash_data` → sidebar shows only **Data** + **Help**; the rest are hidden; direct-navigating to a hidden route still 403s (server authority intact) |
+
+---
+
+## 10. Rollout
+
+- **Backward-compatible**, **no migration**, **no JWT change**, **no AS change**.
+- Ship Worker + frontend together or in either order — version skew degrades to "show all," which is exactly today's behavior.
+- Single PR: `auth.ts` (PERM_KEYS + projection + 2 response fields) + `auth-context.tsx` (1 field) + `Layout.tsx` (requiredPerm tags + filter) + tests.
+- Effort: ~½ day. The diff is small; the value is the closed cosmetic gap and a clean, server-authoritative perm surface that the sub-tab follow-up can reuse.
+
+---
+
+### Appendix — files touched
+
+| File | Change |
+|---|---|
+| `worker/src/admin/handlers/auth.ts` | `PERM_KEYS`, `projectPermissions`, `LoginSuccess.permissions`, set in `handleLogin` + `handleChangeMyPassword` |
+| `worker/test/admin/handlers/auth.test.ts` | login/change-pw return perms; projection unit |
+| `app/src/admin/lib/auth-context.tsx` | `AdminLoginResponse.permissions?`, `AdminAuthState.permissions`, store in `setAuth` |
+| `app/src/admin/Layout.tsx` | `NavItemSpec.requiredPerm`, route→perm tags, `canSee` filter + empty-group hide (desktop + mobile) |
+| `app/src/admin/Layout.test.tsx` (new/extended) | nav-gating behavior |
+</content>

--- a/deliverables/F2/PWA/app/src/admin/Layout.test.tsx
+++ b/deliverables/F2/PWA/app/src/admin/Layout.test.tsx
@@ -40,7 +40,9 @@ function renderAuthedLayout(permissions?: Record<string, boolean>) {
   return render(
     <AdminAuthProvider>
       <RouterProvider>
-        <AuthPrime permissions={permissions}>
+        {/* Conditional spread: under exactOptionalPropertyTypes, passing an
+            explicit `undefined` to an optional prop is a type error. */}
+        <AuthPrime {...(permissions ? { permissions } : {})}>
           <Layout>
             <section>
               <h2>Content</h2>

--- a/deliverables/F2/PWA/app/src/admin/Layout.test.tsx
+++ b/deliverables/F2/PWA/app/src/admin/Layout.test.tsx
@@ -13,8 +13,15 @@ import { Layout } from './Layout';
 import { AdminAuthProvider, useAdminAuth } from './lib/auth-context';
 import { RouterProvider } from './lib/pages-router';
 
-/** Primes the auth context to an authenticated state before children render. */
-function AuthPrime({ children }: { children: React.ReactNode }): JSX.Element | null {
+/** Primes the auth context to an authenticated state before children render.
+ * `permissions` is optional (omitted → the Worker sent none → null → show all). */
+function AuthPrime({
+  children,
+  permissions,
+}: {
+  children: React.ReactNode;
+  permissions?: Record<string, boolean>;
+}): JSX.Element | null {
   const { setAuth, isAuthenticated } = useAdminAuth();
   useEffect(() => {
     setAuth('kidd_admin', {
@@ -23,16 +30,17 @@ function AuthPrime({ children }: { children: React.ReactNode }): JSX.Element | n
       role_version: 0,
       expires_at: Math.floor(Date.now() / 1000) + 3600,
       password_must_change: false,
+      ...(permissions ? { permissions } : {}),
     });
-  }, [setAuth]);
+  }, [setAuth, permissions]);
   return isAuthenticated ? <>{children}</> : null;
 }
 
-function renderAuthedLayout() {
+function renderAuthedLayout(permissions?: Record<string, boolean>) {
   return render(
     <AdminAuthProvider>
       <RouterProvider>
-        <AuthPrime>
+        <AuthPrime permissions={permissions}>
           <Layout>
             <section>
               <h2>Content</h2>
@@ -42,6 +50,11 @@ function renderAuthedLayout() {
       </RouterProvider>
     </AdminAuthProvider>,
   );
+}
+
+/** Count nav links (desktop + mobile both render under JSDOM) for an item label. */
+function navLinkCount(label: string): number {
+  return screen.queryAllByRole('link', { name: new RegExp(`^${label} —`) }).length;
 }
 
 describe('<Layout /> — #328 username change-password entry point', () => {
@@ -59,5 +72,46 @@ describe('<Layout /> — #328 username change-password entry point', () => {
   it('keeps Sign out as a separate control', () => {
     renderAuthedLayout();
     expect(screen.getAllByRole('button', { name: /sign out/i }).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('<Layout /> — FX-002 (#324) role-aware nav gating', () => {
+  it('shows only the items the role permits, plus the always-on Help', () => {
+    // A custom role granting only dash_data.
+    renderAuthedLayout({ dash_data: true });
+    expect(navLinkCount('Data')).toBeGreaterThanOrEqual(1);
+    expect(navLinkCount('Help')).toBeGreaterThanOrEqual(1); // no requiredPerm → always
+    // Everything the role lacks is hidden.
+    expect(navLinkCount('Reports')).toBe(0); // dash_report
+    expect(navLinkCount('Encode')).toBe(0); // dict_paper_encoded_up
+    expect(navLinkCount('Apps & Settings')).toBe(0); // dash_apps
+    expect(navLinkCount('Users')).toBe(0); // dash_users
+    expect(navLinkCount('Roles')).toBe(0); // dash_roles
+  });
+
+  it('hides a group whose every item filters out (orphaned eyebrow header)', () => {
+    // dash_data is in the Operate group, so Configure (apps/users/roles) is empty.
+    renderAuthedLayout({ dash_data: true });
+    expect(screen.getByText('Operate')).toBeInTheDocument();
+    expect(screen.queryByText('Configure')).toBeNull();
+  });
+
+  it('shows everything when permissions are unknown (null → graceful degradation)', () => {
+    // No permissions field → the Worker didn't send one; the server still
+    // enforces 403, so the nav fails open (shows all) rather than hiding work.
+    renderAuthedLayout();
+    for (const label of ['Data', 'Reports', 'Encode', 'Apps & Settings', 'Users', 'Roles', 'Help']) {
+      expect(navLinkCount(label)).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('renders the full set for a perms map that grants everything', () => {
+    renderAuthedLayout({
+      dash_data: true, dash_report: true, dash_apps: true,
+      dash_users: true, dash_roles: true, dict_paper_encoded_up: true,
+    });
+    for (const label of ['Data', 'Reports', 'Encode', 'Apps & Settings', 'Users', 'Roles', 'Help']) {
+      expect(navLinkCount(label)).toBeGreaterThanOrEqual(1);
+    }
   });
 });

--- a/deliverables/F2/PWA/app/src/admin/Layout.tsx
+++ b/deliverables/F2/PWA/app/src/admin/Layout.tsx
@@ -46,6 +46,10 @@ interface NavItemSpec {
   label: string;
   description: string;
   icon: (props: SVGProps<SVGSVGElement>) => JSX.Element;
+  // FX-002 (#324): the RBAC perm a role needs for this item to be useful.
+  // Omitted = always visible (e.g. Help). The Worker enforces actual access;
+  // this only hides controls the current role can't use.
+  requiredPerm?: string;
 }
 
 interface NavGroup {
@@ -62,12 +66,14 @@ const NAV_GROUPS: NavGroup[] = [
         label: 'Data',
         description: 'Submissions, audit log, DLQ, HCWs registry — day-to-day operations.',
         icon: IconTable,
+        requiredPerm: 'dash_data',
       },
       {
         to: '/admin/report',
         label: 'Reports',
         description: 'Coverage by region/province/facility + geographic Map Report.',
         icon: IconChart,
+        requiredPerm: 'dash_report',
       },
       {
         to: '/admin/encode',
@@ -75,6 +81,7 @@ const NAV_GROUPS: NavGroup[] = [
         description:
           'Paper-response transcription flow. Used when an HCW completed the survey on paper.',
         icon: IconEdit,
+        requiredPerm: 'dict_paper_encoded_up',
       },
     ],
   },
@@ -87,18 +94,21 @@ const NAV_GROUPS: NavGroup[] = [
         description:
           'Build versions, file uploads, scheduled break-out exports, Apps Script quota.',
         icon: IconSliders,
+        requiredPerm: 'dash_apps',
       },
       {
         to: '/admin/users',
         label: 'Users',
         description: 'CRUD for ops staff accounts. Bulk-import for new cohorts.',
         icon: IconUsers,
+        requiredPerm: 'dash_users',
       },
       {
         to: '/admin/roles',
         label: 'Roles',
         description: 'Permission matrix editor. Built-in + custom roles.',
         icon: IconShield,
+        requiredPerm: 'dash_roles',
       },
     ],
   },
@@ -118,7 +128,7 @@ const NAV_GROUPS: NavGroup[] = [
 const FLAT_NAV: NavItemSpec[] = NAV_GROUPS.flatMap((g) => g.items);
 
 export function Layout({ children }: LayoutProps): JSX.Element {
-  const { username, role, clearAuth, isAuthenticated } = useAdminAuth();
+  const { username, role, clearAuth, isAuthenticated, permissions } = useAdminAuth();
   const { navigate } = useRouter();
 
   const onLogout = () => {
@@ -127,6 +137,15 @@ export function Layout({ children }: LayoutProps): JSX.Element {
   };
 
   const initial = (username ?? '—').slice(0, 1).toUpperCase();
+
+  // FX-002 (#324): show an item when it needs no perm (Help), when perms are
+  // unknown (null → graceful degradation, since the Worker still enforces
+  // 403), or when the current role grants its perm.
+  const canSee = (item: NavItemSpec): boolean =>
+    !item.requiredPerm || permissions === null || !!permissions[item.requiredPerm];
+  const visibleGroups = NAV_GROUPS
+    .map((g) => ({ ...g, items: g.items.filter(canSee) }))
+    .filter((g) => g.items.length > 0);
 
   return (
     <div className="flex h-screen-dvh w-full flex-col overflow-hidden md:flex-row">
@@ -150,7 +169,7 @@ export function Layout({ children }: LayoutProps): JSX.Element {
 
         <nav className="flex flex-1 flex-col gap-4 overflow-y-auto py-2">
           {isAuthenticated
-            ? NAV_GROUPS.map((group) => (
+            ? visibleGroups.map((group) => (
                 <div key={group.title} className="flex flex-col">
                   <p className="px-5 pb-1 pt-2 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
                     {group.title}
@@ -276,7 +295,7 @@ export function Layout({ children }: LayoutProps): JSX.Element {
         </div>
         {isAuthenticated && (
           <nav className="flex flex-wrap gap-x-4 gap-y-2 text-sm" aria-label="Primary (mobile)">
-            {FLAT_NAV.map((item) => (
+            {FLAT_NAV.filter(canSee).map((item) => (
               <MobileNavLink key={item.to} item={item} />
             ))}
           </nav>

--- a/deliverables/F2/PWA/app/src/admin/lib/auth-context.tsx
+++ b/deliverables/F2/PWA/app/src/admin/lib/auth-context.tsx
@@ -19,6 +19,10 @@ export interface AdminAuthState {
   roleVersion: number | null;
   expiresAt: number | null;
   passwordMustChange: boolean;
+  // FX-002 (#324): advisory perm map for nav gating. null = unknown (logged
+  // out, or the Worker didn't send it) → callers treat null as "show all"
+  // since the Worker still enforces 403 on the actual request.
+  permissions: Record<string, boolean> | null;
 }
 
 const INITIAL_STATE: AdminAuthState = {
@@ -28,6 +32,7 @@ const INITIAL_STATE: AdminAuthState = {
   roleVersion: null,
   expiresAt: null,
   passwordMustChange: false,
+  permissions: null,
 };
 
 export interface AdminLoginResponse {
@@ -36,6 +41,8 @@ export interface AdminLoginResponse {
   role_version: number;
   expires_at: number;
   password_must_change: boolean;
+  // Optional so an older Worker (no permissions field) degrades gracefully.
+  permissions?: Record<string, boolean>;
 }
 
 export interface AdminAuthApi extends AdminAuthState {
@@ -57,6 +64,7 @@ export function AdminAuthProvider({ children }: { children: ReactNode }): JSX.El
       roleVersion: resp.role_version,
       expiresAt: resp.expires_at,
       passwordMustChange: resp.password_must_change,
+      permissions: resp.permissions ?? null,
     });
   }, []);
 

--- a/deliverables/F2/PWA/worker/src/admin/handlers/auth.ts
+++ b/deliverables/F2/PWA/worker/src/admin/handlers/auth.ts
@@ -55,6 +55,33 @@ export interface AdminRoleRow {
   [perm: string]: unknown;
 }
 
+// FX-002 (#324): the RBAC permission columns on F2_Roles, in display order.
+// Single source of truth for what the client may learn about its OWN role —
+// an advisory, UI-only hint for nav gating. Keep in sync with the F2_Roles
+// schema (Migrations.js) and the rbac.ts perm checks. Deliberately excludes
+// the non-perm columns (name, is_builtin, version, created_at, created_by) so
+// the projection never leaks metadata or a future non-perm column.
+export const PERM_KEYS = [
+  'dash_data', 'dash_report', 'dash_apps', 'dash_users', 'dash_roles',
+  'dict_self_admin_up', 'dict_self_admin_down',
+  'dict_paper_encoded_up', 'dict_paper_encoded_down',
+  'dict_capi_up', 'dict_capi_down',
+] as const;
+
+export type PermissionSet = Record<string, boolean>;
+
+/**
+ * Project a resolved F2_Roles row into a boolean perm map. ADVISORY ONLY —
+ * the client uses it to hide nav controls it can't use; the Worker's
+ * requirePerm (rbac.ts) remains the sole authorization gate. Coerces each
+ * perm cell to a strict boolean.
+ */
+export function projectPermissions(role: Record<string, unknown>): PermissionSet {
+  const out: PermissionSet = {};
+  for (const k of PERM_KEYS) out[k] = !!role[k];
+  return out;
+}
+
 export type UsersListFn = () => Promise<AppsScriptResponse<{ users: AdminUserRow[] }>>;
 export type RolesListFn = () => Promise<AppsScriptResponse<{ roles: AdminRoleRow[] }>>;
 
@@ -99,6 +126,9 @@ interface LoginSuccess {
   role_version: number;
   expires_at: number;
   password_must_change: boolean;
+  // FX-002 (#324): advisory perm map for client-side nav gating. The server
+  // (rbac.ts) stays authoritative; this only hides controls the role can't use.
+  permissions: PermissionSet;
 }
 
 function errorJson(code: string, message: string, status: number, headers: Record<string, string> = {}): Response {
@@ -234,6 +264,7 @@ export async function handleLogin(
     role_version: role.version,
     expires_at: expiresAt,
     password_must_change: isTruthy(user.password_must_change),
+    permissions: projectPermissions(role),
   };
   return jsonResponse(success, 200);
 }
@@ -412,6 +443,7 @@ export async function handleChangeMyPassword(
     role_version: role.version,
     expires_at: expiresAt,
     password_must_change: false,
+    permissions: projectPermissions(role),
   };
   return jsonResponse(success, 200);
 }

--- a/deliverables/F2/PWA/worker/test/admin/handlers/auth.test.ts
+++ b/deliverables/F2/PWA/worker/test/admin/handlers/auth.test.ts
@@ -14,6 +14,8 @@ import {
   handleLogin,
   handleLogout,
   handleChangeMyPassword,
+  projectPermissions,
+  PERM_KEYS,
   type AuthAuditCtx,
   type ChangeMyPasswordAsCallable,
   type LastLoginFn,
@@ -139,6 +141,14 @@ describe('handleLogin', () => {
     expect(body.role_version).toBe(1);
     expect(body.password_must_change).toBe(false);
     expect(body.expires_at).toBeGreaterThan(before);
+
+    // FX-002 (#324): the advisory perm map reflects this role's columns.
+    const withPerms = body as unknown as { permissions: Record<string, boolean> };
+    expect(withPerms.permissions.dash_data).toBe(true); // Administrator fixture grants dash_data
+    expect(withPerms.permissions.dash_users).toBe(false); // fixture doesn't grant it
+    // It only carries the known perm keys — never leaks non-perm columns.
+    expect(Object.keys(withPerms.permissions).sort()).toEqual([...PERM_KEYS].sort());
+    expect(withPerms.permissions).not.toHaveProperty('manage_users');
 
     // Token verifies and carries the expected claims.
     const v = await verifyAdminJwt(KEY, body.token);
@@ -600,6 +610,9 @@ describe('handleChangeMyPassword — R2-#134', () => {
     expect(body.role).toBe('Administrator');
     expect(body.role_version).toBe(1);
     expect(body.token).toMatch(/.+\..+\..+/);
+    // FX-002 (#324): the re-mint response also carries the perm map so a
+    // post-rotation client keeps consistent nav gating without re-login.
+    expect((body as unknown as { permissions: Record<string, boolean> }).permissions.dash_data).toBe(true);
 
     // AS RPC was called with the freshly-hashed new password (not equal to
     // the input), and with the actor's username from the JWT.
@@ -643,5 +656,50 @@ describe('handleChangeMyPassword — R2-#134', () => {
     expect(ctx.event_type).toBe('admin_password_change');
     expect(ctx.actor_username).toBe('alice');
     expect(ctx.client_ip_hash).toBe('iphash-9');
+  });
+});
+
+// FX-002 (#324): advisory permission-set projection for nav gating.
+describe('projectPermissions', () => {
+  it('projects exactly the known perm keys, coercing each to boolean', () => {
+    const role = {
+      name: 'Custom', version: 3, is_builtin: false, created_by: 'admin', created_at: 'x',
+      dash_data: true, dash_report: 1, dash_apps: '', dash_users: 0, dash_roles: undefined,
+      dict_paper_encoded_up: 'yes',
+    } as Record<string, unknown>;
+    const perms = projectPermissions(role);
+    // Only perm keys — never the metadata columns.
+    expect(Object.keys(perms).sort()).toEqual([...PERM_KEYS].sort());
+    expect(perms).not.toHaveProperty('name');
+    expect(perms).not.toHaveProperty('is_builtin');
+    expect(perms).not.toHaveProperty('created_by');
+    // Strict boolean coercion.
+    expect(perms.dash_data).toBe(true);
+    expect(perms.dash_report).toBe(true); // 1 → true
+    expect(perms.dash_apps).toBe(false); // '' → false
+    expect(perms.dash_users).toBe(false); // 0 → false
+    expect(perms.dash_roles).toBe(false); // undefined → false
+    expect(perms.dict_paper_encoded_up).toBe(true); // 'yes' → true
+  });
+
+  it('a custom role grants only the perms its row sets', async () => {
+    const kv = makeKv();
+    const env = { JWT_SIGNING_KEY: KEY, F2_AUTH: kv as unknown as KVNamespace };
+    const user = await makeUser('reader', 'CorrectPw1', 'Read Only', false);
+    const customRoles = [{ name: 'Read Only', version: 1, dash_data: true, dash_report: true }];
+    const r = await handleLogin(
+      { username: 'reader', password: 'CorrectPw1' },
+      'iphash-fx002',
+      env,
+      async () => ({ ok: true, data: { users: [user] } }),
+      async () => ({ ok: true, data: { roles: customRoles } }),
+    );
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { permissions: Record<string, boolean> };
+    expect(body.permissions.dash_data).toBe(true);
+    expect(body.permissions.dash_report).toBe(true);
+    expect(body.permissions.dash_apps).toBe(false);
+    expect(body.permissions.dash_users).toBe(false);
+    expect(body.permissions.dash_roles).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes #324 (FX-002). Hides sidebar controls the current role can't use — the cosmetic enhancement that was **design-blocked** because custom roles exist (the frontend can't hardcode which items to show). Design spec committed at `deliverables/F2/PWA/2026-06-02-fx-002-permission-set-design.md`.

## Approach

Surface the user's **resolved permission set in the login response body** (and the change-password re-mint), store it in the in-memory admin auth context, and filter `NAV_GROUPS` against it. `handleLogin` *already* resolves the full `F2_Roles` row (it reads `role.version` for the JWT), so projecting the perm columns is a pure, near-zero-cost addition. The admin JWT is in-memory only, so the perm map has the **same lifecycle** as the token.

**No JWT change · no new endpoint · no Apps Script change · no migration.**

Rejected alternatives: JWT-claim (bloat, no persistence benefit on an in-memory token); dedicated `/me/permissions` endpoint (extra round-trip for data login already has — noted as the extension point if live mid-session refresh is ever wanted).

## Backend — `worker/src/admin/handlers/auth.ts`
- `PERM_KEYS` (the 11 `F2_Roles` perm columns) + `projectPermissions(role)` → `Record<string, boolean>` (strict boolean coercion; excludes `name`/`is_builtin`/`version`/`created_*` so it never leaks metadata).
- `LoginSuccess.permissions`, set in `handleLogin` **and** `handleChangeMyPassword`.

## Frontend
- `auth-context`: `AdminLoginResponse.permissions?` + `AdminAuthState.permissions` (stored in `setAuth`; `null` when absent).
- `Layout`: `NavItemSpec.requiredPerm` per item; `canSee` filter on desktop groups + mobile strip; empty groups hide their eyebrow header.

| Item | requiredPerm |
|---|---|
| Data | `dash_data` |
| Reports | `dash_report` |
| Encode | `dict_paper_encoded_up` |
| Apps & Settings | `dash_apps` |
| Users | `dash_users` |
| Roles | `dash_roles` |
| Help | *(none — always visible)* |

## Security
Advisory **UI-only** — `rbac.ts requirePerm` stays the sole authorization gate (unchanged). **Fail-open nav** (null/missing perms → show all) + **fail-closed enforcement** (server 403). A user who hand-edits their in-memory perms to reveal a hidden link gains nothing — the actual request is still rejected. Custom roles work natively (projection of the resolved role). Demoted-mid-session is handled by the existing `role_version` invalidation (≤5-min TTL / next-gated-request re-login) — cosmetic lag only.

## Scope
Coarse **top-level** nav gating **in**. Intra-page **sub-tab** gating **out** — it would need new `F2_Roles` perm columns (the Data/Apps pages' sub-tabs all share one perm today). Noted as a clearly-scoped follow-up; the same perm map extends to it.

## Rollout
Backward-compatible **both directions** — version skew degrades to "show all" = today's behavior. Ship Worker + frontend in any order.

## Test plan
- [x] Worker: `handleLogin` + `handleChangeMyPassword` return `permissions` for built-in **and** custom roles; `projectPermissions` key-set + boolean coercion (worker 219 pass)
- [x] Frontend: only-permitted items shown; Help always; empty-group header hidden; `null` → show all; all-perms → full set (app Layout 6/6)
- [x] `tsc` (app + worker) + eslint clean
- [ ] Manual: log in as a custom role granting only `dash_data` → sidebar shows only **Data** + **Help**; direct-navigating to a hidden route still 403s (server authority intact)

> Note: 1 pre-existing `MultiSectionForm` flake times out only under full-suite load (a survey component untouched here; passes in isolation).