### PR TITLE
chore(cspro): harden preflight lints (setvalueset/arity) + sync compile/desk-test runbook

### DIFF
--- a/deliverables/CSPro/CSPro-Compile-and-Desk-Test-Runbook.md
+++ b/deliverables/CSPro/CSPro-Compile-and-Desk-Test-Runbook.md
@@ -1,0 +1,139 @@
+---
+type: deliverable
+kind: runbook
+audience: Carl (Data Programmer) — CSPro Designer + CSEntry on Windows
+prepared_by: Carl Patrick L. Reyes
+date: 2026-06-04
+related_tasks: [E6-CAPI-001 (#193), E6-CAPI-002 (#194), E6-CAPI-003 (#195), E2-F3-010 (#251), E2-F4-010 (#253), E3-F1-060 (#161), E2-PLF-006 (#140)]
+tags: [cspro, csentry, compile, desk-test, runbook, e6]
+---
+
+# CSPro Compile & Desk-Test Runbook — F1 / F3 / F4 (+ PLF)
+
+The turnkey procedure to take the three generator-built instruments through **Designer compile → CSEntry desk-test → gate-issue closure**. This is the keystone that unblocks epic:testing, epic:csweb sync, and the pretest.
+
+> **Why this is a manual step.** CSPro 8.0 is installed, but the compile lives in **Designer** (GUI) and the desk-test in **CSEntry** (GUI, interactive). The headless runners (`CSBatch`, `CSProProductionRunner`, `runpff`) all load a **`.ent` application bundle** — which Designer creates by binding the `.dcf` + `.fmf` + `.ent.apc`; the generators deliberately produce the components, not the `.ent`. So there's no honest headless compile. This runbook makes the GUI pass first-try clean.
+>
+> **Empirically confirmed (2026-06-04).** Tested `CSProProductionRunner.exe` against an `AppType=Entry` `.pff` over the F1 sample `.csdb` (scratch copy, 40-s timeout): it **hung with no listing output** (entry apps need the interactive engine — production-runner is for batch/tabulate/export, not entry-logic compile). `-?` also returns no console usage. So the GUI requirement is verified, not assumed — don't burn time re-attempting a headless entry compile.
+
+---
+
+## 0. Pre-compile state — already green (2026-06-04)
+
+> **12-digit case-key migration (2026-06-04) — folded in.** All three dicts now key on the decomposed **`RR-PP-MMM-FF-CCC`** (5 ID items: `REGION_CODE`·`PROVINCE_HUC_CODE`·`CITY_MUNICIPALITY_CODE`·`FACILITY_NO`·`CASE_SEQ`); the single 6-digit `QUESTIONNAIRE_NO` is retired, `F3_FACILITY_ID` retired (facility = first 9 digits), `F4_PARENT_F3_CASE_SEQ` added for the F4→F3 link. Dicts re-registered in CSWeb (#235/#251/#253/#140 closed). The desk-test (§3) now also verifies the **id-block entry**.
+
+| Check | F1 | F3 | F4 |
+|---|---|---|---|
+| Dictionary `.dcf` | ✅ FacilityHeadSurvey.dcf (12-digit id-block) | ✅ PatientSurvey.dcf (id-block) | ✅ HouseholdSurvey.dcf (id-block) |
+| Logic `.ent.apc` | ✅ (129 PROC blocks) | ✅ (60) | ✅ (125) |
+| Forms `.fmf` | ⚠️ FacilityHeadSurvey.fmf (Apr-21 Designer-refined; **Id-Items form pre-migration** — see ⚠️ below) | ⚠️ PatientSurvey.generated.fmf (skeleton; Id-Items regenerated) | ⚠️ HouseholdSurvey.generated.fmf (skeleton; Id-Items regenerated) |
+| **preflight_validate.py** | ✅ ALL CLEAN | ✅ ALL CLEAN | ✅ ALL CLEAN |
+| §15.E `LANGUAGE_USED` | ⚠️ not on a form (auto-set in preproc via `getlanguage()`; unplaced ≠ error) | ✅ placed | ✅ placed |
+| 12-digit id-block | ⚠️ **in `.dcf` only** — `.fmf`/`.ent` still bind retired `QUESTIONNAIRE_NO`; Id-Items form **re-syncs on Designer open** (drops `QUESTIONNAIRE_NO`, places the 5 items) | ✅ | ✅ |
+
+> ⚠️ **F1 Id-Items drift (caught 2026-06-04, verified).** `FacilityHeadSurvey.fmf` + `.ent` are **Apr-21, pre-migration**: the (Id Items) form `FORM000` places the single retired `QUESTIONNAIRE_NO`, and **none** of the 5 new id items. The `.dcf` (Jun-4) is correct (`REGION_CODE`·2 / `PROVINCE_HUC_CODE`·2 / `CITY_MUNICIPALITY_CODE`·3 / `FACILITY_NO`·2 / `CASE_SEQ`·3 = 12 digits). The (Id Items) form is **dictionary-driven**, so opening the `.ent` in Designer triggers a "dictionary changed — synchronize?" prompt that **auto-rebuilds the Id-Items form** to the 12-digit block. This is **§2 F1 Step 0** below — do it before the smoke. **Do not hand-edit the INI `.fmf`** (the IRON RULE; F1 has no FMF generator — the Id-Items form is Designer/dict-managed).
+
+`preflight_validate.py` statically catches **3 of the 5** Designer error classes below (hardened 2026-06-04): **(1)** PROC-target / dictionary-reference drift (the documented item-name-drift class), **(2)** `setvalueset()` on a non-field working variable (the F1 Q121 trap), **(3)** user-function call-arity mismatch (against the `function` defs in the `.apc` + shared `Capture-Helpers.apc`/`PSGC-Cascade.apc`). It still does **not** catch general syntax errors, type mismatches, or value-set-code-membership — those surface on the real Designer compile and route through the fix-loop below. (Self-tested: the new lints fire on injected faults and ignore nested-paren args; all three instruments stay **ALL CLEAN**.)
+
+---
+
+## 1. THE IRON RULE — fix at the generator, never the artifact
+
+When Designer reports a compile error, **do not edit the `.apc` / `.dcf` / `.fmf` by hand.** Fix the **source table in the generator** and regenerate. Hand-edits are overwritten on the next regenerate and break the single-source-of-truth.
+
+```
+Designer error  →  edit F{1,3,4}/generate_apc.py (or generate_dcf.py)
+                →  python generate_dcf.py && python generate_apc.py  (+ generate_fmf.py for F3/F4)
+                →  python deliverables/CSPro/preflight_validate.py   (must stay ALL CLEAN)
+                →  reload in Designer → recompile
+```
+
+**Paste the verbatim Designer error to me and I turn the generator fix in this loop** — typically a one-line source-table edit + regenerate.
+
+### Error → cause → fix cheat-sheet
+| Designer says | Almost always | Fix | preflight catches? |
+|---|---|---|---|
+| `'QXX_FOO' is not defined` | item-name drift (logic name ≠ dcf name) | rename in the generator's source table; preflight will confirm | ✅ yes |
+| `setvalueset: argument is not a field` | value-set applied to a non-field/computed item | per-option `noinput` gate instead (see F1 Q121 pattern) | ✅ yes (working-var case) |
+| `skip to 'LABEL' — label not found` | skip target renamed/positional | point to the correct item code; preflight resolves PROC targets | ✅ yes |
+| `function expects N arguments` | helper arity (e.g. `ReadGPSReading`) | match the helper signature in `Capture-Helpers.apc` | ✅ yes (user-defined fns) |
+| value-set code not in dictionary | dcf value-set vs logic constant mismatch | align the constant to the dcf value-set | ❌ no — surfaces in Designer |
+
+---
+
+## 2. Per-instrument Designer compile
+
+### F1 — Facility Head  *(closes #161 smoke + feeds #193)*
+0. **Id-block re-sync (do this first — see §0 ⚠️).** Open **`FacilityHeadSurvey.ent`** in Designer. It will detect the `.dcf` changed under it ("dictionary modified — synchronize?") → **accept**. The (Id Items) form rebuilds to the **5-item 12-digit block** (`REGION_CODE`·`PROVINCE_HUC_CODE`·`CITY_MUNICIPALITY_CODE`·`FACILITY_NO`·`CASE_SEQ`) and the retired `QUESTIONNAIRE_NO` field drops off `FORM000`. **Save the forms.** *(Don't hand-edit the `.fmf` — the Id-Items form is dict-managed.)* If no prompt appears, force it: Dictionary ▸ (any no-op) or re-attach `FacilityHeadSurvey.dcf` as the input dictionary; confirm `FORM000` now shows the 5 items, not `QUESTIONNAIRE_NO`.
+1. Designer → open/create **`FacilityHeadSurvey.ent`**; Input dictionary = `FacilityHeadSurvey.dcf`; Forms = **`FacilityHeadSurvey.fmf`** (Designer-refined; Id-Items re-synced per Step 0).
+2. Set **`FacilityHeadSurvey.ent.apc`** as the application's main logic.
+3. **Build ▸ Compile.** Work the fix-loop until clean.
+4. Watch the known-risky spots: **Q121** (per-option `noinput` gates — O10/O11/O12 hospital-only, O13 PCF-only, O14 None→skip Q135), the 7 positional skip-targets, **PSGC cascade** (`onfocus`+`loadcase`+`setvalueset`, external lookup dicts must be on the path), **GPS/photo** helpers, `getlanguage()`→`LANGUAGE_USED`.
+
+### F3 — Patient  *(feeds #194, #251)*
+1. Create **`PatientSurvey.ent`**; Input dict = `PatientSurvey.dcf`; Forms = import **`PatientSurvey.generated.fmf`** (then Designer splits oversized sections per `F3-Form-Layout-Plan.md` — the skeleton carries item membership + tab order).
+2. Set **`PatientSurvey.ent.apc`** as main logic; **Compile.**
+3. Risky spots: **outpatient/inpatient branching** at the eligibility screen (#164), the **case-control block in FIELD_CONTROL** (#251 verifies this), Q1 consent gate, **Q162 terminator**, **Q169 routing**.
+
+### F4 — Household  *(feeds #195, #253)*
+1. Create **`HouseholdSurvey.ent`**; Input dict = `HouseholdSurvey.dcf`; Forms = import **`HouseholdSurvey.generated.fmf`**.
+2. Set **`HouseholdSurvey.ent.apc`** main logic; **Compile.**
+3. Riskiest of the three — **roster** (`C_HOUSEHOLD_ROSTER`, one member per row), **per-member sub-loop**, **cross-member rules** (one head; spouse implies head), **max-roster soft warning**, **WHO expenditure grid** (Section N flat batteries), **bill-recall chain**, **Q129 Section-M gate**.
+
+### PLF — listing apps  *(closes #140)*
+- The PLF is the **F3/F4 listing apps** (`PickPatient()` / `PickHousehold()`). Designer-validate + publish; record the sign-off note on #140.
+
+---
+
+## 3. Desk-test scenarios (CSEntry) → what each closes
+
+Run on a Windows CSEntry build. For each instrument, walk the happy path **and** the targeted scenarios; capture pass/fail + a screenshot per scenario (drop into the issue).
+
+### F1 — #193 (desk test) + #161 (smoke)
+- [ ] **Case-key id-block:** the 5 ID items (`REGION_CODE`·`PROVINCE_HUC_CODE`·`CITY_MUNICIPALITY_CODE`·`FACILITY_NO`·`CASE_SEQ`) prompt/accept in order and compose the 12-digit `RR-PP-MMM-FF-CCC` case key; no leftover `QUESTIONNAIRE_NO` field.
+- [ ] **Smoke (closes #161):** cover page → every section → last question → save, happy path, no dead-ends.
+- [ ] Consent **refuse** → disposition recorded + `endlevel` (interview ends cleanly).
+- [ ] **Eligibility** gate blocks ineligible before main questionnaire loads.
+- [ ] Age **< 18** → hard block + reenter.
+- [ ] **Q121** option behavior: hospital-only options gated; O14 "None" → skips Q135.
+- [ ] **PSGC cascade**: region→province→city→barangay narrows correctly.
+- [ ] **GPS** captured at start; **verification photo** taken; **AAPOR** disposition set.
+- [ ] **Language switch** mid-form → `LANGUAGE_USED` records the active language.
+
+### F3 — #194 (full A–L) + #251 (Designer validation)
+- [ ] Full **A–L** walkthrough, sane data, reaches end.
+- [ ] **OP vs IP branching** (#164) routes to the correct block at eligibility.
+- [ ] **Case-control block in FIELD_CONTROL** correct (#251 sign-off).
+- [ ] Q1 consent gate; **Q162 terminator** ends where intended; **Q169 routing** lands correctly.
+
+### F4 — #195 (full A–Q) + #253 (Designer validation)
+- [ ] Full **A–Q** walkthrough including the roster.
+- [ ] **Roster**: add / edit / remove / reorder members; per-member sub-loop fires on the right conditions.
+- [ ] **Cross-member**: only one household head; spouse implies a head exists.
+- [ ] **Max-roster** soft warning at unusual sizes.
+- [ ] **WHO expenditure grid** (Section N) accepts the PHP batteries; **catastrophic-expenditure** logic sane.
+- [ ] **Bill-recall chain** flows; **interval-sampling** sanity (#195).
+
+---
+
+## 4. Gate-issue closure map
+
+| Issue | Closes when | Evidence to attach |
+|---|---|---|
+| **#161** F1 CSEntry smoke | happy path cover→last question passes | screenshot of final save |
+| **#193** F1 desk test | §3 F1 scenarios pass | per-scenario pass/fail + shots |
+| **#194** F3 desk test | §3 F3 scenarios pass | A–L walkthrough notes |
+| **#195** F4 desk test | §3 F4 scenarios pass | roster + Section N shots |
+| **#251** F3 Designer validation | FIELD_CONTROL case-control block verified; full item walkthrough | sign-off note |
+| **#253** F4 Designer validation | same scope as F3 | sign-off note |
+| **#140** PLF Designer validation | listing apps validated + published | sign-off note |
+
+> When a desk-test surfaces a **logic defect**, it routes to the generator fix-loop (§1) — and the related Epic-3 build issue does **not** reopen; the fix-batch is tracked via the pretest-debrief issue **#199**.
+
+---
+
+## 5. What unblocks next (the cascade)
+
+Once these close: **#196** sync round-trip needs the compiled `.pen` packages → **CSWeb #235/#237** per-survey upload + sync config → **#198/#199** pretest → **#190** F2 pilot. The whole right-hand side of the board keys off this compile.
+
+**I'm standing by for compile errors** — paste any Designer message verbatim and I'll turn the generator fix in the §1 loop (usually a one-line source edit + regenerate + preflight).

--- a/deliverables/CSPro/preflight_validate.py
+++ b/deliverables/CSPro/preflight_validate.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python
+"""
+CSPro pre-flight validator — static symbol-resolution check of a .ent.apc
+against its .dcf dictionary + #included shared logic. Catches the compile-error
+class (PROC for a non-existent item; references to undefined dictionary symbols)
+BEFORE a Designer compile, so the GUI round-trip is clean on the first try.
+
+Not a substitute for the real compile — it can't catch syntax errors, type
+mismatches, or function-arity errors. It is high-signal on item-name drift,
+which is the documented failure mode (spec used shortened names != dcf).
+
+Run:  python deliverables/CSPro/preflight_validate.py
+Exit 0 = every PROC target resolves (no hard compile errors); exit 1 otherwise.
+Re-run after editing any generate_apc.py and regenerating the .apc.
+"""
+import json, re, sys
+from pathlib import Path
+
+# --- CSPro reserved words + built-in functions (uppercase-relevant subset).
+# Lowercase keywords/functions are excluded by the UPPER_SNAKE reference filter,
+# so this only needs tokens that could appear UPPER_SNAKE in logic. We add the
+# common all-caps ones defensively.
+CSPRO_RESERVED = {
+    # section/proc keywords
+    'PROC', 'GLOBAL', 'PREPROC', 'POSTPROC', 'ONFOCUS', 'ONOCCCHANGE', 'KILLFOCUS',
+    # control flow / statements (usually lowercase, listed for safety)
+    'IF', 'THEN', 'ELSE', 'ELSEIF', 'ENDIF', 'DO', 'WHILE', 'ENDDO', 'FOR', 'ENDFOR',
+    'SKIP', 'TO', 'NEXT', 'ENDLEVEL', 'REENTER', 'NOINPUT', 'ADVANCE', 'AND', 'OR', 'NOT',
+    # common constants / system tokens
+    'YES', 'NO', 'TRUE', 'FALSE', 'NOTAPPL', 'DEFAULT', 'MAXOCC', 'CUROCC', 'TOTOCC',
+}
+
+
+def _collect_dcf_names(node, names):
+    """Recursively collect every 'name' under items/subitems/valueSets/records."""
+    if isinstance(node, dict):
+        if 'name' in node and isinstance(node['name'], str):
+            names.add(node['name'].upper())
+        for k, v in node.items():
+            _collect_dcf_names(v, names)
+    elif isinstance(node, list):
+        for x in node:
+            _collect_dcf_names(x, names)
+
+
+def dcf_symbols(dcf_path):
+    d = json.load(open(dcf_path, encoding='utf-8-sig'))
+    names = set()
+    # dict name + level/record/item/valueset/value names (recursive catch-all)
+    _collect_dcf_names(d, names)
+    return names
+
+
+def strip_comments(src):
+    """Remove CSPro { ... } brace comments, // line comments, and string
+    literals (so identifiers quoted in errmsg/maketext text don't false-flag)."""
+    src = re.sub(r'\{[^{}]*\}', ' ', src)          # most braces (non-nested)
+    src = re.sub(r'\{.*?\}', ' ', src, flags=re.S)  # any spanning leftovers
+    src = re.sub(r'//[^\n]*', ' ', src)
+    src = re.sub(r'"(?:[^"\\]|\\.)*"', ' ', src)     # double-quoted strings
+    return src
+
+
+def declared_symbols(src):
+    """Symbols DECLARED in this logic file: var declarations, PROC names,
+    function defs, valueset defs — all valid non-dcf references."""
+    decl = set()
+    # numeric/string/alpha/array declarations:  numeric FOO, BAR;
+    for m in re.finditer(r'(?im)^\s*(?:numeric|string|alpha(?:\(\d+\))?|array)\s+([A-Za-z0-9_,\s\(\)]+);', src):
+        for name in re.findall(r'[A-Za-z_][A-Za-z0-9_]*', m.group(1)):
+            decl.add(name.upper())
+    # PROC <name>
+    for m in re.finditer(r'(?im)^\s*PROC\s+([A-Za-z_][A-Za-z0-9_]*)', src):
+        decl.add(m.group(1).upper())
+    # function <name>(  /  def <name>(
+    for m in re.finditer(r'(?im)\b(?:function|def)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(', src):
+        decl.add(m.group(1).upper())
+    # valueset <name>
+    for m in re.finditer(r'(?im)\bvalueset\s+([A-Za-z_][A-Za-z0-9_]*)', src):
+        decl.add(m.group(1).upper())
+    return decl
+
+
+def declared_vars(src):
+    """ONLY working-variable declarations (numeric/string/alpha/array NAME...;).
+    A provably-non-field set, used by the setvalueset lint."""
+    dv = set()
+    for m in re.finditer(r'(?im)^\s*(?:numeric|string|alpha(?:\(\d+\))?|array(?:\([^)]*\))?)\s+([A-Za-z0-9_,\s\(\)]+);', src):
+        for name in re.findall(r'[A-Za-z_][A-Za-z0-9_]*', m.group(1)):
+            dv.add(name.upper())
+    return dv
+
+
+def _balanced_paren(s, open_idx):
+    """s[open_idx] must be '('. Return (inner, idx_after_close) or (None, -1)."""
+    depth = 0
+    for j in range(open_idx, len(s)):
+        if s[j] == '(':
+            depth += 1
+        elif s[j] == ')':
+            depth -= 1
+            if depth == 0:
+                return s[open_idx + 1:j], j + 1
+    return None, -1
+
+
+def _split_top(inner):
+    """Split a paren-balanced, string-stripped arg list on TOP-LEVEL commas."""
+    parts, depth, cur = [], 0, ''
+    for c in inner:
+        if c == '(':
+            depth += 1; cur += c
+        elif c == ')':
+            depth -= 1; cur += c
+        elif c == ',' and depth == 0:
+            parts.append(cur); cur = ''
+        else:
+            cur += c
+    parts.append(cur)
+    return parts
+
+
+def _count_args(inner):
+    return 0 if inner.strip() == '' else len(_split_top(inner))
+
+
+FUNC_DEF_RE = re.compile(r'(?i)\bfunction\b\s+(?:(?:numeric|string|alpha(?:\(\d+\))?)\s+)?([A-Za-z_]\w*)\s*\(')
+
+
+def function_arities(src):
+    """Map user-FUNCTION name -> declared param count, plus the set of def '(' indices."""
+    arities, def_idx = {}, set()
+    for m in FUNC_DEF_RE.finditer(src):
+        open_idx = m.end() - 1            # the '(' the regex ended on
+        inner, _ = _balanced_paren(src, open_idx)
+        if inner is None:
+            continue
+        arities[m.group(1).upper()] = _count_args(inner)
+        def_idx.add(open_idx)
+    return arities, def_idx
+
+
+def arity_problems(apc, shared_srcs):
+    """Call sites of USER functions whose arg count != the declared param count.
+    Only checks functions we can SEE a definition for (built-ins are skipped),
+    so false positives are near-zero. Catches the 'function expects N arguments'
+    compile-error class."""
+    arities, local_def_idx = function_arities(apc)
+    for s in shared_srcs:
+        sh_ar, _ = function_arities(s)
+        for k, v in sh_ar.items():
+            arities.setdefault(k, v)       # local def wins on name clash
+    problems = []
+    for name, want in arities.items():
+        for m in re.finditer(r'(?i)\b' + re.escape(name) + r'\s*\(', apc):
+            open_idx = m.end() - 1
+            if open_idx in local_def_idx:  # skip the definition itself
+                continue
+            inner, _ = _balanced_paren(apc, open_idx)
+            if inner is None:
+                continue
+            got = _count_args(inner)
+            if got != want:
+                line = apc[:m.start()].count('\n') + 1
+                problems.append((name, line, got, want))
+    return problems
+
+
+def setvalueset_problems(apc, working_vars, dcf):
+    """setvalueset(X, ...) where X is provably a working variable (declared
+    numeric/string/array, not a dcf field). Catches 'setvalueset: argument is
+    not a field' — the F1 Q121 trap."""
+    problems = []
+    for m in re.finditer(r'(?i)\bsetvalueset\s*\(', apc):
+        inner, _ = _balanced_paren(apc, m.end() - 1)
+        if inner is None:
+            continue
+        first = _split_top(inner)[0].strip()
+        idm = re.match(r'([A-Za-z_]\w*)', first)
+        if not idm:
+            continue
+        ident = idm.group(1).upper()
+        if ident in working_vars and ident not in dcf:
+            problems.append((idm.group(1), apc[:m.start()].count('\n') + 1))
+    return problems
+
+
+# Identifier that "looks like" a dictionary reference: UPPER_SNAKE with at least
+# one underscore or a leading Q-number, length >= 3. Keeps false positives low.
+REF_RE = re.compile(r'\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+|Q\d+[A-Z0-9_]*)\b')
+PROC_RE = re.compile(r'(?im)^\s*PROC\s+([A-Za-z_][A-Za-z0-9_]*)')
+
+
+def validate(instrument, apc_path, dcf_path, shared_paths):
+    dcf = dcf_symbols(dcf_path)
+    apc_raw = open(apc_path, encoding='utf-8-sig').read()
+    apc = strip_comments(apc_raw)
+
+    known = set(dcf) | set(CSPRO_RESERVED)
+    known |= declared_symbols(apc)
+    shared_srcs = []
+    working_vars = declared_vars(apc)
+    for sp in shared_paths:
+        if Path(sp).exists():
+            sh = strip_comments(open(sp, encoding='utf-8-sig').read())
+            shared_srcs.append(sh)
+            known |= declared_symbols(sh)
+            working_vars |= declared_vars(sh)
+
+    # 1) PROC-target validation (the hard-error class): every PROC name must be
+    #    GLOBAL, a form-flow proc (<DICT>_FF), or a dcf item/record/level name.
+    #    Crucially, do NOT accept a name just because a PROC declares it — that
+    #    would self-whitelist `PROC <typo>` for a non-existent item.
+    proc_allowed = set(dcf) | set(CSPRO_RESERVED) | {'GLOBAL'}
+    proc_bad = []
+    for m in PROC_RE.finditer(apc_raw):
+        name = m.group(1)
+        u = name.upper()
+        if u in proc_allowed or u.endswith('_FF'):
+            continue
+        line = apc_raw[:m.start()].count('\n') + 1
+        proc_bad.append((name, line))
+
+    # 2) General undefined-reference scan.
+    refs = {}
+    for m in REF_RE.finditer(apc):
+        tok = m.group(1)
+        if tok.upper() not in known:
+            refs[tok] = refs.get(tok, 0) + 1
+
+    return {
+        'instrument': instrument,
+        'dcf_symbol_count': len(dcf),
+        'proc_count': len(PROC_RE.findall(apc_raw)),
+        'proc_bad': proc_bad,
+        'undefined_refs': sorted(refs.items(), key=lambda x: -x[1]),
+        'arity_bad': arity_problems(apc, shared_srcs),
+        'setvalueset_bad': setvalueset_problems(apc, working_vars, dcf),
+    }
+
+
+def main():
+    # Lives in deliverables/CSPro/ — resolve the instrument dirs relative to it.
+    base = Path(__file__).resolve().parent
+    shared = [base / 'shared' / 'Capture-Helpers.apc', base / 'shared' / 'PSGC-Cascade.apc']
+    targets = [
+        ('F1', base / 'F1' / 'FacilityHeadSurvey.ent.apc', base / 'F1' / 'FacilityHeadSurvey.dcf'),
+        ('F3', base / 'F3' / 'PatientSurvey.ent.apc',      base / 'F3' / 'PatientSurvey.dcf'),
+        ('F4', base / 'F4' / 'HouseholdSurvey.ent.apc',    base / 'F4' / 'HouseholdSurvey.dcf'),
+    ]
+    overall_clean = True
+    for name, apc, dcf in targets:
+        if not apc.exists() or not dcf.exists():
+            print(f'[{name}] SKIP — missing apc or dcf')
+            continue
+        r = validate(name, apc, dcf, shared)
+        print(f'\n========== {name} ==========')
+        print(f'  dcf symbols: {r["dcf_symbol_count"]}   PROC blocks: {r["proc_count"]}')
+        if r['proc_bad']:
+            overall_clean = False
+            print(f'  !! PROC targets NOT in dcf ({len(r["proc_bad"])}) — HARD compile errors:')
+            for nm, ln in r['proc_bad']:
+                print(f'       line {ln}: PROC {nm}')
+        else:
+            print('  OK — every PROC target resolves to a known symbol')
+        if r['setvalueset_bad']:
+            overall_clean = False
+            print(f'  !! setvalueset() on a non-field working var ({len(r["setvalueset_bad"])}) — HARD compile errors:')
+            for nm, ln in r['setvalueset_bad']:
+                print(f'       line {ln}: setvalueset({nm}, ...)  — {nm} is a declared variable, not a field')
+        else:
+            print('  OK — no setvalueset() on a non-field')
+        if r['arity_bad']:
+            overall_clean = False
+            print(f'  !! user-function arity mismatch ({len(r["arity_bad"])}) — HARD compile errors:')
+            for nm, ln, got, want in r['arity_bad']:
+                print(f'       line {ln}: {nm}() called with {got} arg(s), defined with {want}')
+        else:
+            print('  OK — user-function call arity matches definitions')
+        if r['undefined_refs']:
+            print(f'  ?? Unresolved UPPER_SNAKE references ({len(r["undefined_refs"])} distinct):')
+            for tok, cnt in r['undefined_refs'][:60]:
+                print(f'       {tok}  (x{cnt})')
+        else:
+            print('  OK — no unresolved dictionary-style references')
+    print('\n' + ('ALL CLEAN' if overall_clean else 'ISSUES FOUND — see PROC errors above'))
+    return 0 if overall_clean else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Hardens the CSPro preflight validator and syncs the compile/desk-test runbook.

- `deliverables/CSPro/preflight_validate.py` — tightened setvalueset / arity checks.
- `deliverables/CSPro/CSPro-Compile-and-Desk-Test-Runbook.md` — synced.

Split out of #363 so the preflight-lint work (which feeds the desk-test session) can review/merge on its own timeline. Scrum close-out + standup automation is now in its own PR.