### PR TITLE
fix(f2): correct Section C/D/E/G role-gating (#539) — split ahead of UAT

### DIFF
--- a/deliverables/F2/PWA/app/src/lib/cross-field.test.ts
+++ b/deliverables/F2/PWA/app/src/lib/cross-field.test.ts
@@ -103,6 +103,18 @@ describe('evaluateCrossField', () => {
     expect(out.map((w) => w.id)).not.toContain('GATE-05');
   });
 
+  // #539: these two roles were removed from the C/D set; the data-quality gate
+  // shares that set, so it must now flag C/D data from either of them.
+  it('#539: flags GATE-05 for Physician assistant who answered Section C', () => {
+    const out = evaluateCrossField({ Q5: 'Physician assistant', Q31: 'Yes' });
+    expect(out.map((w) => w.id)).toContain('GATE-05');
+  });
+
+  it('#539: flags GATE-05 for Nutrition action officer/coordinator who answered Section C', () => {
+    const out = evaluateCrossField({ Q5: 'Nutrition action officer/ coordinator', Q31: 'Yes' });
+    expect(out.map((w) => w.id)).toContain('GATE-05');
+  });
+
   it('warning has a human-readable message and lists involved fields', () => {
     const out = evaluateCrossField({ Q4: 25, Q5: 'Nurse', Q9_1: 15 });
     const prof01 = out.find((w): w is Warning => w.id === 'PROF-01');

--- a/deliverables/F2/PWA/app/src/lib/cross-field.ts
+++ b/deliverables/F2/PWA/app/src/lib/cross-field.ts
@@ -1,4 +1,4 @@
-import type { FormValues } from './skip-logic';
+import { SECTION_CDE_ROLES, type FormValues } from './skip-logic';
 
 export type Severity = 'info' | 'warn' | 'clean' | 'error';
 
@@ -10,14 +10,11 @@ export interface Warning {
   derived?: Record<string, string>;
 }
 
-const BUCKET_CD = new Set([
-  'Administrator',
-  'Physician/Doctor',
-  'Physician assistant',
-  'Nurse',
-  'Midwife',
-  'Dentist',
-]);
+// #539: GATE-05 (Section C/D data filled by a role that shouldn't answer them)
+// must use the same role policy as the skip-logic section gate. This set
+// previously carried the stale 'Physician assistant' entry and disagreed with
+// skip-logic on the nutrition role; alias the canonical set so they can't drift.
+const BUCKET_CD = SECTION_CDE_ROLES;
 
 const DOCTOR_DENTIST = new Set(['Physician/Doctor', 'Dentist']);
 

--- a/deliverables/F2/PWA/app/src/lib/skip-logic.test.ts
+++ b/deliverables/F2/PWA/app/src/lib/skip-logic.test.ts
@@ -123,19 +123,19 @@ describe('shouldShow', () => {
       ).toBe(false);
     });
 
-    it('R2-#117: shows Q48 for the 7 CDE roles (admin, doctor, PA, nurse, midwife, dentist, nutrition)', () => {
-      const cdeRoles = [
-        'Administrator',
-        'Physician/Doctor',
-        'Physician assistant',
-        'Nurse',
-        'Midwife',
-        'Dentist',
-        'Nutrition action officer/ coordinator',
-      ];
+    it('shows Q48 (BUCAS gate) for the 5 patient-care CDE roles', () => {
+      const cdeRoles = ['Administrator', 'Physician/Doctor', 'Nurse', 'Midwife', 'Dentist'];
       for (const role of cdeRoles) {
         expect(shouldShow('E', 'Q48', { Q5: role })).toBe(true);
       }
+    });
+
+    // #539: Physician assistant and Nutrition action officer/coordinator were in
+    // the R2 CDE set; the updated spec excludes them, so the E1 BUCAS gate must
+    // hide Q48 for both.
+    it('#539: hides Q48 for Physician assistant and Nutrition action officer/coordinator', () => {
+      expect(shouldShow('E', 'Q48', { Q5: 'Physician assistant' })).toBe(false);
+      expect(shouldShow('E', 'Q48', { Q5: 'Nutrition action officer/ coordinator' })).toBe(false);
     });
   });
 
@@ -248,28 +248,29 @@ describe('shouldShow', () => {
   });
 });
 
-// R2-#114: prior to this regression-prevention block, shouldShowSection
-// only gated Section G; sections C/D/E always returned true regardless
-// of Q5 role. Tester (Shan, 2026-05-07 R2) saw C/D/E visible to all 3
-// personas tested (Pharmacist/Dispenser, Physician/Doctor, Dentist aide).
+// shouldShowSection gates which sections each Q5 role sees.
 //
-// Spec (per UAT R2 tester guide notes):
-//   C/D/E (full):      Administrator, Physician/Doctor, Physician
-//                      assistant, Nurse, Midwife, Dentist, Nutrition
-//                      action officer/coordinator
-//   E only (E2 half):  Pharmacist/Dispenser. Until #117 splits
-//                      E1 (Q48–Q52) from E2 (Q53–Q55), pharmacists
-//                      see all of E (the E1 leak is #117's surface).
-//   None of C/D/E:     all other roles (Nursing assistant, Lab tech,
-//                      Med tech, Dentist aide, BHW, etc.) — proceed to F.
+// Spec (updated tester-guide, #539 — supersedes the R2-#114 list):
+//   C/D/E1:           Administrator, Physician/Doctor, Nurse, Midwife, Dentist.
+//   E2 only:          Pharmacist/Dispenser — skips C/D/E1, answers E2 (Q53–Q55)
+//                     via the item-level gates; Section E shows for them.
+//   None of C/D/E:    Physician assistant, Nursing assistant, Lab tech, Med
+//                     tech, Health promotion officer, Nutrition action
+//                     officer/coordinator, Physical Therapist, Dentist aide,
+//                     BHW, Other — proceed to F.
+//   G:                Physician/Doctor, Dentist only.
+//
+// #539 (Aidan re-test 2026-06-16): Physician assistant and Nutrition action
+// officer/coordinator were leaking C/D/E from the R2 list; Physician assistant
+// was also leaking G. The fix removed all three from their respective sets.
 describe('shouldShowSection', () => {
-  describe('Section G — prescribing roles only (existing behavior)', () => {
+  describe('Section G — physicians and dentists only', () => {
     it('shows G for Physician/Doctor', () => {
       expect(shouldShowSection('G', { Q5: 'Physician/Doctor' })).toBe(true);
     });
 
-    it('shows G for Physician assistant', () => {
-      expect(shouldShowSection('G', { Q5: 'Physician assistant' })).toBe(true);
+    it('#539: hides G for Physician assistant', () => {
+      expect(shouldShowSection('G', { Q5: 'Physician assistant' })).toBe(false);
     });
 
     it('shows G for Dentist', () => {
@@ -293,20 +294,22 @@ describe('shouldShowSection', () => {
     it.each([
       'Administrator',
       'Physician/Doctor',
-      'Physician assistant',
       'Nurse',
       'Midwife',
       'Dentist',
-      'Nutrition action officer/ coordinator',
     ])('shows C for %s', (role) => {
       expect(shouldShowSection('C', { Q5: role })).toBe(true);
     });
 
     it.each([
       'Pharmacist/Dispenser',
+      'Physician assistant', // #539
       'Nursing assistant',
       'Laboratory technician',
       'Medical/ radiologic technologist',
+      'Health promotion officer',
+      'Nutrition action officer/ coordinator', // #539
+      'Physical Therapist',
       'Dentist aide',
       'Barangay Health Worker',
       'Other (specify)',
@@ -337,21 +340,25 @@ describe('shouldShowSection', () => {
     it.each([
       'Administrator',
       'Physician/Doctor',
-      'Physician assistant',
       'Nurse',
       'Midwife',
       'Dentist',
-      'Nutrition action officer/ coordinator',
-      'Pharmacist/Dispenser', // E2 GAMOT half — until #117 splits, sees all of E
+      'Pharmacist/Dispenser', // E2 GAMOT half — sees E (item gates hide E1 Q48–Q52)
     ])('shows E for %s', (role) => {
       expect(shouldShowSection('E', { Q5: role })).toBe(true);
     });
 
     it.each([
+      'Physician assistant', // #539
       'Nursing assistant',
       'Laboratory technician',
+      'Medical/ radiologic technologist',
+      'Health promotion officer',
+      'Nutrition action officer/ coordinator', // #539
+      'Physical Therapist',
       'Dentist aide',
       'Barangay Health Worker',
+      'Other (specify)',
     ])('hides E for %s', (role) => {
       expect(shouldShowSection('E', { Q5: role })).toBe(false);
     });
@@ -365,7 +372,7 @@ describe('shouldShowSection', () => {
     });
   });
 
-  describe('Three personas Shan tested (R2 #114 reproduction)', () => {
+  describe('Persona section-visibility (R2 #114 + #539)', () => {
     it('Pharmacist/Dispenser sees A,B,E,F,H,I,J — not C,D,G', () => {
       const v = { Q5: 'Pharmacist/Dispenser' };
       expect(shouldShowSection('A', v)).toBe(true);
@@ -394,6 +401,29 @@ describe('shouldShowSection', () => {
       expect(shouldShowSection('E', v)).toBe(false); // was the bug
       expect(shouldShowSection('F', v)).toBe(true);
       expect(shouldShowSection('G', v)).toBe(false);
+    });
+
+    // #539 (Aidan re-test 2026-06-16): these two roles leaked C/D/E.
+    it('#539: Physician assistant sees A,B,F,H,I,J — not C,D,E,G', () => {
+      const v = { Q5: 'Physician assistant' };
+      expect(shouldShowSection('C', v)).toBe(false);
+      expect(shouldShowSection('D', v)).toBe(false);
+      expect(shouldShowSection('E', v)).toBe(false);
+      expect(shouldShowSection('G', v)).toBe(false);
+      for (const id of ['A', 'B', 'F', 'H', 'I', 'J']) {
+        expect(shouldShowSection(id, v)).toBe(true);
+      }
+    });
+
+    it('#539: Nutrition action officer/coordinator sees A,B,F,H,I,J — not C,D,E,G', () => {
+      const v = { Q5: 'Nutrition action officer/ coordinator' };
+      expect(shouldShowSection('C', v)).toBe(false);
+      expect(shouldShowSection('D', v)).toBe(false);
+      expect(shouldShowSection('E', v)).toBe(false);
+      expect(shouldShowSection('G', v)).toBe(false);
+      for (const id of ['A', 'B', 'F', 'H', 'I', 'J']) {
+        expect(shouldShowSection(id, v)).toBe(true);
+      }
     });
   });
 });

--- a/deliverables/F2/PWA/app/src/lib/skip-logic.ts
+++ b/deliverables/F2/PWA/app/src/lib/skip-logic.ts
@@ -1,30 +1,36 @@
 export type FormValues = Record<string, unknown>;
 type Predicate = (values: FormValues) => boolean;
 
-const SECTION_G_ROLES = new Set(['Physician/Doctor', 'Physician assistant', 'Dentist']);
+// #539: Section G is restricted to physicians and dentists only. The R2-#114
+// list also included 'Physician assistant'; the updated tester-guide spec
+// excludes it ("Only Physicians/Doctors, and Dentist should answer Section G").
+const SECTION_G_ROLES = new Set(['Physician/Doctor', 'Dentist']);
 
-// R2-#114: sections C/D/E are role-gated to patient-care roles. Pre-fix
-// shouldShowSection returned true for everything except G; tester saw
-// C/D/E visible to Pharmacist/Dispenser, Physician/Doctor, and Dentist
-// aide (1 of 3 should see them — Doctor only).
+// Sections C/D/E are role-gated to patient-care roles. shouldShowSection gates
+// C/D on SECTION_CDE_ROLES and E on SECTION_E_ROLES; the E2 (GAMOT) half adds
+// pharmacists/dispensers, who skip E1 (Q48–Q52) but answer E2 (Q53–Q55) via the
+// item-level gates below.
 //
-// Per UAT R2 tester guide spec:
-//   - C/D/E: admin, doctor, physician assistant, nurse, midwife, dentist,
-//            nutrition action officer/coordinator
-//   - E only (E2 GAMOT half): pharmacists/dispensers — they should skip
-//            E1 (Q48–Q52) but see E2 (Q53–Q55). Until #117 splits E1/E2,
-//            pharmacists see all of E (acceptable trade for v2.0.1; the
-//            E1 leak is #117's surface).
-//   - All other roles (Nursing assistant, Lab tech, Med tech, Dentist
-//            aide, BHW, Other): proceed straight to F.
-const SECTION_CDE_ROLES = new Set([
+// Per the updated tester-guide spec (#539 — supersedes the R2-#114 list):
+//   - C/D/E1: Administrator, Physician/Doctor, Nurse, Midwife, Dentist.
+//   - E2 only: Pharmacist/Dispenser (skip C/D/E1, answer the E2 GAMOT half).
+//   - None of C/D/E — proceed to F: Physician assistant, Nursing assistant,
+//            Laboratory technician, Medical/radiologic technologist, Health
+//            promotion officer, Nutrition action officer/coordinator, Physical
+//            Therapist, Dentist aide, Barangay Health Worker, Other.
+//
+// #539: 'Physician assistant' and 'Nutrition action officer/ coordinator' were
+// in the R2-#114 set; the new spec excludes both. They leaked C/D/E to those
+// two personas (Aidan re-test 2026-06-16) until removed here.
+// Exported so cross-field.ts (the C/D data-quality gate, GATE-05) shares one
+// source of truth and can't drift from the section gate — the drift that let
+// #539 slip in.
+export const SECTION_CDE_ROLES = new Set([
   'Administrator',
   'Physician/Doctor',
-  'Physician assistant',
   'Nurse',
   'Midwife',
   'Dentist',
-  'Nutrition action officer/ coordinator',
 ]);
 const SECTION_E_ROLES = new Set([...SECTION_CDE_ROLES, 'Pharmacist/Dispenser']);
 


### PR DESCRIPTION
## #539 role-leak fix — split out of #717 to ship ahead of the #524/#587 UAT gate

**The bug (live on prod now):** Sections C/D/E/G use role-gating, but `main`'s role lists still include roles the updated tester-guide spec excludes. Per Aidan's 2026-06-16 retest, **Physician assistant** and **Nutrition action officer/coordinator** see Sections C/D/E, and **Physician assistant** sees Section G — sections they shouldn't.

**The fix** (cherry-picked from staging `45144cf`, self-contained — 4 files, no other coupling):
- `SECTION_CDE_ROLES` → the 5 clinical roles only (Administrator, Physician/Doctor, Nurse, Midwife, Dentist). Pharmacist/Dispenser keeps the E2/GAMOT half via the existing item-level gate.
- `SECTION_G_ROLES` → `['Physician/Doctor', 'Dentist']`.
- Collapses the duplicate role list: `cross-field.ts`'s `BUCKET_CD` (GATE-05 data-quality gate) now aliases the exported `SECTION_CDE_ROLES`, so the visibility gate and the data-quality gate can't drift apart again (that drift is what let this through).
- Realigned `skip-logic` + `cross-field` test suites to the new spec + added #539 persona regressions (PA + nutrition officer see none of C/D/E/G).

**Why split it out:** it's a low-risk, pure role-list correction that's been on staging since 2026-06-16. #717 bundles it with the timing/validation fixes (#524/#587) that are still under UAT; this PR lets the role-leak fix reach prod independently.

**Verified:** tsc clean · 506/506 tests pass · cherry-pick applied clean onto current `main`.

**Scope:** zero overlap with #717's other commits; when #717 later promotes, this fix is already in `main` (no conflict — same commit content).

_Ready to merge — a `main` push auto-deploys prod._