### PR TITLE
feat(f2-survey): persist consent_given for audit parity (§15.B)

### DIFF
--- a/deliverables/F2/PWA/app/src/App.tsx
+++ b/deliverables/F2/PWA/app/src/App.tsx
@@ -242,7 +242,11 @@ function AppShell() {
       // Auto-inject the active locale so the harmonization ETL can stratify
       // by language without needing the user to declare it explicitly. See
       // codebook §13 (survey_language) and §15.E.
-      const valuesWithMeta: FormValues = { ...values, survey_language: locale };
+      // §15.B: persist explicit consent. F2 has no separate consent flag —
+      // reaching submit means the respondent saw the consent disclosure and
+      // chose to submit, so consent_given = 1 (Yes), for audit parity with the
+      // F1/F3/F4 CONSENT_GIVEN field.
+      const valuesWithMeta: FormValues = { ...values, survey_language: locale, consent_given: 1 };
       await saveDraft(draftId, valuesWithMeta, enrollmentInfo);
       // Capture GPS at the click moment (5s timeout, all failures map to null).
       // Per spec §9 the disclosure is shown on the review screen near submit.


### PR DESCRIPTION
Codebook **§15.B** (Carl's go 2026-06-03): F2 had no explicit consent data field; F1/F3/F4 do (`CONSENT_GIVEN`).

F2's model is **disclosure-then-submit** (no separate consent flag — the GPS-consent disclosure is shown on the review screen, and submitting *is* the consent). So `App.handleSubmit` now injects **`consent_given = 1`** into the submission values — exactly the same pattern as `survey_language` — stored in `values_json`. The harmonization ETL extracts it to canonical `consent_given` (codebook §9), giving **audit parity** with F1/F3/F4.

**No backend column** — the `F2_Responses` writer is header-mapped (an unknown field is silently dropped), and `values_json` is the established home for these injected meta fields (cf. `survey_language`, which has no column either). The paper-encoder path is covered too (paper consent on file ⟹ 1).

Verified: `tsc -b --force` clean; full suite **465/465**.
