### PR TITLE
DO NOT MERGE until token has Workers Scripts Edit - ci(f2-pwa): fail run on worker-deploy error

### DIFF
--- a/.github/workflows/cf-pages-deploy.yml
+++ b/.github/workflows/cf-pages-deploy.yml
@@ -148,18 +148,14 @@ jobs:
       #
       # NOTE: the CLOUDFLARE_API_TOKEN must carry BOTH `Cloudflare Pages: Edit`
       # AND `Workers Scripts: Edit`. A Pages-only token deploys the frontend but
-      # fails here with `Authentication error [code: 10000]` (the recurring
-      # failure this step previously hit).
-      #
-      # TEMPORARY: continue-on-error keeps this step from failing the whole run
-      # while CLOUDFLARE_API_TOKEN still lacks `Workers Scripts: Edit` (code 10000).
-      # The Pages frontend has already deployed above, so the run goes green and the
-      # follow-up step emits a ::warning instead. REMOVE continue-on-error once the
-      # token carries Workers Scripts:Edit, so a real worker-deploy failure fails the run.
+      # fails here with `Authentication error [code: 10000]`. This step now FAILS
+      # the run on a worker-deploy error: the temporary `continue-on-error` guard
+      # (and its companion ::warning step) were removed 2026-06-17 once the token
+      # carried `Workers Scripts: Edit`, so a broken worker deploy is loud instead
+      # of a swallowed warning. If you ever see code 10000 here again, the token
+      # lost `Workers Scripts: Edit` — re-add it rather than re-muting this step.
       - if: steps.secrets.outputs.ready == 'true'
         name: Deploy Worker (version-stamped)
-        id: worker_deploy
-        continue-on-error: true
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -167,8 +163,3 @@ jobs:
           workingDirectory: deliverables/F2/PWA/worker
           wranglerVersion: "3.114.17"
           command: deploy ${{ steps.wvars.outputs.env_flag }} --var PWA_VERSION:${{ steps.wvars.outputs.version }} --var WORKER_VERSION:${{ steps.wvars.outputs.worker_version }} --var PWA_BUILD_SHA:${{ steps.wvars.outputs.sha_short }}
-
-      - if: steps.worker_deploy.outcome == 'failure'
-        name: Warn — worker deploy skipped (non-blocking)
-        run: |
-          echo "::warning title=Worker deploy skipped::Version-stamped Worker deploy failed (likely CLOUDFLARE_API_TOKEN missing 'Workers Scripts: Edit' — error code 10000). The Pages frontend deployed fine. Fix the token + remove continue-on-error, or deploy the Worker manually."


### PR DESCRIPTION
## Draft — do not merge yet

Removes the **temporary** `continue-on-error: true` guard (plus its dead companion `::warning` step and the now-unused step id) from the "Deploy Worker (version-stamped)" step in `cf-pages-deploy.yml`, so a real worker-deploy failure **fails the run** instead of being swallowed as a warning.

`+6 / -15`, one file.

### Merge precondition — BOTH must be true first

1. `CLOUDFLARE_API_TOKEN` carries **`Workers Scripts: Edit`** (today it has `Cloudflare Pages: Edit` only -> worker deploy fails with `Authentication error [code: 10000]`).
2. You have seen **one successful worker deploy** — a green CI run on that step, or a clean manual `wrangler deploy --env staging`.

Merging before then would make the **next `staging` deploy fail** at this step.

### Why

While the token lacked the scope, the guard kept the run green (the Pages frontend still deployed) and emitted a `::warning`. Once the token is fixed, that masking is no longer wanted — a broken worker deploy should be loud. The updated comment tells a future reader who sees code 10000 again to **re-add the token scope**, not re-mute the step.

### Targets `staging`

Where all the F2 PWA work lives. Rides along to prod's deploy path on the next `staging -> main` promotion — no separate main edit needed.

_Prepped 2026-06-17 alongside the `broadcast_message` editor work, which is the first feature gated by this same Worker-deploy fix._
