### PR TITLE
ci(f2-pwa): land worker-deploy hard-fail on main (companion to #623)

### DIFF
--- a/.github/workflows/cf-pages-deploy.yml
+++ b/.github/workflows/cf-pages-deploy.yml
@@ -148,18 +148,14 @@ jobs:
       #
       # NOTE: the CLOUDFLARE_API_TOKEN must carry BOTH `Cloudflare Pages: Edit`
       # AND `Workers Scripts: Edit`. A Pages-only token deploys the frontend but
-      # fails here with `Authentication error [code: 10000]` (the recurring
-      # failure this step previously hit).
-      #
-      # TEMPORARY: continue-on-error keeps this step from failing the whole run
-      # while CLOUDFLARE_API_TOKEN still lacks `Workers Scripts: Edit` (code 10000).
-      # The Pages frontend has already deployed above, so the run goes green and the
-      # follow-up step emits a ::warning instead. REMOVE continue-on-error once the
-      # token carries Workers Scripts:Edit, so a real worker-deploy failure fails the run.
+      # fails here with `Authentication error [code: 10000]`. This step now FAILS
+      # the run on a worker-deploy error: the temporary `continue-on-error` guard
+      # (and its companion ::warning step) were removed 2026-06-17 once the token
+      # carried `Workers Scripts: Edit`, so a broken worker deploy is loud instead
+      # of a swallowed warning. If you ever see code 10000 here again, the token
+      # lost `Workers Scripts: Edit` — re-add it rather than re-muting this step.
       - if: steps.secrets.outputs.ready == 'true'
         name: Deploy Worker (version-stamped)
-        id: worker_deploy
-        continue-on-error: true
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -167,8 +163,3 @@ jobs:
           workingDirectory: deliverables/F2/PWA/worker
           wranglerVersion: "3.114.17"
           command: deploy ${{ steps.wvars.outputs.env_flag }} --var PWA_VERSION:${{ steps.wvars.outputs.version }} --var WORKER_VERSION:${{ steps.wvars.outputs.worker_version }} --var PWA_BUILD_SHA:${{ steps.wvars.outputs.sha_short }}
-
-      - if: steps.worker_deploy.outcome == 'failure'
-        name: Warn — worker deploy skipped (non-blocking)
-        run: |
-          echo "::warning title=Worker deploy skipped::Version-stamped Worker deploy failed (likely CLOUDFLARE_API_TOKEN missing 'Workers Scripts: Edit' — error code 10000). The Pages frontend deployed fine. Fix the token + remove continue-on-error, or deploy the Worker manually."


### PR DESCRIPTION
## Land the worker-deploy hard-fail on `main` (where it actually runs)

Companion to #623. That PR removed the temporary `continue-on-error` guard on the "Deploy Worker (version-stamped)" step, but merged it to `staging` — and `cf-pages-deploy` is a **`workflow_run`** workflow, which GitHub **always executes from the default branch (`main`)**. So #623 is inert until the change reaches `main`; this PR puts it there.

Cherry-pick of the #623 commit — one file, `+6 / -15` (removes `continue-on-error: true`, the dead companion `::warning` step, and the now-unused step id).

### Precondition — already satisfied
- `CLOUDFLARE_API_TOKEN` now carries `Workers Scripts: Edit` (fixed 2026-06-18).
- A worker deploy has succeeded with it — verified on **staging** (`f2-pwa-worker-staging`, Version ID `634b1ba5…`).

### Production implication — merge on your timing
Once this is on `main`, the **next `main` deploy hard-gates the production worker deploy** (`f2-pwa-worker`). With the token fixed it should pass — and that deploy will also **refresh the prod worker**, which has been silently failing under the old guard (so prod is likely running a stale worker). That's a production change, which is why the merge is left to you.

_Branch off `main`; targets `main`. Pairs with #623 (staging)._
