### PR TITLE
fix(f2-survey): block Q9 zero-tenure 0y+0m (#305/3a)

### DIFF
--- a/deliverables/F2/PWA/app/src/i18n/locales/bcl.ts
+++ b/deliverables/F2/PWA/app/src/i18n/locales/bcl.ts
@@ -122,6 +122,7 @@ export const bcl: EnBundle = {
   },
   crossField: {
     tenureImplausible: 'Years of service ({{years}}) must be less than your age ({{age}}) minus 20. Please correct your tenure or age.',
+    tenureZero: 'Years and months of service cannot both be zero. Enter at least 1 month of tenure at this facility.',
     specialtyMismatch:
       'Role "{{role}}" does not normally carry a medical specialty ({{specialty}}).',
     employmentClassDerived: 'Derived employment class: {{employmentClass}}.',

--- a/deliverables/F2/PWA/app/src/i18n/locales/bis.ts
+++ b/deliverables/F2/PWA/app/src/i18n/locales/bis.ts
@@ -121,6 +121,7 @@ export const bis: EnBundle = {
   },
   crossField: {
     tenureImplausible: 'Ang gireport nga tenure ({{years}} ka tuig) dili katuohan alang sa edad nga {{age}}.',
+    tenureZero: 'Years and months of service cannot both be zero. Enter at least 1 month of tenure at this facility.',
     specialtyMismatch:
       'Ang tahas nga "{{role}}" kasagaran walay medikal nga espesyalidad ({{specialty}}).',
     employmentClassDerived: 'Gisubay nga klase sa trabaho: {{employmentClass}}.',

--- a/deliverables/F2/PWA/app/src/i18n/locales/ceb.ts
+++ b/deliverables/F2/PWA/app/src/i18n/locales/ceb.ts
@@ -121,6 +121,7 @@ export const ceb: EnBundle = {
   },
   crossField: {
     tenureImplausible: 'Ang gireport nga tenure ({{years}} ka tuig) dili katuohan alang sa edad nga {{age}}.',
+    tenureZero: 'Years and months of service cannot both be zero. Enter at least 1 month of tenure at this facility.',
     specialtyMismatch:
       'Ang papel nga "{{role}}" kasagaran walay medikal nga espesyalidad ({{specialty}}).',
     employmentClassDerived: 'Nakuha nga klase sa empleyo: {{employmentClass}}.',

--- a/deliverables/F2/PWA/app/src/i18n/locales/en.ts
+++ b/deliverables/F2/PWA/app/src/i18n/locales/en.ts
@@ -118,6 +118,7 @@ export const en = {
   },
   crossField: {
     tenureImplausible: 'Years of service ({{years}}) must be less than your age ({{age}}) minus 20. Please correct your tenure or age.',
+    tenureZero: 'Years and months of service cannot both be zero. Enter at least 1 month of tenure at this facility.',
     specialtyMismatch:
       'Role "{{role}}" does not normally carry a medical specialty ({{specialty}}).',
     employmentClassDerived: 'Derived employment class: {{employmentClass}}.',

--- a/deliverables/F2/PWA/app/src/i18n/locales/fil.ts
+++ b/deliverables/F2/PWA/app/src/i18n/locales/fil.ts
@@ -122,6 +122,7 @@ export const fil: EnBundle = {
   crossField: {
     // Updated for the R3 #305 age−20 hard block; Tagalog draft pending ASPSI QC.
     tenureImplausible: 'Ang taon ng serbisyo ({{years}}) ay dapat mas mababa sa iyong edad ({{age}}) na binawasan ng 20. Pakitama ang iyong tenure o edad.',
+    tenureZero: 'Years and months of service cannot both be zero. Enter at least 1 month of tenure at this facility.',
     specialtyMismatch:
       'Ang tungkuling "{{role}}" ay karaniwang walang medikal na specialty ({{specialty}}).',
     employmentClassDerived: 'Hinangong klase ng empleyo: {{employmentClass}}.',

--- a/deliverables/F2/PWA/app/src/i18n/locales/hil.ts
+++ b/deliverables/F2/PWA/app/src/i18n/locales/hil.ts
@@ -122,6 +122,7 @@ export const hil: EnBundle = {
   },
   crossField: {
     tenureImplausible: 'Years of service ({{years}}) must be less than your age ({{age}}) minus 20. Please correct your tenure or age.',
+    tenureZero: 'Years and months of service cannot both be zero. Enter at least 1 month of tenure at this facility.',
     specialtyMismatch:
       'Role "{{role}}" does not normally carry a medical specialty ({{specialty}}).',
     employmentClassDerived: 'Derived employment class: {{employmentClass}}.',

--- a/deliverables/F2/PWA/app/src/i18n/locales/ilo.ts
+++ b/deliverables/F2/PWA/app/src/i18n/locales/ilo.ts
@@ -122,6 +122,7 @@ export const ilo: EnBundle = {
   },
   crossField: {
     tenureImplausible: 'Years of service ({{years}}) must be less than your age ({{age}}) minus 20. Please correct your tenure or age.',
+    tenureZero: 'Years and months of service cannot both be zero. Enter at least 1 month of tenure at this facility.',
     specialtyMismatch:
       'Role "{{role}}" does not normally carry a medical specialty ({{specialty}}).',
     employmentClassDerived: 'Derived employment class: {{employmentClass}}.',

--- a/deliverables/F2/PWA/app/src/i18n/locales/war.ts
+++ b/deliverables/F2/PWA/app/src/i18n/locales/war.ts
@@ -122,6 +122,7 @@ export const war: EnBundle = {
   },
   crossField: {
     tenureImplausible: 'Years of service ({{years}}) must be less than your age ({{age}}) minus 20. Please correct your tenure or age.',
+    tenureZero: 'Years and months of service cannot both be zero. Enter at least 1 month of tenure at this facility.',
     specialtyMismatch:
       'Role "{{role}}" does not normally carry a medical specialty ({{specialty}}).',
     employmentClassDerived: 'Derived employment class: {{employmentClass}}.',

--- a/deliverables/F2/PWA/app/src/lib/cross-field.test.ts
+++ b/deliverables/F2/PWA/app/src/lib/cross-field.test.ts
@@ -36,6 +36,21 @@ describe('evaluateCrossField', () => {
     expect(out.map((w) => w.id)).not.toContain('PROF-01');
   });
 
+  it('flags PROF-05 (error) when both Q9 years and months are zero (#305/3a)', () => {
+    const out = evaluateCrossField({ Q4: 30, Q5: 'Nurse', Q9_1: 0, Q9_2: 0 });
+    expect(out.find((w) => w.id === 'PROF-05')?.severity).toBe('error');
+  });
+
+  it('allows years=0 with months ≥ 1 (valid sub-1-year tenure) — no PROF-05', () => {
+    const out = evaluateCrossField({ Q4: 30, Q5: 'Nurse', Q9_1: 0, Q9_2: 6 });
+    expect(out.map((w) => w.id)).not.toContain('PROF-05');
+  });
+
+  it('does not flag PROF-05 for normal tenure', () => {
+    const out = evaluateCrossField({ Q4: 30, Q5: 'Nurse', Q9_1: 3, Q9_2: 0 });
+    expect(out.map((w) => w.id)).not.toContain('PROF-05');
+  });
+
   it('flags PROF-02 when a non-doctor reports a specialty', () => {
     const out = evaluateCrossField({ Q5: 'Nurse', Q6: 'Pediatrics' });
     expect(out.map((w) => w.id)).toContain('PROF-02');

--- a/deliverables/F2/PWA/app/src/lib/cross-field.ts
+++ b/deliverables/F2/PWA/app/src/lib/cross-field.ts
@@ -102,6 +102,25 @@ export function evaluateCrossField(values: FormValues): Warning[] {
     });
   }
 
+  // R3 #305/3a (Carl 2026-06-03, pending Myra's final confirm): block the
+  // "0 years AND 0 months" tenure combination — a respondent must have worked
+  // some time at the facility. years=0 with months>=1 (valid sub-1-year HCWs)
+  // remains allowed.
+  const tenureMonths = typeof values.Q9_2 === 'number' ? values.Q9_2 : Number(values.Q9_2);
+  if (
+    Number.isFinite(tenureYears) &&
+    Number.isFinite(tenureMonths) &&
+    tenureYears === 0 &&
+    tenureMonths === 0
+  ) {
+    out.push({
+      id: 'PROF-05',
+      severity: 'error',
+      message: { key: 'crossField.tenureZero' },
+      fields: ['Q9_1', 'Q9_2'],
+    });
+  }
+
   const role = typeof values.Q5 === 'string' ? values.Q5 : '';
   const specialty = typeof values.Q6 === 'string' ? values.Q6 : '';
   if (role && !DOCTOR_DENTIST.has(role) && specialty && specialty !== 'No specialty') {


### PR DESCRIPTION
Per Carl's go (2026-06-03): build the **#305 sub-item 3a** with the recommended interpretation — block only the **"0 years AND 0 months"** Q9 tenure, *not* a strict `years ≥ 1`.

- **`cross-field.ts`** — new rule **PROF-05** (severity `error` = hard block) when `Q9_1 = 0 && Q9_2 = 0`. `years = 0` with `months ≥ 1` (valid sub-1-year HCWs) stays allowed.
- **3 tests** — 0+0 blocks; years=0+months≥1 allowed; normal tenure clean.
- **i18n** — `crossField.tenureZero` added to all 8 locales (en real; non-en en-placeholder pending ASPSI translation, per the translations pipeline).

Verified: `tsc -b --force` clean; cross-field + i18n tests pass (the `App.test` flake is the known parallel-runner one — 8/8 in isolation).

**Not auto-closing #305** — this builds 3a per the recommended reading; Dr. Myra's confirm on whether she intended strict `years ≥ 1` is the final gate.
