### PR TITLE
qa(capi): CAPI bug-report template + handoff workflow (#197)

### DIFF
--- a/.github/ISSUE_TEMPLATE/capi_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/capi_bug_report.yml
@@ -1,0 +1,117 @@
+name: CAPI Bug Report (F1 / F3 / F4)
+description: Report a defect found while desk-testing or running the CSPro/CSEntry CAPI instruments
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For the **CSPro/CSEntry** instruments (F1 Facility Head, F3 Patient, F4 Household).
+        For the F2 Healthcare-Worker PWA, use **Bug Report** instead.
+        Fill every field — a complete report is fixed (at the generator) and re-flighted faster.
+
+  - type: dropdown
+    id: instrument
+    attributes:
+      label: Instrument
+      options:
+        - F1 — Facility Head
+        - F3 — Patient
+        - F4 — Household
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Where (section + question / PROC)
+      placeholder: 'e.g. Section F, Q121 (Q121_DOH_LIC_DIFFICULT) — or a PROC name from a compile error'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: context
+    attributes:
+      label: Test context
+      options:
+        - Designer compile (Build → Compile)
+        - Desk test (DCF + FMF walkthrough in CSEntry)
+        - CSEntry smoke test (cover → last question)
+        - Sync round-trip (tablet → CSWeb)
+        - Pretest pilot (live, real respondents)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: bugtype
+    attributes:
+      label: Bug type
+      description: The triager maps this to a `type:` label.
+      options:
+        - Skip logic — wrong routing / skip target
+        - Validation — hard / soft / gate behaves wrong
+        - GPS or photo capture
+        - Roster / occurrence flow (F4)
+        - PSGC cascade (region → province → city → barangay)
+        - Sync / CSWeb
+        - Display / form layout
+        - Question text / value set / translation
+        - Designer compile error
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open the <instrument> app in CSEntry
+        2. Start a case with questionnaire number "…"
+        3. At Q__, answer "…"
+        4. …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: 'What should have happened per the skip-logic/validation spec? (e.g. "Q__ = No should skip to Q__")'
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What actually happened? Paste the exact Designer/CSEntry message (PROC name + line) for a compile error.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical — data loss, case won't save/sync, or cannot proceed through the interview
+        - High — wrong skip or validation (wrong data captured), interview still completes
+        - Medium — display / form-layout / UX issue; data captured correctly
+        - Low — cosmetic, typo, or label wording
+    validations:
+      required: true
+
+  - type: input
+    id: env
+    attributes:
+      label: Tablet + version
+      placeholder: 'e.g. Samsung Tab A9, CSEntry 8.0, app built from <date> generated artifacts'
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or screen recording
+      placeholder: Drag and drop images here (a photo of the CSEntry/Designer screen), or paste a link.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: UAT Guide
+  - name: UAT Guide (F2 PWA)
     url: https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/blob/main/docs/F2-PWA-UAT-Guide.md
-    about: Read the test scenarios before filing feedback
+    about: Read the test scenarios before filing F2 feedback
+  - name: CAPI QA Handoff Workflow (F1/F3/F4)
+    url: https://github.com/cplreyes/ASPSI-DOH-UHC-CAPI-Development/blob/main/docs/CAPI-QA-Handoff-Workflow.md
+    about: F1/F3/F4 bug reporting — severity rubric, labels, and the generator-fix flow

--- a/docs/CAPI-QA-Handoff-Workflow.md
+++ b/docs/CAPI-QA-Handoff-Workflow.md
@@ -1,0 +1,97 @@
+---
+type: deliverable
+kind: qa-workflow
+audience: Shan (QA tester) · Carl (data programmer) · ASPSI data manager (triager)
+prepared_by: Carl Patrick L. Reyes
+date_drafted: 2026-06-03
+status: draft-for-review
+related_task: E6-CAPI-005
+companion_to:
+  - .github/ISSUE_TEMPLATE/capi_bug_report.yml
+tags: [qa, capi, testing, bug-triage, handoff, e6]
+---
+
+# CAPI QA Handoff Workflow (F1 / F3 / F4)
+
+Extends the F2 PWA QA tester workflow to the **CSPro/CSEntry CAPI instruments**. Defines how desk-test + pretest defects get **reported, triaged, fixed, and re-verified** — and the one thing that makes CAPI different from the PWA: **fixes go through the generator, never the `.apc` by hand.**
+
+> **Why a separate flow.** The F2 PWA fix path is *edit code → PR → deploy*. The CAPI fix path is *edit `generate_*.py` → regenerate → pre-flight → Designer compile → re-test*. Same triage + severity + labels; different fix mechanics. This doc + `capi_bug_report.yml` are the CAPI half of the QA system.
+
+---
+
+## 1. Roles
+
+| Role | In this workflow |
+|---|---|
+| **QA tester (Shan)** | Runs the desk-test / smoke-test / pretest scenarios; files each defect via the **CAPI Bug Report** template; re-verifies fixes. |
+| **Triager (data manager)** | Labels each report (epic + type + severity + source); assigns to the fix batch. |
+| **Data programmer (Carl)** | Fixes at the **generator**, regenerates, re-runs pre-flight, hands back a compiled build; marks `status:fixed-pending-verify`. |
+
+---
+
+## 2. The loop
+
+```
+tester runs a scenario
+   └─> files a CAPI Bug Report (.github template)        [label: bug]
+        └─> triager adds:  epic:f1|f3|f4 · type:* · severity:* · from-capi-desk-test|from-capi-pretest
+             └─> Carl fixes at generate_apc.py / generate_dcf.py  (NEVER the .apc/.dcf by hand)
+                  └─> regenerate → `python preflight_validate.py` (exit 0) → Designer compile
+                       └─> label status:fixed-pending-verify, comment the build date
+                            └─> tester re-runs the same scenario
+                                 ├─ passes → close
+                                 └─ fails  → reopen / comment, back to Carl
+```
+
+---
+
+## 3. Severity rubric (CAPI)
+
+Mirrors the F2 rubric, with CAPI examples. The tester picks it in the template; the triager applies the matching `severity:` label.
+
+| Severity | Means | CAPI examples |
+|---|---|---|
+| **Critical** (`severity:critical`) | Data loss, case won't save/sync, or the interview can't proceed | Case won't accept/save; sync fails for all cases; a Designer **compile error** blocks the build; consent/eligibility gate doesn't fire |
+| **High** (`severity:high`) | Wrong data captured — interview still completes | Skip routes to the wrong question; a hard validation accepts an out-of-range value (or blocks a valid one); PSGC cascade allows a mismatched barangay; F4 roster loses/duplicates a member |
+| **Medium** (`severity:medium`) | Display / layout / UX; data is captured correctly | Question shows on the wrong screen; a label is truncated; a soft warning's wording is unclear |
+| **Low** (`severity:low`) | Cosmetic | Typo, spacing, label wording |
+
+---
+
+## 4. Label taxonomy (reuse the F2 scheme)
+
+- **Instrument:** `epic:f1` · `epic:f3` · `epic:f4`
+- **Type** (from the template's Bug type): `type:skip-logic` · `type:validation` · `type:sync` · `type:visual` · `type:i18n` — plus, for CAPI specifics, propose adding **`type:roster`** (F4 occurrence flow), **`type:gps-photo`**, **`type:psgc`**, **`type:compile`**.
+- **Severity:** `severity:critical|high|medium|low`
+- **Source:** propose adding **`from-capi-desk-test`** and **`from-capi-pretest`** (parallel to the existing `from-uat-round-N-YYYY-MM`).
+- **Status:** `status:investigating` · `status:fixed-pending-verify` · `status:blocked` (e.g. waiting on a questionnaire-design decision → also tag `design-decision`).
+
+> **Milestone:** group a fix sweep as a milestone (e.g. *CAPI desk-test fix batch 1*) so the pretest debrief (#199) can point at a closed batch — mirrors the F2 `v1.3.x` batch pattern.
+
+---
+
+## 5. The generator-fix rule (the CAPI-specific discipline)
+
+When a CAPI bug is real:
+
+1. **Find the source table**, not the symptom: a wrong skip → `SKIP_RULES` / `ROUTING_PROCS` in `deliverables/CSPro/<F>/generate_apc.py`; a wrong item/value set → `generate_dcf.py`; a form-layout issue → `generate_fmf.py` (F3/F4) or the static `.fmf` (F1).
+2. **Edit the generator + regenerate.** Never hand-edit the `.apc`/`.dcf`/`.fmf` in Designer — the next regenerate would silently overwrite it (the generator-over-hand-edit rule).
+3. **Re-run pre-flight:** `python deliverables/CSPro/preflight_validate.py` (exit 0 = symbols resolve) before handing back.
+4. **Designer compile + a quick CSEntry pass**, then `status:fixed-pending-verify` + comment the build date so the tester knows which build to re-test.
+
+---
+
+## 6. Tester quick-start (Shan)
+
+1. Run a scenario from the desk-test plan (#193 F1 / #194 F3 / #195 F4).
+2. Hit something wrong? → **New issue → CAPI Bug Report** → fill instrument, where (Q-number/PROC), context, type, steps, expected vs actual, severity, screenshot.
+3. When a fix lands (`status:fixed-pending-verify`), re-run the **same** scenario on the noted build; comment pass/fail.
+
+---
+
+## Issue coverage
+| Section | Issue |
+|---|---|
+| `.github/ISSUE_TEMPLATE/capi_bug_report.yml` (template) + §3 rubric + §4 labels | #197 (E6-CAPI-005) |
+
+**Operational follow-ups (not blocking this deliverable):** create the proposed `from-capi-*` / `type:roster|gps-photo|psgc|compile` labels in the repo; create the first *CAPI desk-test fix batch* milestone when desk-testing starts (#193–195). Feeds the pretest debrief → Epic 3 fix batch (#199).


### PR DESCRIPTION
Closes #197 (E6-CAPI-005) — extends the F2 QA-tester (Shan) workflow to the CSPro/CSEntry instruments, ready for the F1/F3/F4 desk-tests.

## What's in it
- **`.github/ISSUE_TEMPLATE/capi_bug_report.yml`** — a CAPI bug template (separate from the F2 `bug_report.yml`): instrument (F1/F3/F4), where (section + Q-number / PROC), test context (compile / desk-test / smoke / sync / pretest), bug type, steps, expected vs actual, a **CAPI severity rubric**, tablet + CSEntry version.
- **`docs/CAPI-QA-Handoff-Workflow.md`** — the triage loop, the severity rubric with CAPI examples, the label taxonomy, and the **CAPI-specific fix rule**: defects are fixed at the **generator** (`generate_*.py`) → regenerate → `preflight_validate.py` → Designer compile → `status:fixed-pending-verify` → re-test (never hand-edit the `.apc`/`.dcf`). This is what makes CAPI QA different from the F2 code+PR flow.
- **`config.yml`** — adds a contact link to the workflow doc (so testers find it), relabels the F2 link.

## Labels created (alongside this PR)
`from-capi-desk-test` · `from-capi-pretest` · `type:roster` · `type:gps-photo` · `type:psgc` · `type:compile` — so the taxonomy is live for triage. (Existing `severity:*`, `type:skip-logic/validation/sync`, `epic:f1/f3/f4` are reused.)

## Why now
The F1/F3/F4 Designer compiles + desk-tests in progress will generate exactly the defects this handles — a `type:compile` PROC error or a `type:skip-logic` wrong-route routes straight to a generator fix.

Repo-infra + docs only; no app code.
